### PR TITLE
chore: add '?' pattern to test cases of copy_to_directory

### DIFF
--- a/lib/tests/copy_to_directory/BUILD.bazel
+++ b/lib/tests/copy_to_directory/BUILD.bazel
@@ -307,7 +307,7 @@ copy_to_directory(
     include_srcs_patterns = [
         "a",
         "b",
-        "e/e*",
+        "?/e*",
         "f/f2/f2",
     ],
 )
@@ -328,8 +328,8 @@ copy_to_directory(
     include_srcs_patterns = [
         "a",
         "b",
-        "e/e*",
-        "f/f2/**",
+        "?/e*",
+        "f/f?/**",
     ],
 )
 


### PR DESCRIPTION
There is coverage in glob_match for this but might as well be robust and cover in copy_to_directory as well