### PR TITLE
fix: diff_test not working for files in directories starting with "external"

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,6 +2,9 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("//lib:write_source_files.bzl", "write_source_files")
 load("//lib:yq.bzl", "yq")
+load("//lib:diff_test.bzl", "diff_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 
 gazelle_binary(
     name = "gazelle_bin",
@@ -42,4 +45,24 @@ yq(
     name = "yq_root-test",
     srcs = ["//lib/tests/yq:a.yaml"],
     expression = ".",
+)
+
+# Test case: diff_test with a file in a directory prefixed with "external"
+# stamped in the root package
+write_file(
+    name = "file_in_external_prefixed_dir",
+    out = "external-dir/foo.txt",
+    content = ["foo"],
+)
+
+copy_file(
+    name = "copy_of_file_in_external_prefixed_dir",
+    src = "external-dir/foo.txt",
+    out = "foo_copy.txt",
+)
+
+diff_test(
+    name = "case_file_has_external_prefix",
+    file1 = "external-dir/foo.txt",
+    file2 = "foo_copy.txt",
 )

--- a/lib/private/diff_test.bzl
+++ b/lib/private/diff_test.bzl
@@ -177,8 +177,8 @@ exit /b 1
 set -euo pipefail
 F1="{file1}"
 F2="{file2}"
-[[ "$F1" =~ ^external/* ]] && F1="${{F1#external/}}" || F1="$TEST_WORKSPACE/$F1"
-[[ "$F2" =~ ^external/* ]] && F2="${{F2#external/}}" || F2="$TEST_WORKSPACE/$F2"
+[[ "$F1" =~ ^external/ ]] && F1="${{F1#external/}}" || F1="$TEST_WORKSPACE/$F1"
+[[ "$F2" =~ ^external/ ]] && F2="${{F2#external/}}" || F2="$TEST_WORKSPACE/$F2"
 if [[ -d "${{RUNFILES_DIR:-/dev/null}}" && "${{RUNFILES_MANIFEST_ONLY:-}}" != 1 ]]; then
   RF1="$RUNFILES_DIR/$F1"
   RF2="$RUNFILES_DIR/$F2"


### PR DESCRIPTION
Example "external-dependencies/foo.txt"

fyi: @jesseschalken

[This pr](https://github.com/aspect-build/bazel-lib/pull/180) plus a test.
