### PR TITLE
chore: create a pull request against our bcr fork on successful release

### DIFF
--- a/.github/workflows/bcr-fork.yml
+++ b/.github/workflows/bcr-fork.yml
@@ -1,0 +1,50 @@
+# GitHub Actions workflow to create a pull request to our fork of the bazel central
+# registry after a successful release.
+
+name: BCR-FORK
+
+on:
+  release:
+    types: [published]
+
+env:
+  BCR_FORK: aspect-build/bazel-central-registry
+
+jobs:
+  bcr-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "14"
+      - name: Get the tag
+        id: get_tag
+        run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+      - name: Checkout this repo to access scripts
+        uses: actions/checkout@v3
+      - name: Checkout the released version of this repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.GITHUB_REF }}
+          path: project
+      - name: Checkout bcr
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.BCR_FORK }}
+          path: bcr
+      - name: Create bcr entry
+        run: node .github/workflows/create-bcr-entry.mjs project bcr $GITHUB_REPOSITORY ${{ steps.get_tag.outputs.TAG }}
+      - name: Create Pull Request (BCR)
+        id: post_pr
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.DEREK_BCR_PAT }}
+          path: bcr
+          commit-message: ${{ github.repository }}@${{ steps.get_tag.outputs.TAG }}-fork
+          branch: ${{ github.repository }}@${{ steps.get_tag.outputs.TAG }}-fork
+          title: ${{ github.repository }}@${{ steps.get_tag.outputs.TAG }}
+          assignees: ${{ github.actor }}
+          body: |
+            [Automated] Publish ${{ github.repository }}@${{ steps.get_tag.outputs.TAG }}.
+      - name: Echo PR url
+        run: echo ${{ steps.post_pr.outputs.pull-request-url }}


### PR DESCRIPTION
I copied the existing workflow and made some minor changes so that we PR against our own bcr fork on release. That way we don't have to do this manually each release bazel-lib and want our downstream bzlmod e2es to pass.