### PR TITLE
chore: declare bzlmod repository

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -7,6 +7,7 @@
       "name": "Aspect team"
     }
   ],
+  "repository": ["github:aspect-build/bazel-lib"],
   "versions": [],
   "yanked_versions": {}
 }


### PR DESCRIPTION
This is needed to match what's in the upstream BCR now