### PR TITLE
fix: use person as release author

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,4 @@ jobs:
           # Use GH feature to populate the changelog automatically
           generate_release_notes: true
           body_path: release_notes.txt
+          token: ${{ secrets.DEREK_BCR_PAT }}


### PR DESCRIPTION
Recall that for the Publish to BCR app to pick up a release author (to use them as the commit author), the release needs to be done by a human rather than a bot.

Doing this temporarily until we change how our release automation works.