### PR TITLE
fix: /bin/false instead of /dev/null

### DIFF
--- a/.aspectci/config.yaml
+++ b/.aspectci/config.yaml
@@ -1,6 +1,6 @@
 ---
 env:
-  CC: /dev/null
+  CC: /bin/false
 workspaces:
   - .
   - e2e/bzlmod


### PR DESCRIPTION
The `/dev/null` is a pseudo-device file that's not executable. If we expect a call to `CC` to actually fail, then `/bin/false` is the right file.