### PR TITLE
fix: add missing .bzl suffix in release template loads

### DIFF
--- a/.github/workflows/workspace_snippet.sh
+++ b/.github/workflows/workspace_snippet.sh
@@ -22,7 +22,7 @@ http_archive(
     url = "https://github.com/aspect-build/bazel-lib/archive/${TAG}.tar.gz",
 )
 
-load("@aspect_bazel_lib//lib:repositories", "aspect_bazel_lib_dependencies")
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
 
 aspect_bazel_lib_dependencies()
 


### PR DESCRIPTION
Adds the missing `.bzl` extension. Copying these verbatim results in the following error:

```
bazel build //...
ERROR: /Users/matt/workspace/multi_python_workspace_example/WORKSPACE:19:6: in load statement: The label must reference a file with extension '.bzl'
ERROR: error loading package '': malformed load statements
INFO: Elapsed time: 0.120s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)
```