### PR TITLE
fix: determine copy file action based on execution platform

### DIFF
--- a/lib/private/copy_common.bzl
+++ b/lib/private/copy_common.bzl
@@ -57,3 +57,12 @@ COPY_EXECUTION_REQUIREMENTS = {
     "no-sandbox": "1",
     "local": "1",
 }
+
+COPY_EXEC_GROUPS = {
+    "windows": exec_group(
+        exec_compatible_with = ["@platforms//os:windows"],
+    ),
+    "not_windows": exec_group(
+        exec_compatible_with = ["@platforms//os:linux", "@platforms//os:osx"],
+    ),
+}

--- a/lib/private/copy_file.bzl
+++ b/lib/private/copy_file.bzl
@@ -24,7 +24,7 @@ cmd.exe (on Windows). `_copy_xfile` marks the resulting file executable,
 `_copy_file` does not.
 """
 
-load(":copy_common.bzl", _COPY_EXECUTION_REQUIREMENTS = "COPY_EXECUTION_REQUIREMENTS")
+load(":copy_common.bzl", "COPY_EXEC_GROUPS", _COPY_EXECUTION_REQUIREMENTS = "COPY_EXECUTION_REQUIREMENTS")
 load(":directory_path.bzl", "DirectoryPathInfo")
 
 def _copy_cmd(ctx, src, src_path, dst):
@@ -65,6 +65,7 @@ def _copy_cmd(ctx, src, src_path, dst):
         progress_message = progress_message,
         use_default_shell_env = True,
         execution_requirements = _COPY_EXECUTION_REQUIREMENTS,
+        exec_group = "windows",
     )
 
 def _copy_bash(ctx, src, src_path, dst):
@@ -81,9 +82,10 @@ def _copy_bash(ctx, src, src_path, dst):
         progress_message = progress_message,
         use_default_shell_env = True,
         execution_requirements = _COPY_EXECUTION_REQUIREMENTS,
+        exec_group = "not_windows",
     )
 
-def copy_file_action(ctx, src, dst, dir_path = None, is_windows = False):
+def copy_file_action(ctx, src, dst, dir_path = None):
     """Helper function that creates an action to copy a file from src to dst.
 
     If src is a TreeArtifact, dir_path must be specified as the path within
@@ -97,7 +99,6 @@ def copy_file_action(ctx, src, dst, dir_path = None, is_windows = False):
         src: The source file to copy or TreeArtifact to copy a single file out of.
         dst: The destination file.
         dir_path: If src is a TreeArtifact, the path within the TreeArtifact to the file to copy.
-        is_windows: If true, an cmd.exe action is created so there is no bash dependency.
     """
     if dst.is_directory:
         fail("dst must not be a TreeArtifact")
@@ -107,14 +108,10 @@ def copy_file_action(ctx, src, dst, dir_path = None, is_windows = False):
         src_path = "/".join([src.path, dir_path])
     else:
         src_path = src.path
-    if is_windows:
-        _copy_cmd(ctx, src, src_path, dst)
-    else:
-        _copy_bash(ctx, src, src_path, dst)
+    _copy_cmd(ctx, src, src_path, dst)
+    _copy_bash(ctx, src, src_path, dst)
 
 def _copy_file_impl(ctx):
-    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
-
     if ctx.attr.allow_symlink:
         if len(ctx.files.src) != 1:
             fail("src must be a single file when allow_symlink is True")
@@ -131,14 +128,13 @@ def _copy_file_impl(ctx):
             ctx.attr.src[DirectoryPathInfo].directory,
             ctx.outputs.out,
             dir_path = ctx.attr.src[DirectoryPathInfo].path,
-            is_windows = is_windows,
         )
     else:
         if len(ctx.files.src) != 1:
             fail("src must be a single file or a target that provides a DirectoryPathInfo")
         if ctx.files.src[0].is_directory:
             fail("cannot use copy_file on a directory; try copy_directory instead")
-        copy_file_action(ctx, ctx.files.src[0], ctx.outputs.out, is_windows = is_windows)
+        copy_file_action(ctx, ctx.files.src[0], ctx.outputs.out)
 
     files = depset(direct = [ctx.outputs.out])
     runfiles = ctx.runfiles(files = [ctx.outputs.out])
@@ -152,13 +148,13 @@ _ATTRS = {
     "is_executable": attr.bool(mandatory = True),
     "allow_symlink": attr.bool(mandatory = True),
     "out": attr.output(mandatory = True),
-    "_windows_constraint": attr.label(default = "@platforms//os:windows"),
 }
 
 _copy_file = rule(
     implementation = _copy_file_impl,
     provides = [DefaultInfo],
     attrs = _ATTRS,
+    exec_groups = COPY_EXEC_GROUPS,
 )
 
 _copy_xfile = rule(
@@ -166,6 +162,7 @@ _copy_xfile = rule(
     executable = True,
     provides = [DefaultInfo],
     attrs = _ATTRS,
+    exec_groups = COPY_EXEC_GROUPS,
 )
 
 def copy_file(name, src, out, is_executable = False, allow_symlink = False, **kwargs):

--- a/lib/private/copy_to_bin.bzl
+++ b/lib/private/copy_to_bin.bzl
@@ -16,6 +16,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":copy_file.bzl", "copy_file_action")
+load(":copy_common.bzl", "COPY_EXEC_GROUPS")
 
 def copy_file_to_bin_action(ctx, file, is_windows = False):
     """Helper function that creates an action to copy a file to the output tree.
@@ -124,6 +125,7 @@ _copy_to_bin = rule(
         "srcs": attr.label_list(mandatory = True, allow_files = True),
         "_windows_constraint": attr.label(default = "@platforms//os:windows"),
     },
+    exec_groups = COPY_EXEC_GROUPS,
 )
 
 def copy_to_bin(name, srcs, **kwargs):


### PR DESCRIPTION
@alexeagle || @gregmagolan 

Trying to follow the suggestions in these threads [1](https://bazelbuild.slack.com/archives/CDCMRLS23/p1660894883837699), [2](https://bazelbuild.slack.com/archives/CA31HN1T3/p1660853078169879). Apparently what we're doing here is choosing the batch or the shell script based on the target platform rather than the platform that's doing the copy.

I'm stuck. Running into errors like the following:
```
While resolving toolchains for target //lib/tests/copy_file:a_copy_from_dir: Unable to find an execution platform for target platform @local_config_platform//:host from available execution platforms []
```

Seems like it isn't recognizing my host system (Linux) as an execution platform. I haven't worked much with platforms or constraints in bazel yet, so maybe I'm missing something.

[Related Slack thread](https://bazelbuild.slack.com/archives/CDCMRLS23/p1661018990795499?thread_ts=1660894883.837699&cid=CDCMRLS23)