### PR TITLE
fix: fix a bug where transition tests required cpp toolchain on osx

### DIFF
--- a/lib/tests/transitions/BUILD.bazel
+++ b/lib/tests/transitions/BUILD.bazel
@@ -16,6 +16,7 @@ platform(
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
+        "@io_bazel_rules_go//go/toolchain:cgo_off",  # https://github.com/bazelbuild/rules_go/pull/3390
     ],
 )
 


### PR DESCRIPTION
Same bug fix as on the platform below this, but this surfaces on OSX and causes the build to fail. Last PR was only tested on Linux.