### PR TITLE
fix: buildifier lint errors

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,18 +2,20 @@
 
 module(
     name = "aspect_bazel_lib",
-    version = "0.0.0",
     compatibility_level = 1,
     toolchains_to_register = [
         "@jq_toolchains//:all",
         "@yq_toolchains//:all",
     ],
+    version = "0.0.0",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.1.1")
 bazel_dep(name = "platforms", version = "0.0.4")
-bazel_dep(name = "stardoc", version = "0.5.0", repo_name = "io_bazel_stardoc")
+bazel_dep(name = "stardoc", repo_name = "io_bazel_stardoc", version = "0.5.0")
 
 ext = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "ext")
+
 use_repo(ext, "jq_toolchains")
+
 use_repo(ext, "yq_toolchains")

--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "e2e_bzlmod",
-    version = "0.0.0",
     compatibility_level = 1,
+    version = "0.0.0",
 )
 
 bazel_dep(name = "aspect_bazel_lib", version = "0.9.8")

--- a/lib/private/jq.bzl
+++ b/lib/private/jq.bzl
@@ -45,7 +45,7 @@ def _jq_impl(ctx):
         inputs = inputs,
         outputs = [out],
         command = cmd,
-        mnemonic = "Jq"
+        mnemonic = "Jq",
     )
 
     return DefaultInfo(files = depset([out]), runfiles = ctx.runfiles([out]))


### PR DESCRIPTION
After this we should be green and ready for a 1.0 release if we want to do that.

https://buildkite.com/bazel/bazel-lib
