### PR TITLE
feat: let jq act like copy_to_bin

### DIFF
--- a/lib/jq.bzl
+++ b/lib/jq.bzl
@@ -95,8 +95,9 @@ def jq(name, srcs, filter = None, filter_file = None, args = [], out = None, **k
         out: Name of the output json file; defaults to the rule name plus ".json"
         **kwargs: Other common named parameters such as `tags` or `visibility`
     """
-    if not out:
-        out = name + ".json"
+    default_name = name + ".json"
+    if not out and not default_name in srcs:
+        out = default_name
 
     _jq_rule(
         name = name,

--- a/lib/private/jq.bzl
+++ b/lib/private/jq.bzl
@@ -9,13 +9,13 @@ _jq_attrs = {
     "filter": attr.string(),
     "filter_file": attr.label(allow_single_file = True),
     "args": attr.string_list(),
-    "out": attr.output(mandatory = True),
+    "out": attr.output(),
 }
 
 def _jq_impl(ctx):
     jq_bin = ctx.toolchains["@aspect_bazel_lib//lib:jq_toolchain_type"].jqinfo.bin
 
-    out = ctx.outputs.out
+    out = ctx.outputs.out or ctx.actions.declare_file(ctx.attr.name + ".json")
     args = ctx.attr.args
     inputs = ctx.files.srcs[:]
 

--- a/lib/private/jq_toolchain.bzl
+++ b/lib/private/jq_toolchain.bzl
@@ -8,7 +8,9 @@ JQ_PLATFORMS = {
         release_platform = "osx-amd64",
         compatible_with = [
             "@platforms//os:macos",
-            "@platforms//cpu:x86_64",
+            # JQ only ships a universal binary; it should work on
+            # Apple Silicon (amd64) as well.
+            #"@platforms//cpu:x86_64",
         ],
     ),
     "linux_amd64": struct(

--- a/lib/tests/jq/BUILD.bazel
+++ b/lib/tests/jq/BUILD.bazel
@@ -126,3 +126,12 @@ diff_test(
     file1 = ":case_raw_input",
     file2 = "raw_expected.json",
 )
+
+# Similar to copy_to_bin, this will create a file a.json in the output folder.
+# That's the same path as an input file, but that's okay as long as the jq
+# rule doesn't pre-declare that output.
+jq(
+    name = "a",
+    srcs = ["a.json"],
+    filter = """ .foo = "baz" """,
+)


### PR DESCRIPTION
This lets you have a file in the output tree with the same path as a source file, but modified.

Came up while translating an angular `ng-package.json` file to fix up the `dest` path. We don't want to change the source file name, as Angular CLI generates it, and we can't change the output file name.