### PR TITLE
fix: fix a bug where bcr action wouldn't follow redirects to artifact

### DIFF
--- a/.github/workflows/bcr/source.template.json
+++ b/.github/workflows/bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "**leave this alone**",
   "strip_prefix": "{REPO}-{VERSION}",
-  "url": "https://github.com/{OWNER}/{REPO}/archive/{TAG}.tar.gz"
+  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
 }


### PR DESCRIPTION
My downloader didn't follow http `302`, which for some reason I wasn't running into locally.