### PR TITLE
feat: add buildozer command to add visibility to the copy_to_bin helper error

### DIFF
--- a/lib/private/copy_to_bin.bzl
+++ b/lib/private/copy_to_bin.bzl
@@ -47,6 +47,7 @@ target to {file_basename}'s package using:
     buildozer 'new copy_to_bin {target_name}' {file_package}:__pkg__
     buildozer 'add srcs {file_basename}' {file_package}:{target_name}
     buildozer 'new_load @aspect_bazel_lib//lib:copy_to_bin.bzl copy_to_bin' {file_package}:__pkg__
+    buildozer 'add visibility {package}:__subpackages__' {file_package}:{target_name}
 
 """.format(
                 file_basename = file.basename,


### PR DESCRIPTION
We can add visibility here based on the incoming files package. It was nice that the error gave me the fix, but the resulting rule still produced visibility errors.