### PR TITLE
chore: update pre-bazel 6 work-around in utils to only apply for bazel versions < 6

### DIFF
--- a/lib/private/utils.bzl
+++ b/lib/private/utils.bzl
@@ -76,11 +76,8 @@ def _is_external_label(param):
     Returns:
         a bool
     """
-
-    # Seems like a bug in Bazel that the workspace_root for a label like
-    # @@//js/private/node-patches:fs.js is "external"
-    # See https://github.com/bazelbuild/bazel/issues/16528
-    if str(param).startswith("@@//"):
+    if not _is_bazel_6_or_greater() and str(param).startswith("@@//"):
+        # Work-around for https://github.com/bazelbuild/bazel/issues/16528
         return False
     return len(_to_label(param).workspace_root) > 0
 

--- a/lib/tests/utils_test.bzl
+++ b/lib/tests/utils_test.bzl
@@ -51,11 +51,12 @@ def _is_external_label_test_impl(ctx):
     asserts.false(env, utils.is_external_label("//some/label"))
     asserts.false(env, utils.is_external_label(Label("//some/label")))
     asserts.false(env, utils.is_external_label("@//some/label"))
-
-    # TODO(Bazel 6.0): enable this test when the @@ syntax is available
-    # asserts.false(env, utils.is_external_label("@@//some/label"))
     asserts.false(env, utils.is_external_label(Label("@aspect_bazel_lib//some/label")))
     asserts.false(env, ctx.attr.internal_with_workspace_as_string)
+
+    # the "@@" repository name syntax applies to Bazel 6 or greater
+    if utils.is_bazel_6_or_greater():
+        asserts.false(env, utils.is_external_label("@@//some/label"))
 
     # assert that labels and string that give a workspace return true
     asserts.true(env, utils.is_external_label(Label("@foo//some/label")))


### PR DESCRIPTION
Fix in Bazel here https://github.com/bazelbuild/bazel/commit/3f92232c17bf4aad51880c811c291ba4b5b42721 made it into Bazel 6.0.0 release