### PR TITLE
chore: switch copy_to_directory binary tool to use com_github_bmatcuk_doublestar_v4 instead of com_github_gobwas_glob

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -7,12 +7,13 @@ def go_dependencies():
     """The Go dependencies.
     """
     go_repository(
-        name = "com_github_gobwas_glob",
+        name = "com_github_bmatcuk_doublestar_v4",
         build_file_proto_mode = "disable_global",
-        importpath = "github.com/gobwas/glob",
-        sum = "h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=",
-        version = "v0.2.3",
+        importpath = "github.com/bmatcuk/doublestar/v4",
+        sum = "h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=",
+        version = "v4.6.0",
     )
+
     go_repository(
         name = "com_github_google_go_cmp",
         build_file_proto_mode = "disable_global",

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/aspect-build/bazel-lib
 go 1.19
 
 require (
-	github.com/gobwas/glob v0.2.3
+	github.com/bmatcuk/doublestar/v4 v4.6.0
 	golang.org/x/exp v0.0.0-20221230185412-738e83a70c30
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
-github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
+github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 golang.org/x/exp v0.0.0-20221230185412-738e83a70c30 h1:m9O6OTJ627iFnN2JIWfdqlZCzneRO6EEBsHXI25P8ws=
 golang.org/x/exp v0.0.0-20221230185412-738e83a70c30/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=

--- a/tools/copy_to_directory/BUILD.bazel
+++ b/tools/copy_to_directory/BUILD.bazel
@@ -20,7 +20,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = _GO_STAMP_X_DEFS,
     deps = [
-        "@com_github_gobwas_glob//:glob",
+        "@com_github_bmatcuk_doublestar_v4//:doublestar",
         "@org_golang_x_exp//maps",
     ],
 )


### PR DESCRIPTION
The former is better maintained and handles the `a` matching `a/**` case properly