### PR TITLE
chore(deps): remove build_bazel_integration_testing

### DIFF
--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -16,15 +16,6 @@ def http_archive(name, **kwargs):
 def bazel_lib_internal_deps():
     "Fetch deps needed for local development"
     http_archive(
-        name = "build_bazel_integration_testing",
-        urls = [
-            "https://github.com/bazelbuild/bazel-integration-testing/archive/165440b2dbda885f8d1ccb8d0f417e6cf8c54f17.zip",
-        ],
-        strip_prefix = "bazel-integration-testing-165440b2dbda885f8d1ccb8d0f417e6cf8c54f17",
-        sha256 = "2401b1369ef44cc42f91dc94443ef491208dbd06da1e1e10b702d8c189f098e3",
-    )
-
-    http_archive(
         name = "io_bazel_rules_go",
         sha256 = "685052b498b6ddfe562ca7a97736741d87916fe536623afb7da2824c0211c369",
         urls = [


### PR DESCRIPTION
This is from the https://github.com/bazel-contrib/rules-template template but we don't seem to use it.