### PR TITLE
refactor: use rm -R instead -r as it is the primary option and lowercase -r is the alias

### DIFF
--- a/e2e/write_source_files.sh
+++ b/e2e/write_source_files.sh
@@ -26,6 +26,8 @@ function run_test {
 }
 
 # Run twice to make sure we can have permission to overwrite the outputs of a previous run
+rm -f lib/tests/write_source_files/dist.js
+rm -f lib/tests/write_source_files/dist_executable.js
 run_test
 run_test
 echo "All tests passed"

--- a/e2e/write_source_files_root.sh
+++ b/e2e/write_source_files_root.sh
@@ -15,6 +15,7 @@ function run_test {
 }
 
 # Run twice to make sure we can have permission to overwrite the outputs of a previous run
+rm -Rf test-out
 run_test
 run_test
 echo "All tests passed"

--- a/e2e/write_source_files_subdir.sh
+++ b/e2e/write_source_files_subdir.sh
@@ -26,8 +26,8 @@ function run_test {
 }
 
 # Run twice to make sure we can have permission to overwrite the outputs of a previous run
-rm -rf lib/tests/write_source_files/subdir_test
-rm -rf lib/tests/write_source_files/subdir_executable_test
+rm -Rf lib/tests/write_source_files/subdir_test
+rm -Rf lib/tests/write_source_files/subdir_executable_test
 run_test
 run_test
 echo "All tests passed"

--- a/e2e/write_source_files_symlinks.sh
+++ b/e2e/write_source_files_symlinks.sh
@@ -34,6 +34,8 @@ function run_test {
 }
 
 # Run twice to make sure we can have permission to overwrite the outputs of a previous run
+rm -f lib/tests/write_source_files/symlink_test/a/test.txt
+rm -f lib/tests/write_source_files/symlink_test/b/test.txt
 run_test
 run_test
 echo "All tests passed"

--- a/lib/private/copy_directory.bzl
+++ b/lib/private/copy_directory.bzl
@@ -47,7 +47,7 @@ def _copy_cmd(ctx, src, dst):
     )
 
 def _copy_bash(ctx, src, dst):
-    cmd = "rm -rf \"$2\" && cp -fR \"$1/\" \"$2\""
+    cmd = "rm -Rf \"$2\" && cp -fR \"$1/\" \"$2\""
     mnemonic = "CopyDirectory"
     progress_message = "Copying directory %s" % src.path
 


### PR DESCRIPTION
```
     -R      Attempt to remove the file hierarchy rooted in each file argument.  The -R option implies the -d option.  If the -i option is specified, the user is prompted
             for confirmation before each directory's contents are processed (as well as before the attempt is made to remove the directory).  If the user does not
             respond affirmatively, the file hierarchy rooted in that directory is skipped.

     -r      Equivalent to -R.
```