### PR TITLE
fix: improve error message in directory_path when directory does not exist

### DIFF
--- a/lib/private/directory_path.bzl
+++ b/lib/private/directory_path.bzl
@@ -14,7 +14,7 @@ DirectoryPathInfo = provider(
 
 def _directory_path(ctx):
     if not ctx.file.directory.is_directory:
-        msg = "expected directory to be a TreeArtifact (ctx.actions.declare_directory) but got {}".format(ctx.file.directory)
+        msg = "Expected directory to be a TreeArtifact (ctx.actions.declare_directory) but {} is either a source file or does not exist.".format(ctx.file.directory)
         fail(msg)
     return [DirectoryPathInfo(path = ctx.attr.path, directory = ctx.file.directory)]
 


### PR DESCRIPTION
Fixes https://github.com/aspect-build/bazel-lib/issues/122.

The error message was already improved in https://github.com/aspect-build/bazel-lib/commit/128f7c63fbe3e2d3ead83ff7d6bb09728666acf2.