### PR TITLE
fix: handle other CPU architectures in local_config_platform

### DIFF
--- a/lib/private/local_config_platform.bzl
+++ b/lib/private/local_config_platform.bzl
@@ -21,26 +21,15 @@ bzl_library(
 )
 """)
 
-    # TODO: we can detect the host CPU in the future as well if needed;
-    # see the repo_utils.platform(rctx) function for an example of this
-    if repo_utils.is_darwin(rctx):
-        rctx.file("constraints.bzl", content = """HOST_CONSTRAINTS = [
-  '@platforms//cpu:x86_64',
-  '@platforms//os:osx',
+    [os, cpu] = repo_utils.platform(rctx).split("_")
+    cpu_constraint = "@platforms//cpu:{0}".format("x86_64" if cpu == "amd64" else cpu)
+    os_constraint = "@platforms//os:{0}".format("osx" if os == "darwin" else os)
+
+    rctx.file("constraints.bzl", content = """HOST_CONSTRAINTS = [
+  '{0}',
+  '{1}',
 ]
-""")
-    elif repo_utils.is_windows(rctx):
-        rctx.file("constraints.bzl", content = """HOST_CONSTRAINTS = [
-  '@platforms//cpu:x86_64',
-  '@platforms//os:windows',
-]
-""")
-    else:
-        rctx.file("constraints.bzl", content = """HOST_CONSTRAINTS = [
-  '@platforms//cpu:x86_64',
-  '@platforms//os:linux',
-]
-""")
+""".format(cpu_constraint, os_constraint))
 
 local_config_platform = repository_rule(
     implementation = _impl,


### PR DESCRIPTION
The current reimplementation assumed everyone one was on `x86_64`, which, well, isn't the case and led to errors such as:

```
ERROR: /private/var/tmp/_bazel_matt/6659d1da76c274502913a8a29ab51672/external/bazel_tools/src/tools/launcher/BUILD:9:14: Target '@bazel_tools//src/tools/launcher:launcher' depends on toolchain '@llvm_toolchain//:cc-clang-x86_64-darwin', which cannot be found: no such target '@llvm_toolchain//:cc-clang-x86_64-darwin': target 'cc-clang-x86_64-darwin' not declared in package '' (did you mean 'cc-clang-arm64-darwin'?) defined by /private/var/tmp/_bazel_matt/6659d1da76c274502913a8a29ab51672/external/llvm_toolchain/BUILD.bazel'
```

Make the impl generic and pass though the arch and os.
Unblocks https://github.com/aspect-build/silo/pull/374