### PR TITLE
feat: add test_suite containing all tests from write_source_files

### DIFF
--- a/lib/private/write_source_file.bzl
+++ b/lib/private/write_source_file.bzl
@@ -30,6 +30,9 @@ def write_source_file(
         suggested_update_target: Label of the write_source_file target to suggest running when files are out of date
         diff_test: Generate a test target to check that the source file(s) exist and are up to date with the generated files(s).
         **kwargs: Other common named parameters such as `tags` or `visibility`
+
+    Returns:
+        Name of the generated test target if requested, otherwise None.
     """
     if out_file:
         if not in_file:
@@ -59,7 +62,7 @@ def write_source_file(
     )
 
     if not in_file or not out_file or not diff_test:
-        return
+        return None
 
     out_file_missing = _is_file_missing(out_file)
     test_target_name = "%s_test" % name
@@ -125,6 +128,8 @@ To update *only* this file, run:
             failure_message = message,
             **kwargs
         )
+
+    return test_target_name
 
 _write_source_file_attrs = {
     "in_file": attr.label(allow_files = True, mandatory = False),

--- a/lib/write_source_files.bzl
+++ b/lib/write_source_files.bzl
@@ -95,6 +95,7 @@ def write_source_files(
 
     single_update_target = len(files.keys()) == 1
     update_targets = []
+    test_targets = []
     for i, pair in enumerate(files.items()):
         out_file, in_file = pair
 
@@ -108,7 +109,7 @@ def write_source_files(
                 this_suggested_update_target = name
 
         # Runnable target that writes to the out file to the source tree
-        _write_source_file(
+        test_target = _write_source_file(
             name = update_target_name,
             in_file = in_file,
             out_file = out_file,
@@ -116,6 +117,17 @@ def write_source_files(
             suggested_update_target = this_suggested_update_target,
             diff_test = diff_test,
             **kwargs
+        )
+
+        if test_target:
+            test_targets.append(test_target)
+
+    if len(test_targets) > 0:
+        native.test_suite(
+            name = "%s_tests" % name,
+            tests = test_targets,
+            visibility = kwargs.get("visibility"),
+            tags = kwargs.get("tags"),
         )
 
     if not single_update_target:


### PR DESCRIPTION
Adds a convenience `test_suite` target that contains all the test targets from `write_source_files`. This allows the user to run a single bazel test target for the entire set of diff tests, rather than having to use a wildcard target or query.

```
$ bazel test //rosetta/src:rosetta_steps_fixtures_tests --override_repository=aspect_bazel_lib=/Users/matt/workspace/bazel-lib

Using config file: /Users/matt/.aspect/cli/config.yaml
INFO: Analyzed 8 targets (4 packages loaded, 209 targets configured).
INFO: Found 8 test targets...
INFO: Elapsed time: 0.280s, Critical Path: 0.09s
INFO: 1 process: 1 internal.
//rosetta/src:rosetta_steps_fixtures_0_test                     (cached) PASSED in 0.5s
//rosetta/src:rosetta_steps_fixtures_1_test                     (cached) PASSED in 0.3s
//rosetta/src:rosetta_steps_fixtures_2_test                     (cached) PASSED in 0.2s
//rosetta/src:rosetta_steps_fixtures_3_test                     (cached) PASSED in 0.3s
//rosetta/src:rosetta_steps_fixtures_4_test                     (cached) PASSED in 0.1s
//rosetta/src:rosetta_steps_fixtures_5_test                     (cached) PASSED in 0.2s
//rosetta/src:rosetta_steps_fixtures_6_test                     (cached) PASSED in 0.5s
//rosetta/src:rosetta_steps_fixtures_7_test                     (cached) PASSED in 0.4s

Executed 0 out of 8 tests: 8 tests pass.
INFO: Build completed successfully, 1 total action
```