### PR TITLE
chore: unrelease

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,7 +3,7 @@
 module(
     name = "aspect_bazel_lib",
     compatibility_level = 1,
-    version = "1.16.1",
+    version = "0.0.0",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.3.0")


### PR DESCRIPTION
Version no longer needed in the MODULE.bazel file thanks to @kormide's wizardry in the bzlmod bot