### PR TITLE
chore: replace is_windows select pattern with target_platform_has_constraint pattern

### DIFF
--- a/lib/copy_to_directory.bzl
+++ b/lib/copy_to_directory.bzl
@@ -100,9 +100,5 @@ def copy_to_directory(
         include_external_repositories = include_external_repositories,
         exclude_prefixes = exclude_prefixes,
         replace_prefixes = replace_prefixes,
-        is_windows = select({
-            "@bazel_tools//src/conditions:host_windows": True,
-            "//conditions:default": False,
-        }),
         **kwargs
     )

--- a/lib/params_file.bzl
+++ b/lib/params_file.bzl
@@ -60,9 +60,5 @@ def params_file(
         args = args,
         data = data,
         newline = newline or "auto",
-        is_windows = select({
-            "@bazel_tools//src/conditions:host_windows": True,
-            "//conditions:default": False,
-        }),
         **kwargs
     )

--- a/lib/private/copy_directory.bzl
+++ b/lib/private/copy_directory.bzl
@@ -83,8 +83,10 @@ def copy_directory_action(ctx, src, dst, is_windows = False):
         _copy_bash(ctx, src, dst)
 
 def _copy_directory_impl(ctx):
+    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
+
     dst = ctx.actions.declare_directory(ctx.attr.out)
-    copy_directory_action(ctx, ctx.file.src, dst, ctx.attr.is_windows)
+    copy_directory_action(ctx, ctx.file.src, dst, is_windows)
 
     files = depset(direct = [dst])
     runfiles = ctx.runfiles(files = [dst])
@@ -96,10 +98,10 @@ _copy_directory = rule(
     provides = [DefaultInfo],
     attrs = {
         "src": attr.label(mandatory = True, allow_single_file = True),
-        "is_windows": attr.bool(mandatory = True),
         # Cannot declare out as an output here, because there's no API for declaring
         # TreeArtifact outputs.
         "out": attr.string(mandatory = True),
+        "_windows_constraint": attr.label(default = "@platforms//os:windows"),
     },
 )
 
@@ -123,10 +125,6 @@ def copy_directory(name, src, out, **kwargs):
     _copy_directory(
         name = name,
         src = src,
-        is_windows = select({
-            "@bazel_tools//src/conditions:host_windows": True,
-            "//conditions:default": False,
-        }),
         out = out,
         **kwargs
     )

--- a/lib/private/copy_to_directory.bzl
+++ b/lib/private/copy_to_directory.bzl
@@ -11,7 +11,7 @@ _copy_to_directory_attr = {
     "include_external_repositories": attr.string_list(default = []),
     "exclude_prefixes": attr.string_list(default = []),
     "replace_prefixes": attr.string_dict(default = {}),
-    "is_windows": attr.bool(mandatory = True),
+    "_windows_constraint": attr.label(default = "@platforms//os:windows"),
 }
 
 def _longest_match(subject, tests, allow_partial = False):
@@ -163,6 +163,8 @@ if exist "{src}\\*" (
     )
 
 def _copy_to_directory_impl(ctx):
+    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
+
     if not ctx.attr.srcs:
         msg = "srcs must not be empty in copy_to_directory %s" % ctx.label
         fail(msg)
@@ -183,7 +185,7 @@ def _copy_to_directory_impl(ctx):
             dst_path = skylib_paths.normalize("/".join([output.path, output_path]))
             copy_paths.append((src_path, dst_path, src_file))
 
-    if ctx.attr.is_windows:
+    if is_windows:
         _copy_to_dir_cmd(ctx, copy_paths, output)
     else:
         _copy_to_dir_bash(ctx, copy_paths, output)

--- a/lib/private/params_file.bzl
+++ b/lib/private/params_file.bzl
@@ -5,12 +5,12 @@ load("//lib/private:expand_make_vars.bzl", "expand_locations")
 _ATTRS = {
     "args": attr.string_list(),
     "data": attr.label_list(allow_files = True),
-    "is_windows": attr.bool(mandatory = True),
     "newline": attr.string(
         values = ["unix", "windows", "auto"],
         default = "auto",
     ),
     "out": attr.output(mandatory = True),
+    "_windows_constraint": attr.label(default = "@platforms//os:windows"),
 }
 
 def _expand_locations(ctx, s):
@@ -20,8 +20,10 @@ def _expand_locations(ctx, s):
     return expand_locations(ctx, s, targets = ctx.attr.data).split(" ")
 
 def _impl(ctx):
+    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
+
     if ctx.attr.newline == "auto":
-        newline = "\r\n" if ctx.attr.is_windows else "\n"
+        newline = "\r\n" if is_windows else "\n"
     elif ctx.attr.newline == "windows":
         newline = "\r\n"
     else:

--- a/lib/tests/write_source_files/write_source_file_test.bzl
+++ b/lib/tests/write_source_files/write_source_file_test.bzl
@@ -123,6 +123,8 @@ exit /b 1
     return test
 
 def _impl(ctx):
+    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
+
     if DirectoryPathInfo in ctx.attr.in_file:
         in_file = ctx.attr.in_file[DirectoryPathInfo].directory
         in_file_path = "/".join([in_file.short_path, ctx.attr.in_file[DirectoryPathInfo].path])
@@ -132,7 +134,7 @@ def _impl(ctx):
         in_file = ctx.files.in_file[0]
         in_file_path = in_file.short_path
 
-    if ctx.attr.is_windows:
+    if is_windows:
         test = _impl_bat(ctx, in_file_path, ctx.file.out_file.short_path)
     else:
         test = _impl_sh(ctx, in_file_path, ctx.file.out_file.short_path)
@@ -162,7 +164,7 @@ _write_source_file_test = rule(
             allow_files = True,
             mandatory = True,
         ),
-        "is_windows": attr.bool(mandatory = True),
+        "_windows_constraint": attr.label(default = "@platforms//os:windows"),
     },
     test = True,
 )
@@ -184,8 +186,4 @@ def write_source_file_test(name, in_file, out_file):
         write_source_file_target = name + "_updater",
         in_file = in_file,
         out_file = out_file,
-        is_windows = select({
-            "@bazel_tools//src/conditions:host_windows": True,
-            "//conditions:default": False,
-        }),
     )


### PR DESCRIPTION
Based on https://github.com/bazelbuild/proposals/blob/main/designs/2019-11-11-target-platform-constraints.md#proposal-a-check-method-that-takes-a-constraint-value-label
Flag added in bazel 2.1.0 https://docs.bazel.build/versions/main/skylark/lib/ctx.html#target_platform_has_constraint
