### PR TITLE
chore: normalize src and outputs paths in copy_to_directory

### DIFF
--- a/lib/private/copy_to_directory.bzl
+++ b/lib/private/copy_to_directory.bzl
@@ -410,7 +410,7 @@ def _copy_paths(
             # replace the longest matching prefix in the output path
             output_path = replace_prefixes[matching_expr] + output_path[len(longest_match):]
 
-    return src_path, output_path, src_file
+    return skylib_paths.normalize(src_path), skylib_paths.normalize(output_path), src_file
 
 def _merge_into_copy_path(copy_paths, src_path, dst_path, src_file):
     for i, s in enumerate(copy_paths):


### PR DESCRIPTION
Since we're comparing these paths this will prevent an accidental `/./` segment from sneaking in a breaking our comparison