### PR TITLE
fix: fix host platform detection on all copy actions which always run locally

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,3 +35,10 @@ go_rules_dependencies()
 go_register_toolchains(version = "1.17.2")
 
 gazelle_dependencies()
+
+# buildifier: disable=bzl-visibility
+load("//lib/private:local_config_platform.bzl", "local_config_platform")
+
+local_config_platform(
+    name = "local_config_platform",
+)

--- a/docs/copy_directory.md
+++ b/docs/copy_directory.md
@@ -58,6 +58,6 @@ other rule implementations.
 | <a id="copy_directory_action-ctx"></a>ctx |  The rule context.   |  none |
 | <a id="copy_directory_action-src"></a>src |  The directory to make a copy of. Can be a source directory or TreeArtifact.   |  none |
 | <a id="copy_directory_action-dst"></a>dst |  The directory to copy to. Must be a TreeArtifact.   |  none |
-| <a id="copy_directory_action-is_windows"></a>is_windows |  If true, an cmd.exe action is created so there is no bash dependency.   |  <code>False</code> |
+| <a id="copy_directory_action-is_windows"></a>is_windows |  Deprecated and unused   |  <code>None</code> |
 
 

--- a/docs/copy_file.md
+++ b/docs/copy_file.md
@@ -72,6 +72,6 @@ other rule implementations.
 | <a id="copy_file_action-src"></a>src |  The source file to copy or TreeArtifact to copy a single file out of.   |  none |
 | <a id="copy_file_action-dst"></a>dst |  The destination file.   |  none |
 | <a id="copy_file_action-dir_path"></a>dir_path |  If src is a TreeArtifact, the path within the TreeArtifact to the file to copy.   |  <code>None</code> |
-| <a id="copy_file_action-is_windows"></a>is_windows |  If true, an cmd.exe action is created so there is no bash dependency.   |  <code>False</code> |
+| <a id="copy_file_action-is_windows"></a>is_windows |  Deprecated and unused   |  <code>None</code> |
 
 

--- a/docs/copy_to_bin.md
+++ b/docs/copy_to_bin.md
@@ -33,7 +33,7 @@ without a copy action.
 | :------------- | :------------- | :------------- |
 | <a id="copy_file_to_bin_action-ctx"></a>ctx |  The rule context.   |  none |
 | <a id="copy_file_to_bin_action-file"></a>file |  The file to copy.   |  none |
-| <a id="copy_file_to_bin_action-is_windows"></a>is_windows |  If true, an cmd.exe action is created so there is no bash dependency.   |  <code>False</code> |
+| <a id="copy_file_to_bin_action-is_windows"></a>is_windows |  Deprecated and unused   |  <code>None</code> |
 
 **RETURNS**
 
@@ -64,7 +64,7 @@ directly to the result without a copy action.
 | :------------- | :------------- | :------------- |
 | <a id="copy_files_to_bin_actions-ctx"></a>ctx |  The rule context.   |  none |
 | <a id="copy_files_to_bin_actions-files"></a>files |  List of File objects.   |  none |
-| <a id="copy_files_to_bin_actions-is_windows"></a>is_windows |  If true, an cmd.exe action is created so there is no bash dependency.   |  <code>False</code> |
+| <a id="copy_files_to_bin_actions-is_windows"></a>is_windows |  Deprecated and unused   |  <code>None</code> |
 
 **RETURNS**
 

--- a/docs/copy_to_directory.md
+++ b/docs/copy_to_directory.md
@@ -72,7 +72,7 @@ other rule implementations where additional_files can also be passed in.
 | <a id="copy_to_directory_action-exclude_prefixes"></a>exclude_prefixes |  List of path prefixes to exclude from output directory.   |  <code>[]</code> |
 | <a id="copy_to_directory_action-replace_prefixes"></a>replace_prefixes |  Map of paths prefixes to replace in the output directory path when copying files.<br><br>See copy_to_directory rule documentation for more details.   |  <code>{}</code> |
 | <a id="copy_to_directory_action-allow_overwrites"></a>allow_overwrites |  If True, allow files to be overwritten if the same output file is copied to twice.<br><br>See copy_to_directory rule documentation for more details.   |  <code>False</code> |
-| <a id="copy_to_directory_action-is_windows"></a>is_windows |  If true, an cmd.exe action is created so there is no bash dependency.   |  <code>False</code> |
+| <a id="copy_to_directory_action-is_windows"></a>is_windows |  Deprecated and unused   |  <code>None</code> |
 
 
 <a id="copy_to_directory_lib.impl"></a>

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -8,13 +8,18 @@ exports_files(
 )
 
 exports_files(
-    ["diff_test_tmpl.sh", "diff_test_tmpl.bat", "parse_status_file.jq"],
+    [
+        "diff_test_tmpl.sh",
+        "diff_test_tmpl.bat",
+        "parse_status_file.jq",
+    ],
     visibility = ["//visibility:public"],
 )
 
 bzl_library(
     name = "copy_common",
     srcs = ["copy_common.bzl"],
+    deps = ["@local_config_platform//:constraints"],
 )
 
 bzl_library(

--- a/lib/private/copy_common.bzl
+++ b/lib/private/copy_common.bzl
@@ -1,5 +1,7 @@
 "Helpers for copy rules"
 
+load("@local_config_platform//:constraints.bzl", "HOST_CONSTRAINTS")
+
 # Hints for Bazel spawn strategy
 COPY_EXECUTION_REQUIREMENTS = {
     # ----------------+-----------------------------------------------------------------------------
@@ -57,3 +59,6 @@ COPY_EXECUTION_REQUIREMENTS = {
     "no-sandbox": "1",
     "local": "1",
 }
+
+def is_windows_host():
+    return "@platforms//os:windows" in HOST_CONSTRAINTS

--- a/lib/private/copy_to_bin.bzl
+++ b/lib/private/copy_to_bin.bzl
@@ -17,7 +17,7 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":copy_file.bzl", "copy_file_action")
 
-def copy_file_to_bin_action(ctx, file, is_windows = False):
+def copy_file_to_bin_action(ctx, file, is_windows = None):
     """Helper function that creates an action to copy a file to the output tree.
 
     File are copied to the same workspace-relative path. The resulting files is
@@ -29,11 +29,13 @@ def copy_file_to_bin_action(ctx, file, is_windows = False):
     Args:
         ctx: The rule context.
         file: The file to copy.
-        is_windows: If true, an cmd.exe action is created so there is no bash dependency.
+        is_windows: Deprecated and unused
 
     Returns:
         A File in the output tree.
     """
+
+    # TODO(2.0): remove depcreated & unused is_windows parameter
     if not file.is_source:
         return file
     if ctx.label.workspace_name != file.owner.workspace_name:
@@ -89,7 +91,7 @@ target to {file_package} using:
         package = "%s//%s" % (curr_package_label.workspace_name, curr_package_label.package),
     )
 
