### PR TITLE
fix: set correct suggested_update_target for write_source_files macros with multiple files

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -7,10 +7,10 @@ Public API for docs helpers
 ## stardoc_with_diff_test
 
 <pre>
-stardoc_with_diff_test(<a href="#stardoc_with_diff_test-name">name</a>, <a href="#stardoc_with_diff_test-bzl_library_target">bzl_library_target</a>, <a href="#stardoc_with_diff_test-suggested_update_target">suggested_update_target</a>, <a href="#stardoc_with_diff_test-kwargs">kwargs</a>)
+stardoc_with_diff_test(<a href="#stardoc_with_diff_test-name">name</a>, <a href="#stardoc_with_diff_test-bzl_library_target">bzl_library_target</a>, <a href="#stardoc_with_diff_test-kwargs">kwargs</a>)
 </pre>
 
-Creates a stardoc target, diff test, and an executable to rule to write the generated doc to the source tree and test that it's up to date.
+Creates a stardoc target that can be auto-detected by update_docs to write the generated doc to the source tree and test that it's up to date.
 
 This is helpful for minimizing boilerplate in repos wih lots of stardoc targets.
 
@@ -22,7 +22,6 @@ This is helpful for minimizing boilerplate in repos wih lots of stardoc targets.
 | :------------- | :------------- | :------------- |
 | <a id="stardoc_with_diff_test-name"></a>name |  the name of the stardoc file to be written to the current source directory (.md will be appended to the name). Call bazel run on this target to update the file.   |  none |
 | <a id="stardoc_with_diff_test-bzl_library_target"></a>bzl_library_target |  the label of the <code>bzl_library</code> target to generate documentation for   |  none |
-| <a id="stardoc_with_diff_test-suggested_update_target"></a>suggested_update_target |  the target suggested to be run when a doc is out of date (should be the label for [update_docs](#update_docs))   |  <code>"//docs:update"</code> |
 | <a id="stardoc_with_diff_test-kwargs"></a>kwargs |  additional attributes passed to the stardoc() rule, such as for overriding the templates   |  none |
 
 

--- a/lib/private/docs.bzl
+++ b/lib/private/docs.bzl
@@ -1,43 +1,30 @@
 "Helpers for generating stardoc documentation"
 
-load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
+load("@io_bazel_stardoc//stardoc:stardoc.bzl", _stardoc = "stardoc")
 load("//lib:write_source_files.bzl", "write_source_files")
 
 def stardoc_with_diff_test(
         name,
         bzl_library_target,
-        suggested_update_target = "//docs:update",
         **kwargs):
-    """Creates a stardoc target, diff test, and an executable to rule to write the generated doc to the source tree and test that it's up to date.
+    """Creates a stardoc target that can be auto-detected by update_docs to write the generated doc to the source tree and test that it's up to date.
 
     This is helpful for minimizing boilerplate in repos wih lots of stardoc targets.
 
     Args:
         name: the name of the stardoc file to be written to the current source directory (.md will be appended to the name). Call bazel run on this target to update the file.
         bzl_library_target: the label of the `bzl_library` target to generate documentation for
-        suggested_update_target: the target suggested to be run when a doc is out of date (should be the label for [update_docs](#update_docs))
         **kwargs: additional attributes passed to the stardoc() rule, such as for overriding the templates
     """
 
-    stardoc_label = name + "-docgen"
-    out_file = name + ".md"
-
     # Generate MD from .bzl
-    stardoc(
-        name = stardoc_label,
+    _stardoc(
+        name = name,
         out = name + "-docgen.md",
         input = bzl_library_target + ".bzl",
         deps = [bzl_library_target],
         tags = ["package:" + native.package_name()],  # Tag the package name which will help us reconstruct the write_source_files label in update_docs
         **kwargs
-    )
-
-    write_source_files(
-        name = name,
-        suggested_update_target = suggested_update_target,
-        files = {
-            out_file: ":" + stardoc_label,
-        },
     )
 
 def update_docs(name = "update"):
@@ -60,16 +47,17 @@ def update_docs(name = "update"):
         name: the name of executable target
     """
 
-    update_labels = []
+    update_files = {}
     for r in native.existing_rules().values():
         if r["kind"] == "stardoc":
             for tag in r["tags"]:
                 if tag.startswith("package:"):
                     stardoc_name = r["name"]
-                    write_source_files_name = stardoc_name[:-len("-docgen")]
-                    update_labels.append("//%s:%s" % (tag[len("package:"):], write_source_files_name))
+                    source_file_name = stardoc_name + ".md"
+                    generated_file_name = stardoc_name + "-docgen.md"
+                    update_files[source_file_name] = generated_file_name
 
     write_source_files(
         name = name,
-        additional_update_targets = update_labels,
+        files = update_files,
     )

--- a/lib/write_source_files.bzl
+++ b/lib/write_source_files.bzl
@@ -96,11 +96,14 @@ def write_source_files(
     for i, pair in enumerate(files.items()):
         out_file, in_file = pair
 
+        this_suggested_update_target = suggested_update_target
         if single_update_target:
             update_target_name = name
         else:
             update_target_name = "%s_%d" % (name, i)
             update_targets.append(update_target_name)
+            if not this_suggested_update_target:
+                this_suggested_update_target = name
 
         # Runnable target that writes to the out file to the source tree
         _write_source_file(
@@ -108,7 +111,7 @@ def write_source_files(
             in_file = in_file,
             out_file = out_file,
             additional_update_targets = additional_update_targets if single_update_target else [],
-            suggested_update_target = suggested_update_target,
+            suggested_update_target = this_suggested_update_target,
             diff_test = diff_test,
             **kwargs
         )


### PR DESCRIPTION
Also simplify `//docs:update` target to use a single `write_source_files`.

Previously the failure would have shown,

```
$ cat /private/var/tmp/_bazel_greg/d429ac343bccdd9460beaa3e7ac46428/execroot/aspect_bazel_lib/bazel-out/darwin-fastbuild/testlogs/docs/update_10_test/test.log
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //docs:update_10_test
-----------------------------------------------------------------------------
7c7
< ## write_source_files
---
> ## write_source_files!
FAIL: files "docs/write_source_files-docgen.md" and "docs/write_source_files.md" differ. 

//docs:write_source_files.md is out of date. To update this and other generated files, run:

    bazel run //docs:update_10
```

with this fix the error is now

```
$ cat /private/var/tmp/_bazel_greg/d429ac343bccdd9460beaa3e7ac46428/execroot/aspect_bazel_lib/bazel-out/darwin-fastbuild/testlogs/docs/update_10_test/test.log
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //docs:update_10_test
-----------------------------------------------------------------------------
7c7
< ## write_source_files
---
> ## write_source_files!
FAIL: files "docs/write_source_files-docgen.md" and "docs/write_source_files.md" differ. 

//docs:write_source_files.md is out of date. To update this and other generated files, run:

    bazel run //docs:update

To update *only* this file, run:

    bazel run //docs:update_10
```