### PR TITLE
ci: remove committer for auto-bcr

### DIFF
--- a/.github/workflows/bcr.yml
+++ b/.github/workflows/bcr.yml
@@ -63,7 +63,6 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           path: bcr
           push-to-fork: ${{ env.BCR_FORK }}
-          committer: ${{ github.actor }}
           commit-message: ${{ github.repository }}@${{ steps.get_tag.outputs.TAG }}
           branch: ${{ github.repository }}@${{ steps.get_tag.outputs.TAG }}
           title: ${{ github.repository }}@${{ steps.get_tag.outputs.TAG }}


### PR DESCRIPTION
I read the docs wrong on this field. It doesn't take a username but a `Name <email>` format. Since I don't have access to the actor's name/email in the action, I'm just going to let it default for now to the github actions bot.

This was causing the bcr workflow to fail.