### PR TITLE
fix: use bzlmod @@ in to_label if Bazel version is 6 or greater

### DIFF
--- a/lib/private/utils.bzl
+++ b/lib/private/utils.bzl
@@ -48,23 +48,16 @@ def _to_label(param):
     Returns:
         a Label
     """
+    root_repo = "@@" if _is_bazel_6_or_greater() else "@"
     param_type = type(param)
     if param_type == "string":
         if param.startswith("@"):
             return Label(param)
         if param.startswith("//"):
-            return Label("@" + param)
-
-        # resolve the relative label from the current package
-        # if 'param' is in another workspace, then this would return the label relative to that workspace, eg:
-        # `Label("@my//foo:bar").relative("@other//baz:bill") == Label("@other//baz:bill")`
+            return Label("{}{}".format(root_repo, param))
         if param.startswith(":"):
             param = param[1:]
-        if native.package_name():
-            return Label("@//" + native.package_name()).relative(param)
-        else:
-            return Label("@//:" + param)
-
+        return Label("{}//{}:{}".format(root_repo, native.package_name(), param))
     elif param_type == "Label":
         return param
     else:

--- a/lib/tests/utils_test.bzl
+++ b/lib/tests/utils_test.bzl
@@ -16,6 +16,23 @@ def _to_label_test_impl(ctx):
     # assert that to_label can convert from string to label
     asserts.true(env, utils.to_label("//hello/world") == Label("//hello/world:world"))
     asserts.true(env, utils.to_label("//hello/world:world") == Label("//hello/world:world"))
+    asserts.true(env, utils.to_label("@//hello/world") == Label("@//hello/world:world"))
+    asserts.true(env, utils.to_label("@//hello/world:world") == Label("@//hello/world:world"))
+    asserts.true(env, utils.to_label("@somewhere//hello/world") == Label("@somewhere//hello/world:world"))
+    asserts.true(env, utils.to_label("@somewhere//hello/world:world") == Label("@somewhere//hello/world:world"))
+
+    # the "@@" repository name syntax applies to Bazel 6 or greater
+    if utils.is_bazel_6_or_greater():
+        asserts.true(env, utils.to_label("@@//hello/world") == Label("@@//hello/world:world"))
+        asserts.true(env, utils.to_label("@@//hello/world:world") == Label("@@//hello/world:world"))
+        asserts.true(env, utils.to_label("@@somewhere//hello/world") == Label("@@somewhere//hello/world:world"))
+        asserts.true(env, utils.to_label("@@somewhere//hello/world:world") == Label("@@somewhere//hello/world:world"))
+
+        # In this context, "@@" should evaluate to the same label as "@"
+        asserts.true(env, utils.to_label("@@//hello/world") == Label("@//hello/world:world"))
+        asserts.true(env, utils.to_label("@@//hello/world:world") == Label("@//hello/world:world"))
+        asserts.true(env, utils.to_label("@@somewhere//hello/world") == Label("@somewhere//hello/world:world"))
+        asserts.true(env, utils.to_label("@@somewhere//hello/world:world") == Label("@somewhere//hello/world:world"))
 
     # assert that to_label will handle a Label as an argument
     asserts.true(env, utils.to_label(Label("//hello/world")) == Label("//hello/world:world"))


### PR DESCRIPTION
This is needed for rules_js e2e/bzlmod to go green with Bazel 6.0.0rc1