### PR TITLE
refactor: move bzl_library target out of @local_config_platform and just use exports_files in there instead

### DIFF
--- a/lib/private/docs/BUILD.bazel
+++ b/lib/private/docs/BUILD.bazel
@@ -8,6 +8,12 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 package(default_visibility = ["//lib:__pkg__"])
 
 bzl_library(
+    name = "local_config_platform_constraints",
+    srcs = ["@local_config_platform//:constraints.bzl"],
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
     name = "copy_common",
     srcs = ["//lib/private:copy_common.bzl"],
 )
@@ -15,7 +21,7 @@ bzl_library(
 bzl_library(
     name = "platform_utils",
     srcs = ["//lib/private:platform_utils.bzl"],
-    deps = ["@local_config_platform//:constraints"],
+    deps = [":local_config_platform_constraints"],
 )
 
 bzl_library(

--- a/lib/private/local_config_platform.bzl
+++ b/lib/private/local_config_platform.bzl
@@ -5,7 +5,6 @@ load(":repo_utils.bzl", "repo_utils")
 
 def _impl(rctx):
     rctx.file("BUILD.bazel", """load(':constraints.bzl', 'HOST_CONSTRAINTS')
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 package(default_visibility = ['//visibility:public'])
 
@@ -14,11 +13,10 @@ platform(name = 'host',
   constraint_values = HOST_CONSTRAINTS,
 )
 
-bzl_library(
-    name = "constraints",
-    srcs = ["constraints.bzl"],
-    visibility = ["//visibility:public"],
-)
+exports_files([
+  # Export constraints.bzl for use in downstream bzl_library targets.
+  'constraints.bzl',
+])
 """)
 
     [os, cpu] = repo_utils.platform(rctx).split("_")


### PR DESCRIPTION
Emulates what the `@local_config_platform` repo will look like after https://github.com/bazelbuild/bazel/pull/16665 lands