### PR TITLE
fix: fix bzl_library breakage created with load from @local_config_platform in copy rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,10 +35,3 @@ go_rules_dependencies()
 go_register_toolchains(version = "1.17.2")
 
 gazelle_dependencies()
-
-# buildifier: disable=bzl-visibility
-load("//lib/private:local_config_platform.bzl", "local_config_platform")
-
-local_config_platform(
-    name = "local_config_platform",
-)

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -176,6 +176,7 @@ bzl_library(
     srcs = ["repositories.bzl"],
     deps = [
         "//lib/private:jq_toolchain",
+        "//lib/private:local_config_platform",
         "//lib/private:yq_toolchain",
         "@bazel_tools//tools/build_defs/repo:http.bzl",
         "@bazel_tools//tools/build_defs/repo:utils.bzl",

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -19,7 +19,7 @@ exports_files(
 bzl_library(
     name = "copy_common",
     srcs = ["copy_common.bzl"],
-    deps = ["@local_config_platform//:constraints"],
+    deps = ["@aspect_bazel_lib_local_config_platform//:constraints"],
 )
 
 bzl_library(
@@ -114,6 +114,11 @@ bzl_library(
     name = "jq",
     srcs = ["jq.bzl"],
     deps = ["//lib:stamping"],
+)
+
+bzl_library(
+    name = "local_config_platform",
+    srcs = ["local_config_platform.bzl"],
 )
 
 bzl_library(

--- a/lib/private/copy_common.bzl
+++ b/lib/private/copy_common.bzl
@@ -1,6 +1,6 @@
 "Helpers for copy rules"
 
-load("@local_config_platform//:constraints.bzl", "HOST_CONSTRAINTS")
+load("@aspect_bazel_lib_local_config_platform//:constraints.bzl", "HOST_CONSTRAINTS")
 
 # Hints for Bazel spawn strategy
 COPY_EXECUTION_REQUIREMENTS = {

--- a/lib/private/local_config_platform.bzl
+++ b/lib/private/local_config_platform.bzl
@@ -1,21 +1,11 @@
-"""Work-around for getting a bzl_library for @local_config_platform//:constraints.bzl load
-
-For internal use only
+"""local_config_platform repository rule
 """
 
-load(":repo_utils.bzl", "repo_utils")
-
 def _impl(rctx):
-    rctx.file("BUILD.bazel", """load(':constraints.bzl', 'HOST_CONSTRAINTS')
+    rctx.file("constraints.bzl", content = rctx.read(rctx.attr._constraints_bzl))
+
+    rctx.file("BUILD.bazel", content = rctx.read(rctx.attr._build_bazel) + """
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-
-package(default_visibility = ['//visibility:public'])
-
-platform(name = 'host',
-  # Auto-detected host platform constraints.
-  constraint_values = HOST_CONSTRAINTS,
-)
-
 bzl_library(
     name = "constraints",
     srcs = ["constraints.bzl"],
@@ -23,27 +13,15 @@ bzl_library(
 )
 """)
 
-    # TODO: we can detect the host CPU in the future as well if needed;
-    # see the repo_utils.platform(rctx) function for an example of this
-    if repo_utils.is_darwin(rctx):
-        rctx.file("constraints.bzl", content = """HOST_CONSTRAINTS = [
-  '@platforms//cpu:x86_64',
-  '@platforms//os:osx',
-]
-""")
-    elif repo_utils.is_windows(rctx):
-        rctx.file("constraints.bzl", content = """HOST_CONSTRAINTS = [
-  '@platforms//cpu:x86_64',
-  '@platforms//os:windows',
-]
-""")
-    else:
-        rctx.file("constraints.bzl", content = """HOST_CONSTRAINTS = [
-  '@platforms//cpu:x86_64',
-  '@platforms//os:linux',
-]
-""")
-
 local_config_platform = repository_rule(
     implementation = _impl,
+    doc = """Generates a copy of the auto-generated @local_config_platform repository with an added bzl_library.
+    
+    This is useful for rules that want to load `HOST_CONSTRAINTS` from `@local_config_platform//:constraints.bzl` and
+    also want to use stardoc for generating documentation.
+    """,
+    attrs = {
+        "_constraints_bzl": attr.label(default = "@local_config_platform//:constraints.bzl"),
+        "_build_bazel": attr.label(default = "@local_config_platform//:BUILD.bazel"),
+    },
 )

--- a/lib/repositories.bzl
+++ b/lib/repositories.bzl
@@ -4,6 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archi
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//lib/private:jq_toolchain.bzl", "JQ_PLATFORMS", "jq_host_alias_repo", "jq_platform_repo", "jq_toolchains_repo", _DEFAULT_JQ_VERSION = "DEFAULT_JQ_VERSION")
 load("//lib/private:yq_toolchain.bzl", "YQ_PLATFORMS", "yq_host_alias_repo", "yq_platform_repo", "yq_toolchains_repo", _DEFAULT_YQ_VERSION = "DEFAULT_YQ_VERSION")
+load("//lib/private:local_config_platform.bzl", "local_config_platform")
 
 # Don't wrap later calls with maybe() as that prevents renovate from parsing our deps
 def http_archive(name, **kwargs):
@@ -18,6 +19,10 @@ def aspect_bazel_lib_dependencies():
             "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
         ],
+    )
+
+    local_config_platform(
+        name = "aspect_bazel_lib_local_config_platform",
     )
 
 # Re-export the default versions


### PR DESCRIPTION
Downstream rules will need to add this to their WORKSPACE if they are loading from @aspect_bazel_lib copy rules and 
generating stardoc:

```
load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
aspect_bazel_lib_dependencies()
```