### PR TITLE
experimental: write source files from depset

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,6 @@ docs/*.md
 lib/tests/jq/*.json
 lib/tests/write_source_files/a2.js
 lib/tests/write_source_files/b2.js
+lib/tests/write_source_files/f.js
+lib/tests/write_source_files/g/g.js
 lib/tests/write_source_files/e_dir/e.js

--- a/docs/write_source_files.md
+++ b/docs/write_source_files.md
@@ -7,7 +7,8 @@ Public API for write_source_files
 ## write_source_files
 
 <pre>
-write_source_files(<a href="#write_source_files-name">name</a>, <a href="#write_source_files-files">files</a>, <a href="#write_source_files-additional_update_targets">additional_update_targets</a>, <a href="#write_source_files-suggested_update_target">suggested_update_target</a>, <a href="#write_source_files-kwargs">kwargs</a>)
+write_source_files(<a href="#write_source_files-name">name</a>, <a href="#write_source_files-files">files</a>, <a href="#write_source_files-include_files">include_files</a>, <a href="#write_source_files-additional_update_targets">additional_update_targets</a>, <a href="#write_source_files-suggested_update_target">suggested_update_target</a>,
+                   <a href="#write_source_files-kwargs">kwargs</a>)
 </pre>
 
 Write to one or more files or folders in the source tree. Stamp out tests that ensure the sources exist and are up to date.
@@ -87,6 +88,7 @@ If you have many sources that you want to update as a group, we recommend wrappi
 | :------------- | :------------- | :------------- |
 | <a id="write_source_files-name"></a>name |  Name of the executable target that creates or updates the source file   |  none |
 | <a id="write_source_files-files"></a>files |  A dict where the keys are source files or folders to write to and the values are labels pointing to the desired content. Sources must be within the same bazel package as the target.   |  none |
+| <a id="write_source_files-include_files"></a>include_files |  TODO   |  <code>[]</code> |
 | <a id="write_source_files-additional_update_targets"></a>additional_update_targets |  (Optional) List of other write_source_files targets to update in the same run   |  <code>[]</code> |
 | <a id="write_source_files-suggested_update_target"></a>suggested_update_target |  (Optional) Label of the write_source_files target to suggest running when files are out of date   |  <code>None</code> |
 | <a id="write_source_files-kwargs"></a>kwargs |  Other common named parameters such as <code>tags</code> or <code>visibility</code>   |  none |

--- a/lib/tests/write_source_files/BUILD.bazel
+++ b/lib/tests/write_source_files/BUILD.bazel
@@ -15,6 +15,20 @@ genrule(
 )
 
 genrule(
+    name = "g-desired",
+    outs = ["g/g.js"],  # Generated in a subdirectory
+    cmd = "echo 'console.log(\"g*\")' > $@",
+)
+
+filegroup(
+    name = "fg-group",
+    srcs = [
+        ":g-desired",
+        "//lib/tests/write_source_files/subdir:f-desired",
+    ],
+)
+
+genrule(
     name = "e",
     outs = ["e.js"],
     cmd = "echo 'console.log(\"e*\")' > $@",
@@ -47,4 +61,7 @@ write_source_files(
         "b2.js": ":b-desired",
         "e_dir": ":e_dir-desired",
     },
+    include_files = [
+        ":fg-group",
+    ],
 )

--- a/lib/tests/write_source_files/f.js
+++ b/lib/tests/write_source_files/f.js
@@ -1,0 +1,1 @@
+console.log("f*")

--- a/lib/tests/write_source_files/g/g.js
+++ b/lib/tests/write_source_files/g/g.js
@@ -1,0 +1,1 @@
+console.log("g*")

--- a/lib/tests/write_source_files/subdir/BUILD.bazel
+++ b/lib/tests/write_source_files/subdir/BUILD.bazel
@@ -1,19 +1,28 @@
 load("//lib:write_source_files.bzl", "write_source_files")
 
+package(
+    default_visibility = ["//visibility:public"],
+)
+
 genrule(
     name = "c-desired",
     outs = ["c-desired.js"],
     cmd = "echo 'console.log(\"c*\");' > $@",
 )
 
+genrule(
+    name = "f-desired",
+    outs = ["f.js"],
+    cmd = "echo 'console.log(\"f*\")' > $@",
+)
+
 write_source_files(
     name = "macro_smoke_test",
+    additional_update_targets = [
+        "//lib/tests/write_source_files/subdir/subsubdir:macro_smoke_test",
+    ],
     files = {
         "c.js": ":c-desired",
     },
     suggested_update_target = "//lib/tests/write_source_files:macro_smoke_test",
-    visibility = ["//visibility:public"],
-    additional_update_targets = [
-        "//lib/tests/write_source_files/subdir/subsubdir:macro_smoke_test",
-    ],
 )

--- a/lib/write_source_files.bzl
+++ b/lib/write_source_files.bzl
@@ -11,7 +11,7 @@ _write_source_files = rule(
     executable = True,
 )
 
-def write_source_files(name, files, additional_update_targets = [], suggested_update_target = None, **kwargs):
+def write_source_files(name, files, include_files = [], additional_update_targets = [], suggested_update_target = None, **kwargs):
     """Write to one or more files or folders in the source tree. Stamp out tests that ensure the sources exist and are up to date.
 
     Usage:
@@ -85,6 +85,7 @@ def write_source_files(name, files, additional_update_targets = [], suggested_up
         name: Name of the executable target that creates or updates the source file
         files: A dict where the keys are source files or folders to write to and the values are labels pointing to the desired content.
             Sources must be within the same bazel package as the target.
+        include_files: TODO
         additional_update_targets: (Optional) List of other write_source_files targets to update in the same run
         suggested_update_target: (Optional) Label of the write_source_files target to suggest running when files are out of date
         **kwargs: Other common named parameters such as `tags` or `visibility`
@@ -98,6 +99,7 @@ def write_source_files(name, files, additional_update_targets = [], suggested_up
         name = name,
         in_files = in_files,
         out_files = out_files,
+        include_files = include_files,
         additional_update_targets = additional_update_targets,
         is_windows = select({
             "@bazel_tools//src/conditions:host_windows": True,


### PR DESCRIPTION
DO NOT MERGE

Decided to try this out. The writing to source files works: it will take each file in the depset and pop it into the source directory. But we can't stamp out missing/out-of-date tests when we don't know what the output files are..

But if we're committing to source we should know what the expected files are after the first time we run the generation. Maybe what we really need is the ability to do something like:

```
files = {
  "some-file.js": struct(
      target = "//foo/bar:some-group",
      take_file: "some-file.js",
   )
}
```
Then we could stamp out our tests.

Wdyt?