### PR TITLE
fix: use -R instead of -r in cp calls so macos & linux behavior is the same

### DIFF
--- a/lib/private/copy_file.bzl
+++ b/lib/private/copy_file.bzl
@@ -85,7 +85,7 @@ def copy_cmd(ctx, src_file, src_path, dst):
 # buildifier: disable=function-docstring
 def copy_bash(ctx, src_file, src_path, dst):
     if dst.is_directory:
-        cmd_tmpl = "rm -rf \"$2\" && cp -rf \"$1/\" \"$2\""
+        cmd_tmpl = "rm -rf \"$2\" && cp -fR \"$1/\" \"$2\""
         mnemonic = "CopyDirectory"
         progress_message = "Copying directory %s" % src_path
     else:

--- a/lib/private/copy_to_directory.bzl
+++ b/lib/private/copy_to_directory.bzl
@@ -90,7 +90,7 @@ if [[ -f "{src}" ]]; then
     cp -f "{src}" "{dst}"
 else
     mkdir -p "{dst}"
-    cp -rf "{src}"/* "{dst}"
+    cp -fR "{src}"/* "{dst}"
 fi
 """.format(src = src_path, dst_dir = skylib_paths.dirname(dst_path), dst = dst_path))
 

--- a/lib/private/write_source_file.bzl
+++ b/lib/private/write_source_file.bzl
@@ -167,7 +167,7 @@ if [[ -f "$in" ]]; then
     chmod 664 "$out"
 else
     mkdir -p "$out"
-    cp -rf "$in"/* "$out"
+    cp -fR "$in"/* "$out"
     chmod 664 "$out"/*
 fi
 """.format(in_path = in_path, out_path = out_path))


### PR DESCRIPTION
Same fix as https://github.com/bazelbuild/rules_nodejs/pull/3383 but we have more instances of it in bazel-lib.

For reference, the cp -r option is historic and discouraged on macos. It differs from cp -r on linux.
https://man7.org/linux/man-pages/man1/cp.1.html
https://ss64.com/osx/cp.html