-def copy_files_to_bin_actions(ctx, files, is_windows = False):
+def copy_files_to_bin_actions(ctx, files, is_windows = None):
     """Helper function that creates actions to copy files to the output tree.
 
     Files are copied to the same workspace-relative path. The resulting list of
@@ -101,17 +103,17 @@ def copy_files_to_bin_actions(ctx, files, is_windows = False):
     Args:
         ctx: The rule context.
         files: List of File objects.
-        is_windows: If true, an cmd.exe action is created so there is no bash dependency.
+        is_windows: Deprecated and unused
 
     Returns:
         List of File objects in the output tree.
     """
+
+    # TODO(2.0): remove depcreated & unused is_windows parameter
     return [copy_file_to_bin_action(ctx, file, is_windows = is_windows) for file in files]
 
 def _impl(ctx):
-    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
-
-    files = copy_files_to_bin_actions(ctx, ctx.files.srcs, is_windows = is_windows)
+    files = copy_files_to_bin_actions(ctx, ctx.files.srcs)
     return DefaultInfo(
         files = depset(files),
         runfiles = ctx.runfiles(files = files),
@@ -122,7 +124,6 @@ _copy_to_bin = rule(
     provides = [DefaultInfo],
     attrs = {
         "srcs": attr.label_list(mandatory = True, allow_files = True),
-        "_windows_constraint": attr.label(default = "@platforms//os:windows"),
     },
 )
 

--- a/lib/private/local_config_platform.bzl
+++ b/lib/private/local_config_platform.bzl
@@ -1,0 +1,49 @@
+"""Work-around for getting a bzl_library for @local_config_platform//:constraints.bzl load
+
+For internal use only
+"""
+
+load(":repo_utils.bzl", "repo_utils")
+
+def _impl(rctx):
+    rctx.file("BUILD.bazel", """load(':constraints.bzl', 'HOST_CONSTRAINTS')
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+package(default_visibility = ['//visibility:public'])
+
+platform(name = 'host',
+  # Auto-detected host platform constraints.
+  constraint_values = HOST_CONSTRAINTS,
+)
+
+bzl_library(
+    name = "constraints",
+    srcs = ["constraints.bzl"],
+    visibility = ["//visibility:public"],
+)
+""")
+
+    # TODO: we can detect the host CPU in the future as well if needed;
+    # see the repo_utils.platform(rctx) function for an example of this
+    if repo_utils.is_darwin(rctx):
+        rctx.file("constraints.bzl", content = """HOST_CONSTRAINTS = [
+  '@platforms//cpu:x86_64',
+  '@platforms//os:osx',
+]
+""")
+    elif repo_utils.is_windows(rctx):
+        rctx.file("constraints.bzl", content = """HOST_CONSTRAINTS = [
+  '@platforms//cpu:x86_64',
+  '@platforms//os:windows',
+]
+""")
+    else:
+        rctx.file("constraints.bzl", content = """HOST_CONSTRAINTS = [
+  '@platforms//cpu:x86_64',
+  '@platforms//os:linux',
+]
+""")
+
+local_config_platform = repository_rule(
+    implementation = _impl,
+)

--- a/lib/tests/copy_to_directory_action/pkg.bzl
+++ b/lib/tests/copy_to_directory_action/pkg.bzl
@@ -8,12 +8,9 @@ load(":other_info.bzl", "OtherInfo")
 _attrs = {
     "srcs": attr.label_list(allow_files = True),
     "out": attr.string(mandatory = True),
-    "_windows_constraint": attr.label(default = "@platforms//os:windows"),
 }
 
 def _impl(ctx):
-    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
-
     dst = ctx.actions.declare_directory(ctx.attr.out)
 
     additional_files_depsets = []
@@ -27,8 +24,7 @@ def _impl(ctx):
         ctx,
         srcs = ctx.attr.srcs,
         dst = dst,
-        additional_files = depset(transitive = additional_files_depsets).to_list(),
-        is_windows = is_windows,
+        additional_files = depset(transitive = additional_files_depsets),
     )
 
     return [


### PR DESCRIPTION
Relies on checking `HOST_CONTRAINTS` from
```
load("@local_config_platform//:constraints.bzl", "HOST_CONSTRAINTS")
```

to figure out the host platform.

Since these actions all have "local" execution requirements then we can assume the host platform is the execution platform
