### PR TITLE
fix: don't set assignees for bcr pr

### DIFF
--- a/.github/workflows/bcr.yml
+++ b/.github/workflows/bcr.yml
@@ -61,7 +61,6 @@ jobs:
           commit-message: ${{ github.repository }}@${{ steps.get_tag.outputs.TAG }}
           branch: ${{ github.repository }}@${{ steps.get_tag.outputs.TAG }}
           title: ${{ github.repository }}@${{ steps.get_tag.outputs.TAG }}
-          assignees: ${{ github.actor }}
           body: |
             [Automated] Publish ${{ github.repository }}@${{ steps.get_tag.outputs.TAG }}.
       - name: Echo PR url


### PR DESCRIPTION
The PRs to bcr work (https://github.com/bazelbuild/bazel-central-registry/pull/108) but this part of the action fails, making it red in our actions logs. We don't have the admin rights to assign the PR to anyone.