### PR TITLE
fix: remote target_compatible_with from jq and yq toolchains

### DIFF
--- a/lib/private/jq_toolchain.bzl
+++ b/lib/private/jq_toolchain.bzl
@@ -134,7 +134,6 @@ resolved_toolchain(name = "resolved_toolchain", visibility = ["//visibility:publ
 toolchain(
     name = "{platform}_toolchain",
     exec_compatible_with = {compatible_with},
-    target_compatible_with = {compatible_with},
     toolchain = "@{user_repository_name}_{platform}//:jq_toolchain",
     toolchain_type = "@aspect_bazel_lib//lib:jq_toolchain_type",
 )

--- a/lib/private/yq_toolchain.bzl
+++ b/lib/private/yq_toolchain.bzl
@@ -174,7 +174,6 @@ resolved_toolchain(name = "resolved_toolchain", visibility = ["//visibility:publ
 toolchain(
     name = "{platform}_toolchain",
     exec_compatible_with = {compatible_with},
-    target_compatible_with = {compatible_with},
     toolchain = "@{user_repository_name}_{platform}//:yq_toolchain",
     toolchain_type = "@aspect_bazel_lib//lib:yq_toolchain_type",
 )


### PR DESCRIPTION
Is this right? I haven't done much with platforms before.