### PR TITLE
Remove the use of realpath in tests

### DIFF
--- a/lib/tests/transitions/test_file_type_contains.sh
+++ b/lib/tests/transitions/test_file_type_contains.sh
@@ -6,4 +6,4 @@
 
 set -o errexit -o nounset -o pipefail
 
-file "$(realpath "$1")" | grep -q "$2"
+file "$1" | grep -q "$2"

--- a/lib/tests/transitions/test_file_type_contains.sh
+++ b/lib/tests/transitions/test_file_type_contains.sh
@@ -6,4 +6,4 @@
 
 set -o errexit -o nounset -o pipefail
 
-file "$1" | grep -q "$2"
+file --dereference "$1" | grep -q "$2"


### PR DESCRIPTION
The `//lib/tests/transitions` tests fail on macOS unless `coreutils` package is installed. Even if the `realpath` is not necessary in this particular case, we should avoid relying on optional packages in tests.