### PR TITLE
chore: cleanup fail msgs with substitutions for cleaner error logs

### DIFF
--- a/lib/private/directory_path.bzl
+++ b/lib/private/directory_path.bzl
@@ -14,7 +14,8 @@ DirectoryPathInfo = provider(
 
 def _directory_path(ctx):
     if not ctx.file.directory.is_directory:
-        fail("expected directory to be a TreeArtifact (ctx.actions.declare_directory) but got {}".format(ctx.file.directory))
+        msg = "expected directory to be a TreeArtifact (ctx.actions.declare_directory) but got {}".format(ctx.file.directory)
+        fail(msg)
     return [DirectoryPathInfo(path = ctx.attr.path, directory = ctx.file.directory)]
 
 directory_path = rule(

--- a/lib/private/patch.bzl
+++ b/lib/private/patch.bzl
@@ -137,18 +137,18 @@ def patch(ctx, patches = None, patch_cmds = None, patch_cmds_win = None, patch_t
             )
             st = ctx.execute([bash_exe, "-c", command], working_directory = patch_directory)
             if st.return_code:
-                fail("Error applying patch %s:\n%s%s" %
-                     (str(patchfile), st.stderr, st.stdout))
+                msg = "Error applying patch {}:\n{}{}".format(str(patchfile), st.stderr, st.stdout)
+                fail(msg)
 
     if repo_utils.is_windows(ctx) and patch_cmds_win:
         for cmd in patch_cmds_win:
             st = ctx.execute([powershell_exe, "/c", cmd], working_directory = patch_directory)
             if st.return_code:
-                fail("Error applying patch command %s:\n%s%s" %
-                     (cmd, st.stdout, st.stderr))
+                msg = "Error applying patch command {}:\n{}{}".format(cmd, st.stdout, st.stderr)
+                fail(msg)
     else:
         for cmd in patch_cmds:
             st = ctx.execute([bash_exe, "-c", cmd], working_directory = patch_directory)
             if st.return_code:
-                fail("Error applying patch command %s:\n%s%s" %
-                     (cmd, st.stdout, st.stderr))
+                msg = "Error applying patch command {}:\n{}{}".format(cmd, st.stdout, st.stderr)
+                fail(msg)

--- a/lib/private/paths.bzl
+++ b/lib/private/paths.bzl
@@ -20,7 +20,8 @@ def _relative_file(to_file, frm_file):
         return to_file
 
     if to_segments[0] != frm_segments[0]:
-        fail("paths must share a common root, got '%s' and '%s'" % (to_file, frm_file))
+        msg = "paths must share a common root, got '{}' and '{}'".format(to_file, frm_file)
+        fail(msg)
 
     longest_common = []
     for to_seg, frm_seg in zip(to_segments, frm_segments):
@@ -32,7 +33,8 @@ def _relative_file(to_file, frm_file):
     split_point = len(longest_common)
 
     if split_point == 0:
-        fail("paths share no common ancestor, '%s' -> '%s'" % (frm_file, to_file))
+        msg = "paths share no common ancestor, '{}' -> '{}'".format(frm_file, to_file)
+        fail(msg)
 
     return _spaths.join(
         *(

--- a/lib/private/utils.bzl
+++ b/lib/private/utils.bzl
@@ -68,7 +68,8 @@ def _to_label(param):
     elif param_type == "Label":
         return param
     else:
-        fail("Expected 'string' or 'Label' but got '%s'" % param_type)
+        msg = "Expected 'string' or 'Label' but got '{}'".format(param_type)
+        fail(msg)
 
 def _is_external_label(param):
     """Returns True if the given Label (or stringy version of a label) represents a target outside of the workspace

--- a/lib/private/write_source_file.bzl
+++ b/lib/private/write_source_file.bzl
@@ -44,9 +44,11 @@ def write_source_file(
         out_file = utils.to_label(out_file)
 
         if utils.is_external_label(out_file):
-            fail("out file %s must be in the user workspace" % out_file)
+            msg = "out file {} must be in the user workspace".format(out_file)
+            fail(msg)
         if out_file.package != native.package_name():
-            fail("out file %s (in package '%s') must be a source file within the target's package: '%s'" % (out_file, out_file.package, native.package_name()))
+            msg = "out file {} (in package '{}') must be a source file within the target's package: '{}'".format(out_file, out_file.package, native.package_name())
+            fail(msg)
 
     _write_source_file(
         name = name,
@@ -264,11 +266,13 @@ def _write_source_file_impl(ctx):
             ])
             runfiles.append(ctx.attr.in_file[DirectoryPathInfo].directory)
         elif len(ctx.files.in_file) == 0:
-            fail("in file %s must provide files" % ctx.attr.in_file.label)
+            msg = "in file {} must provide files".format(ctx.attr.in_file.label)
+            fail(msg)
         elif len(ctx.files.in_file) == 1:
             in_path = ctx.files.in_file[0].short_path
         else:
-            fail("in file %s must be a single file or a target that provides DefaultOutputPathInfo or DirectoryPathInfo" % ctx.attr.in_file.label)
+            msg = "in file {} must be a single file or a target that provides DefaultOutputPathInfo or DirectoryPathInfo".format(ctx.attr.in_file.label)
+            fail(msg)
 
         out_path = "/".join([ctx.label.package, ctx.attr.out_file]) if ctx.label.package else ctx.attr.out_file
         paths.append((in_path, out_path))


### PR DESCRIPTION
I always end up first reading the string with the %s or {} tokens instead of the actual error on these