### PR TITLE
copy_to_directory performance improvements

### DIFF
--- a/docs/copy_to_directory.md
+++ b/docs/copy_to_directory.md
@@ -42,7 +42,7 @@ copy_to_directory(<a href="#copy_to_directory-name">name</a>, <a href="#copy_to_
 ## copy_to_directory_action
 
 <pre>
-copy_to_directory_action(<a href="#copy_to_directory_action-ctx">ctx</a>, <a href="#copy_to_directory_action-srcs">srcs</a>, <a href="#copy_to_directory_action-dst">dst</a>, <a href="#copy_to_directory_action-additional_files">additional_files</a>, <a href="#copy_to_directory_action-additional_files_depsets">additional_files_depsets</a>, <a href="#copy_to_directory_action-root_paths">root_paths</a>,
+copy_to_directory_action(<a href="#copy_to_directory_action-ctx">ctx</a>, <a href="#copy_to_directory_action-srcs">srcs</a>, <a href="#copy_to_directory_action-dst">dst</a>, <a href="#copy_to_directory_action-additional_files">additional_files</a>, <a href="#copy_to_directory_action-root_paths">root_paths</a>,
                          <a href="#copy_to_directory_action-include_external_repositories">include_external_repositories</a>, <a href="#copy_to_directory_action-include_srcs_packages">include_srcs_packages</a>, <a href="#copy_to_directory_action-exclude_srcs_packages">exclude_srcs_packages</a>,
                          <a href="#copy_to_directory_action-include_srcs_patterns">include_srcs_patterns</a>, <a href="#copy_to_directory_action-exclude_srcs_patterns">exclude_srcs_patterns</a>, <a href="#copy_to_directory_action-exclude_prefixes">exclude_prefixes</a>,
                          <a href="#copy_to_directory_action-replace_prefixes">replace_prefixes</a>, <a href="#copy_to_directory_action-allow_overwrites">allow_overwrites</a>, <a href="#copy_to_directory_action-is_windows">is_windows</a>)
@@ -62,8 +62,7 @@ other rule implementations where additional_files can also be passed in.
 | <a id="copy_to_directory_action-ctx"></a>ctx |  The rule context.   |  none |
 | <a id="copy_to_directory_action-srcs"></a>srcs |  Files and/or directories or targets that provide DirectoryPathInfo to copy into the output directory.   |  none |
 | <a id="copy_to_directory_action-dst"></a>dst |  The directory to copy to. Must be a TreeArtifact.   |  none |
-| <a id="copy_to_directory_action-additional_files"></a>additional_files |  Additional files to copy that are not in the DefaultInfo or DirectoryPathInfo of srcs   |  <code>[]</code> |
-| <a id="copy_to_directory_action-additional_files_depsets"></a>additional_files_depsets |  Additional depsets to copy that are not in the DefaultInfo or DirectoryPathInfo of srcs   |  <code>[]</code> |
+| <a id="copy_to_directory_action-additional_files"></a>additional_files |  List or depset of additional files to copy that are not in the DefaultInfo or DirectoryPathInfo of srcs   |  <code>[]</code> |
 | <a id="copy_to_directory_action-root_paths"></a>root_paths |  List of paths that are roots in the output directory.<br><br>See copy_to_directory rule documentation for more details.   |  <code>["."]</code> |
 | <a id="copy_to_directory_action-include_external_repositories"></a>include_external_repositories |  List of external repository names to include in the output directory.<br><br>See copy_to_directory rule documentation for more details.   |  <code>[]</code> |
 | <a id="copy_to_directory_action-include_srcs_packages"></a>include_srcs_packages |  List of Bazel packages to include in output directory.<br><br>See copy_to_directory rule documentation for more details.   |  <code>["**"]</code> |

--- a/docs/copy_to_directory.md
+++ b/docs/copy_to_directory.md
@@ -42,7 +42,7 @@ copy_to_directory(<a href="#copy_to_directory-name">name</a>, <a href="#copy_to_
 ## copy_to_directory_action
 
 <pre>
-copy_to_directory_action(<a href="#copy_to_directory_action-ctx">ctx</a>, <a href="#copy_to_directory_action-srcs">srcs</a>, <a href="#copy_to_directory_action-dst">dst</a>, <a href="#copy_to_directory_action-additional_files">additional_files</a>, <a href="#copy_to_directory_action-root_paths">root_paths</a>,
+copy_to_directory_action(<a href="#copy_to_directory_action-ctx">ctx</a>, <a href="#copy_to_directory_action-srcs">srcs</a>, <a href="#copy_to_directory_action-dst">dst</a>, <a href="#copy_to_directory_action-additional_files">additional_files</a>, <a href="#copy_to_directory_action-additional_files_depsets">additional_files_depsets</a>, <a href="#copy_to_directory_action-root_paths">root_paths</a>,
                          <a href="#copy_to_directory_action-include_external_repositories">include_external_repositories</a>, <a href="#copy_to_directory_action-include_srcs_packages">include_srcs_packages</a>, <a href="#copy_to_directory_action-exclude_srcs_packages">exclude_srcs_packages</a>,
                          <a href="#copy_to_directory_action-include_srcs_patterns">include_srcs_patterns</a>, <a href="#copy_to_directory_action-exclude_srcs_patterns">exclude_srcs_patterns</a>, <a href="#copy_to_directory_action-exclude_prefixes">exclude_prefixes</a>,
                          <a href="#copy_to_directory_action-replace_prefixes">replace_prefixes</a>, <a href="#copy_to_directory_action-allow_overwrites">allow_overwrites</a>, <a href="#copy_to_directory_action-is_windows">is_windows</a>)
@@ -63,6 +63,7 @@ other rule implementations where additional_files can also be passed in.
 | <a id="copy_to_directory_action-srcs"></a>srcs |  Files and/or directories or targets that provide DirectoryPathInfo to copy into the output directory.   |  none |
 | <a id="copy_to_directory_action-dst"></a>dst |  The directory to copy to. Must be a TreeArtifact.   |  none |
 | <a id="copy_to_directory_action-additional_files"></a>additional_files |  Additional files to copy that are not in the DefaultInfo or DirectoryPathInfo of srcs   |  <code>[]</code> |
+| <a id="copy_to_directory_action-additional_files_depsets"></a>additional_files_depsets |  Additional depsets to copy that are not in the DefaultInfo or DirectoryPathInfo of srcs   |  <code>[]</code> |
 | <a id="copy_to_directory_action-root_paths"></a>root_paths |  List of paths that are roots in the output directory.<br><br>See copy_to_directory rule documentation for more details.   |  <code>["."]</code> |
 | <a id="copy_to_directory_action-include_external_repositories"></a>include_external_repositories |  List of external repository names to include in the output directory.<br><br>See copy_to_directory rule documentation for more details.   |  <code>[]</code> |
 | <a id="copy_to_directory_action-include_srcs_packages"></a>include_srcs_packages |  List of Bazel packages to include in output directory.<br><br>See copy_to_directory rule documentation for more details.   |  <code>["**"]</code> |

--- a/lib/private/copy_to_directory.bzl
+++ b/lib/private/copy_to_directory.bzl
@@ -631,6 +631,7 @@ def copy_to_directory_action(
         srcs,
         dst,
         additional_files = [],
+        additional_files_depsets = [],
         root_paths = ["."],
         include_external_repositories = [],
         include_srcs_packages = ["**"],
@@ -654,6 +655,8 @@ def copy_to_directory_action(
         dst: The directory to copy to. Must be a TreeArtifact.
 
         additional_files: Additional files to copy that are not in the DefaultInfo or DirectoryPathInfo of srcs
+
+        additional_files_depsets: Additional depsets to copy that are not in the DefaultInfo or DirectoryPathInfo of srcs
 
         root_paths: List of paths that are roots in the output directory.
 
@@ -717,45 +720,21 @@ def copy_to_directory_action(
 
     # Gather a list of src_path, dst_path pairs
     found_input_paths = False
+
+    src_dirs = []
+    src_depsets = []
     copy_paths = []
     for src in srcs:
         if DirectoryPathInfo in src:
-            found_input_paths = True
-            src_path, output_path, src_file = _copy_paths(
-                src = src,
-                root_paths = root_paths,
-                include_external_repositories = include_external_repositories,
-                include_srcs_packages = include_srcs_packages,
-                exclude_srcs_packages = exclude_srcs_packages,
-                include_srcs_patterns = include_srcs_patterns,
-                exclude_srcs_patterns = exclude_srcs_patterns,
-                replace_prefixes = replace_prefixes,
-            )
-            if src_path != None:
-                dst_path = skylib_paths.normalize("/".join([dst.path, output_path]))
-                if not _merge_into_copy_path(copy_paths, src_path, dst_path, src_file):
-                    copy_paths.append((src_path, dst_path, src_file))
+            src_dirs.append(src)
         if DefaultInfo in src:
-            for src_file in src[DefaultInfo].files.to_list():
-                found_input_paths = True
-                src_path, output_path, src_file = _copy_paths(
-                    src = src_file,
-                    root_paths = root_paths,
-                    include_external_repositories = include_external_repositories,
-                    include_srcs_packages = include_srcs_packages,
-                    exclude_srcs_packages = exclude_srcs_packages,
-                    include_srcs_patterns = include_srcs_patterns,
-                    exclude_srcs_patterns = exclude_srcs_patterns,
-                    replace_prefixes = replace_prefixes,
-                )
-                if src_path != None:
-                    dst_path = skylib_paths.normalize("/".join([dst.path, output_path]))
-                    if not _merge_into_copy_path(copy_paths, src_path, dst_path, src_file):
-                        copy_paths.append((src_path, dst_path, src_file))
-    for additional_file in additional_files:
+            src_depsets.append(src[DefaultInfo].files)
+
+    all_srcs = src_dirs + depset(additional_files, transitive = additional_files_depsets + src_depsets).to_list()
+    for src in all_srcs:
         found_input_paths = True
         src_path, output_path, src_file = _copy_paths(
-            src = additional_file,
+            src = src,
             root_paths = root_paths,
             include_external_repositories = include_external_repositories,
             include_srcs_packages = include_srcs_packages,
@@ -765,7 +744,7 @@ def copy_to_directory_action(
             replace_prefixes = replace_prefixes,
         )
         if src_path != None:
-            dst_path = skylib_paths.normalize("/".join([dst.path, output_path]))
+            dst_path = skylib_paths.normalize("%s/%s" % (dst.path, output_path))
             if not _merge_into_copy_path(copy_paths, src_path, dst_path, src_file):
                 copy_paths.append((src_path, dst_path, src_file))
 

--- a/lib/private/copy_to_directory.bzl
+++ b/lib/private/copy_to_directory.bzl
@@ -631,7 +631,6 @@ def copy_to_directory_action(
         srcs,
         dst,
         additional_files = [],
-        additional_files_depsets = [],
         root_paths = ["."],
         include_external_repositories = [],
         include_srcs_packages = ["**"],
@@ -654,9 +653,7 @@ def copy_to_directory_action(
 
         dst: The directory to copy to. Must be a TreeArtifact.
 
-        additional_files: Additional files to copy that are not in the DefaultInfo or DirectoryPathInfo of srcs
-
-        additional_files_depsets: Additional depsets to copy that are not in the DefaultInfo or DirectoryPathInfo of srcs
+        additional_files: List or depset of additional files to copy that are not in the DefaultInfo or DirectoryPathInfo of srcs
 
         root_paths: List of paths that are roots in the output directory.
 
@@ -739,7 +736,10 @@ def copy_to_directory_action(
     include_srcs_patterns = include_srcs_patterns[:]
     exclude_srcs_patterns = exclude_srcs_patterns[:]
 
-    all_srcs = src_dirs + depset(additional_files, transitive = additional_files_depsets + src_depsets).to_list()
+    if type(additional_files) == "list":
+        additional_files = depset(additional_files)
+
+    all_srcs = src_dirs + depset(transitive = [additional_files] + src_depsets).to_list()
     for src in all_srcs:
         found_input_paths = True
         src_path, output_path, src_file = _copy_paths(
@@ -753,7 +753,7 @@ def copy_to_directory_action(
             replace_prefixes = replace_prefixes,
         )
         if src_path != None:
-            dst_path = skylib_paths.normalize("%s/%s" % (dst.path, output_path))
+            dst_path = skylib_paths.normalize("/".join([dst.path, output_path]))
             if not _merge_into_copy_path(copy_paths, src_path, dst_path, src_file):
                 copy_paths.append((src_path, dst_path, src_file))
 

--- a/lib/private/copy_to_directory.bzl
+++ b/lib/private/copy_to_directory.bzl
@@ -730,6 +730,15 @@ def copy_to_directory_action(
         if DefaultInfo in src:
             src_depsets.append(src[DefaultInfo].files)
 
+    # Convert potentially-large arrays into slices to pass by reference
+    # instead of copying when invoking _copy_paths()
+    root_paths = root_paths[:]
+    include_external_repositories = include_external_repositories[:]
+    include_srcs_packages = include_srcs_packages[:]
+    exclude_srcs_packages = exclude_srcs_packages[:]
+    include_srcs_patterns = include_srcs_patterns[:]
+    exclude_srcs_patterns = exclude_srcs_patterns[:]
+
     all_srcs = src_dirs + depset(additional_files, transitive = additional_files_depsets + src_depsets).to_list()
     for src in all_srcs:
         found_input_paths = True

--- a/lib/private/glob_match.bzl
+++ b/lib/private/glob_match.bzl
@@ -37,6 +37,8 @@ def _split_on(expr, splits):
         result.append(accumulator)
     return result
 
+GLOB_SYMBOLS = ["**", "*", "?"]
+
 def glob_match(expr, path, match_path_separator = False):
     """Test if the passed path matches the glob expression.
 
@@ -61,7 +63,7 @@ def glob_match(expr, path, match_path_separator = False):
     if expr.find("***") != -1:
         fail("glob_match: invalid *** pattern found in glob expression")
 
-    expr_parts = _split_on(expr, ["**", "*", "?"])
+    expr_parts = _split_on(expr, GLOB_SYMBOLS[:])
 
     for i, expr_part in enumerate(expr_parts):
         if expr_part == "**":

--- a/lib/private/output_files.bzl
+++ b/lib/private/output_files.bzl
@@ -16,8 +16,11 @@ def _output_files(ctx):
         files_depset = ctx.attr.target[OutputGroupInfo][ctx.attr.output_group]
     else:
         files_depset = ctx.attr.target[DefaultInfo].files
+
+    files_list = files_depset.to_list()
+
     for path in ctx.attr.paths:
-        file = _find_short_path_in_files_depset(files_depset, path)
+        file = _find_short_path_in_files_list(files_list, path)
         if not file:
             if ctx.attr.output_group:
                 msg = "%s file not found within the %s output group of %s" % (path, ctx.attr.output_group, ctx.attr.target)
@@ -70,18 +73,16 @@ def make_output_files(name, target, paths, **kwargs):
     )
     return _to_label(name)
 
-def _find_short_path_in_files_depset(files_depset, short_path):
+def _find_short_path_in_files_list(files_list, short_path):
     """Helper function find a file in a DefaultInfo by short path
 
     Args:
-        files_depset: a depset
+        files_list: a list of files
         short_path: the short path (path relative to root) to search for
-
     Returns:
         The File if found else None
     """
-    if files_depset:
-        for file in files_depset.to_list():
-            if file.short_path == short_path:
-                return file
+    for file in files_list:
+        if file.short_path == short_path:
+            return file
     return None

--- a/lib/tests/copy_to_directory_action/pkg.bzl
+++ b/lib/tests/copy_to_directory_action/pkg.bzl
@@ -27,7 +27,7 @@ def _impl(ctx):
         ctx,
         srcs = ctx.attr.srcs,
         dst = dst,
-        additional_files_depsets = additional_files_depsets,
+        additional_files = depset(transitive = additional_files_depsets),
         is_windows = is_windows,
     )
 

--- a/lib/tests/copy_to_directory_action/pkg.bzl
+++ b/lib/tests/copy_to_directory_action/pkg.bzl
@@ -27,7 +27,7 @@ def _impl(ctx):
         ctx,
         srcs = ctx.attr.srcs,
         dst = dst,
-        additional_files = depset(transitive = additional_files_depsets),
+        additional_files = depset(transitive = additional_files_depsets).to_list(),
         is_windows = is_windows,
     )
 

--- a/lib/tests/copy_to_directory_action/pkg.bzl
+++ b/lib/tests/copy_to_directory_action/pkg.bzl
@@ -27,7 +27,7 @@ def _impl(ctx):
         ctx,
         srcs = ctx.attr.srcs,
         dst = dst,
-        additional_files = depset(transitive = additional_files_depsets).to_list(),
+        additional_files_depsets = additional_files_depsets,
         is_windows = is_windows,
     )
 


### PR DESCRIPTION
I noticed `copy_to_directory_action` consuming 3-5s in the angular-cli analysis phase, making the analysis phase itself often 30s.

First commit: mainly reducing the number of `depset.to_list()` calls. Seemed to improve performance by at most 5% so maybe this case of `to_list()` isn't done on large enough `depset`s to make a big difference?

Second commit: in ~~go~~ python (and go) passing arrays as params clones them, where a slice is a reference to the array. So switching from arrays to slices avoid cloning the arrays within the file loop. This made the analysis phase in my test go from 30s to 10s...