### PR TITLE
chore: Update github archive URLs to have stable SHAs

### DIFF
--- a/.github/workflows/workspace_snippet.sh
+++ b/.github/workflows/workspace_snippet.sh
@@ -19,7 +19,7 @@ http_archive(
     name = "aspect_bazel_lib",
     sha256 = "${SHA}",
     strip_prefix = "${PREFIX}",
-    url = "https://github.com/aspect-build/bazel-lib/archive/${TAG}.tar.gz",
+    url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/${TAG}.tar.gz",
 )
 
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -51,7 +51,7 @@ def bazel_lib_internal_deps():
         strip_prefix = "bazel-skylib-1.1.1",
         urls = [
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/1.1.1.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/archive/1.1.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/archive/refs/tags/1.1.1.tar.gz",
         ],
     )
 


### PR DESCRIPTION
Required per https://github.com/bazel-contrib/SIG-rules-authors/issues/11