### PR TITLE
write_source_files fails at root with multiple files

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,7 +37,10 @@ genrule(
 write_source_files(
     name = "write_source_file_root-test",
     diff_test = False,
-    files = {"test-out/dist/write_source_file_root-test": ":write_source_file_root"},
+    files = {
+        "test-out/dist/write_source_file_root-test": ":write_source_file_root",
+        "test-out/dist/write_source_file_root-test_b": ":write_source_file_root",
+    },
 )
 
 # Test that yq works in the root package


### PR DESCRIPTION
I added a second file to the existing `write_source_file_root-test` target and now it fails:

```
$ bazel run :write_source_file_root-test
INFO: Analyzed target //:write_source_file_root-test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:write_source_file_root-test up-to-date:
  bazel-bin/write_source_file_root-test_update.sh
INFO: Elapsed time: 0.120s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
/private/var/tmp/_bazel_john/8477ea0acb2593a60b1c001ec039c387/execroot/aspect_bazel_lib/bazel-out/darwin_arm64-fastbuild/bin/write_source_file_root-test_update.sh: line 10: write_source_file_root-test_0_update.sh: command not found
```