### PR TITLE
perf: do not execute glob for non-glob copy_to_directory root_paths/replace_prefix params

### DIFF
--- a/docs/glob_match.md
+++ b/docs/glob_match.md
@@ -33,3 +33,25 @@ Test if the passed path matches the glob expression.
 True if the path matches the glob expression
 
 
+<a id="is_glob"></a>
+
+## is_glob
+
+<pre>
+is_glob(<a href="#is_glob-expr">expr</a>)
+</pre>
+
+Determine if the passed string is a globa expression
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="is_glob-expr"></a>expr |  the potential glob expression   |  none |
+
+**RETURNS**
+
+True if the passed string is a globa expression
+
+

--- a/lib/glob_match.bzl
+++ b/lib/glob_match.bzl
@@ -1,5 +1,6 @@
 "Public API"
 
-load("//lib/private:glob_match.bzl", _glob_match = "glob_match")
+load("//lib/private:glob_match.bzl", _glob_match = "glob_match", _is_glob = "is_glob")
 
 glob_match = _glob_match
+is_glob = _is_glob

--- a/lib/private/copy_to_directory.bzl
+++ b/lib/private/copy_to_directory.bzl
@@ -4,7 +4,7 @@ load("@bazel_skylib//lib:paths.bzl", skylib_paths = "paths")
 load(":copy_common.bzl", _COPY_EXECUTION_REQUIREMENTS = "COPY_EXECUTION_REQUIREMENTS")
 load(":paths.bzl", "paths")
 load(":directory_path.bzl", "DirectoryPathInfo")
-load(":glob_match.bzl", "glob_match")
+load(":glob_match.bzl", "glob_match", "is_glob")
 load(":platform_utils.bzl", _platform_utils = "platform_utils")
 
 _filter_transforms_order_docstring = """Filters and transformations are applied in the following order:
@@ -291,6 +291,9 @@ def _any_globs_match(exprs, path):
     return None
 
 def _longest_glob_match(expr, path):
+    if not is_glob(expr):
+        return path[:len(expr)] if path.startswith(expr) else None
+
     # For a given glob & path, find the longest subpath that matches the glob
     if glob_match(expr, path):
         # Full path matches

--- a/lib/private/copy_to_directory.bzl
+++ b/lib/private/copy_to_directory.bzl
@@ -283,10 +283,17 @@ _copy_to_directory_attr = {
 }
 
 def _any_globs_match(exprs, path):
+    # Exit quick in the common case of having a "**".
+    if "**" in exprs:
+        return True
+
+    # Special case: support non-standard empty glob expr.
+    # Only an empty expression matches an empty path.
+    if path == "":
+        return "" in exprs
+
     for expr in exprs:
-        if expr == path:
-            return True
-        if glob_match(expr, path):
+        if expr != "" and glob_match(expr, path):
             return True
     return None
 
@@ -294,12 +301,8 @@ def _longest_glob_match(expr, path):
     if not is_glob(expr):
         return path[:len(expr)] if path.startswith(expr) else None
 
-    # For a given glob & path, find the longest subpath that matches the glob
-    if glob_match(expr, path):
-        # Full path matches
-        return path
-    for i in range(len(path) - 1):
-        maybe_match = path[:-(i + 1)]
+    for i in range(len(path)):
+        maybe_match = path[:-i]
         if glob_match(expr, maybe_match):
             # Some subpath matches
             return maybe_match
@@ -381,10 +384,9 @@ def _copy_paths(
             return None, None, None
 
     # apply include_srcs_packages if "**" is not included in the list
-    if "**" not in include_srcs_packages:
-        if not _any_globs_match(include_srcs_packages, src_file.owner.package):
-            # file is excluded as it does not match any specified include_srcs_packages
-            return None, None, None
+    if not _any_globs_match(include_srcs_packages, src_file.owner.package):
+        # file is excluded as it does not match any specified include_srcs_packages
+        return None, None, None
 
     # apply exclude_srcs_packages
     if _any_globs_match(exclude_srcs_packages, src_file.owner.package):
@@ -412,10 +414,9 @@ def _copy_paths(
                 output_path = output_path[len(longest_match) + 1:]
 
     # apply include_srcs_patterns if "**" is not included in the list
-    if "**" not in include_srcs_patterns:
-        if not _any_globs_match(include_srcs_patterns, output_path):
-            # file is excluded as it does not match any specified include_srcs_patterns
-            return None, None, None
+    if not _any_globs_match(include_srcs_patterns, output_path):
+        # file is excluded as it does not match any specified include_srcs_patterns
+        return None, None, None
 
     # apply exclude_srcs_patterns
     if _any_globs_match(exclude_srcs_patterns, output_path):

--- a/lib/private/glob_match.bzl
+++ b/lib/private/glob_match.bzl
@@ -15,6 +15,7 @@ def _split_on(expr, splits):
     result = []
     accumulator = ""
     skip = 0
+    has_splits = False
     for i in range(len(expr)):
         j = i + skip
         if j >= len(expr):
@@ -29,13 +30,14 @@ def _split_on(expr, splits):
                 result.append(split)
                 skip = skip + len(split)
                 j = i + skip
+                has_splits = True
                 break
         if j >= len(expr):
             break
         accumulator = accumulator + expr[j]
     if accumulator:
         result.append(accumulator)
-    return result
+    return result, has_splits
 
 GLOB_SYMBOLS = ["**", "*", "?"]
 
@@ -79,7 +81,11 @@ def glob_match(expr, path, match_path_separator = False):
     if expr.find("***") != -1:
         fail("glob_match: invalid *** pattern found in glob expression")
 
-    expr_parts = _split_on(expr, GLOB_SYMBOLS[:])
+    expr_parts, has_splits = _split_on(expr, GLOB_SYMBOLS[:])
+
+    # Quick exit for simple cases.
+    if not has_splits:
+        return expr == path
 
     for i, expr_part in enumerate(expr_parts):
         if expr_part == "**":

--- a/lib/private/glob_match.bzl
+++ b/lib/private/glob_match.bzl
@@ -78,6 +78,9 @@ def glob_match(expr, path, match_path_separator = False):
     expr_i = 0
     path_i = 0
 
+    if expr == "":
+        fail("glob_match: invalid empty glob expression")
+
     if expr.find("***") != -1:
         fail("glob_match: invalid *** pattern found in glob expression")
 

--- a/lib/private/glob_match.bzl
+++ b/lib/private/glob_match.bzl
@@ -39,6 +39,22 @@ def _split_on(expr, splits):
 
 GLOB_SYMBOLS = ["**", "*", "?"]
 
+def is_glob(expr):
+    """Determine if the passed string is a globa expression
+
+    Args:
+        expr: the potential glob expression
+
+    Returns:
+        True if the passed string is a globa expression
+    """
+
+    for s in GLOB_SYMBOLS:
+        if -1 != expr.find(s):
+            return True
+
+    return False
+
 def glob_match(expr, path, match_path_separator = False):
     """Test if the passed path matches the glob expression.
 


### PR DESCRIPTION
df09e9c720e49c54c10478636cbaf428e8cadb7a gets my basic copy test (no globs) from 60s to ~11s. The rest is some basic tests and cleanup that should make it easier to avoid more perf issues in the future (just putting the quick-returns in a common location etc).

The last commit might be a breaking change and we shouldn't do it? But an empty glob really is invalid...