### PR TITLE
feat: add a module extension for http_archive

### DIFF
--- a/e2e/bzlmod/BUILD.bazel
+++ b/e2e/bzlmod/BUILD.bazel
@@ -39,3 +39,11 @@ diff_test(
     file1 = "case_no_sources",
     file2 = "expected",
 )
+
+# Exercise http module extension
+genrule(
+    name = "bazel_lib_readme",
+    srcs = ["@bazel_lib_srcs//:README.md"],
+    outs = ["bazel_lib_README.md"],
+    cmd = "cp $(execpath @bazel_lib_srcs//:README.md) $@",
+)

--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -12,3 +12,15 @@ local_path_override(
     module_name = "aspect_bazel_lib",
     path = "../..",
 )
+
+http = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "http")
+
+http.http_archive(
+    name = "bazel_lib_srcs",
+    build_file_content = """exports_files(["README.md"])""",
+    sha256 = "79623d656aa23ad3fd4692ab99786c613cd36e49f5566469ed97bc9b4c655f03",
+    strip_prefix = "bazel-lib-1.23.3",
+    urls = ["https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.23.3.tar.gz"],
+)
+
+use_repo(http, "bazel_lib_srcs")

--- a/lib/extensions.bzl
+++ b/lib/extensions.bzl
@@ -6,6 +6,7 @@ load(
     "register_jq_toolchains",
     "register_yq_toolchains",
 )
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def _toolchain_extension(_):
     register_yq_toolchains(register = False)
@@ -15,4 +16,48 @@ def _toolchain_extension(_):
 # TODO: some way for users to control repo name/version of the tools installed
 ext = module_extension(
     implementation = _toolchain_extension,
+)
+
+def _http_extension(mctx):
+    for mod in mctx.modules:
+        for attr in mod.tags.http_archive:
+            http_archive(
+                name = attr.name,
+                build_file_content = attr.build_file_content,
+                sha256 = attr.sha256,
+                strip_prefix = attr.strip_prefix,
+                urls = attr.urls,
+            )
+
+# Extension that can declare http repository rules, until there's a better way:
+# https://github.com/bazelbuild/bazel/issues/17141
+http = module_extension(
+    implementation = _http_extension,
+    tag_classes = {
+        "http_archive": tag_class(attrs = {
+            "name": attr.string(),
+            "url": attr.string(),
+            "urls": attr.string_list(),
+            "sha256": attr.string(),
+            "integrity": attr.string(),
+            "netrc": attr.string(),
+            "auth_patterns": attr.string_dict(),
+            "canonical_id": attr.string(),
+            "strip_prefix": attr.string(),
+            "add_prefix": attr.string(),
+            "type": attr.string(),
+            "patches": attr.label_list(),
+            "remote_patches": attr.string_dict(),
+            "remote_patch_strip": attr.int(),
+            "patch_tool": attr.string(),
+            "patch_args": attr.string_list(),
+            "patch_cmds": attr.string_list(),
+            "patch_cmds_win": attr.string_list(),
+            "build_file": attr.label(),
+            "build_file_content": attr.string(),
+            "workspace_file": attr.label(),
+            "workspace_file_content": attr.string(),
+        }),
+        # TODO: http_file and http_jar
+    },
 )


### PR DESCRIPTION
There is a rules_js e2e I want to convert to bzlmod that uses `http_archive` in the WORKSPACE file. I could just use a workspace file alongside a MODULE.bazel file, but I thought of doing this. Wdyt?

Related to https://github.com/bazelbuild/bazel/issues/17141.