### PR TITLE
feat: install Aspect CLI for all users

### DIFF
--- a/.aspect/cli/plugins.yaml
+++ b/.aspect/cli/plugins.yaml
@@ -1,0 +1,6 @@
+- name: plugin-aspect-pro
+  from: https://static.aspect.build/aspect
+  version: 4.2.0
+- name: plugin-aspect-buildkite
+  from: https://static.aspect.build/aspect
+  version: 4.2.0

--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,0 +1,2 @@
+BAZELISK_BASE_URL=https://static.aspect.build/aspect
+USE_BAZEL_VERSION=aspect/4.2.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,6 +112,8 @@ jobs:
         # the //:bazel_version_test uses it and it needs to match the Bazel version being run
         run: |
           echo "${{ matrix.bazelversion }}" > .bazelversion
+          # Overwrite bazeliskrc if there is one, since it may have alternative BAZELISK_BASE_URL
+          echo "USE_BAZEL_VERSION=${{ matrix.bazelversion }}" > .bazeliskrc
           bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test --config=${{ matrix.config }} //...
         env:
           # Bazelisk will download bazel to here


### PR DESCRIPTION
Assuming you are using Bazelisk, this causes it to fetch Aspect's CLI and use that to wrap Bazel

Note, we might want to update Renovate someday to understand this file so users are more likely to stay on current versions.