### PR TITLE
fix: show directory being copied to in copy_to_directory progress message

### DIFF
--- a/lib/private/copy_common.bzl
+++ b/lib/private/copy_common.bzl
@@ -57,3 +57,15 @@ COPY_EXECUTION_REQUIREMENTS = {
     "no-sandbox": "1",
     "local": "1",
 }
+
+def progress_path(f):
+    """
+    Convert a file to an appropriate string to display in an action progress message.
+
+    Args:
+        f: a file to show as a path in a progress message
+
+    Returns:
+        The path formatted for use in a progress message
+    """
+    return f.short_path.removeprefix("../")

--- a/lib/private/copy_directory.bzl
+++ b/lib/private/copy_directory.bzl
@@ -4,7 +4,7 @@ This rule copies a directory to another location using Bash (on Linux/macOS) or
 cmd.exe (on Windows).
 """
 
-load(":copy_common.bzl", _COPY_EXECUTION_REQUIREMENTS = "COPY_EXECUTION_REQUIREMENTS")
+load(":copy_common.bzl", _COPY_EXECUTION_REQUIREMENTS = "COPY_EXECUTION_REQUIREMENTS", _progress_path = "progress_path")
 load(":platform_utils.bzl", _platform_utils = "platform_utils")
 
 def _copy_cmd(ctx, src, dst):
@@ -22,7 +22,7 @@ def _copy_cmd(ctx, src, dst):
     # NB: robocopy return non-zero exit codes on success so we must exit 0 after calling it
     cmd_tmpl = "@robocopy \"{src}\" \"{dst}\" /E >NUL & @exit 0"
     mnemonic = "CopyDirectory"
-    progress_message = "Copying directory %{input}"
+    progress_message = "Copying directory %s" % _progress_path(src)
 
     ctx.actions.write(
         output = bat,
@@ -49,7 +49,7 @@ def _copy_cmd(ctx, src, dst):
 def _copy_bash(ctx, src, dst):
     cmd = "rm -Rf \"$2\" && cp -fR \"$1/\" \"$2\""
     mnemonic = "CopyDirectory"
-    progress_message = "Copying directory %{input}"
+    progress_message = "Copying directory %s" % _progress_path(src)
 
     ctx.actions.run_shell(
         tools = [src],
@@ -145,7 +145,7 @@ def copy_directory_bin_action(
         executable = copy_directory_bin,
         arguments = args,
         mnemonic = "CopyDirectory",
-        progress_message = "Copying directory %{input}",
+        progress_message = "Copying directory %s" % _progress_path(src),
         execution_requirements = _COPY_EXECUTION_REQUIREMENTS,
     )
 

--- a/lib/private/copy_file.bzl
+++ b/lib/private/copy_file.bzl
@@ -24,7 +24,7 @@ cmd.exe (on Windows). `_copy_xfile` marks the resulting file executable,
 `_copy_file` does not.
 """
 
-load(":copy_common.bzl", _COPY_EXECUTION_REQUIREMENTS = "COPY_EXECUTION_REQUIREMENTS")
+load(":copy_common.bzl", _COPY_EXECUTION_REQUIREMENTS = "COPY_EXECUTION_REQUIREMENTS", _progress_path = "progress_path")
 load(":directory_path.bzl", "DirectoryPathInfo")
 load(":platform_utils.bzl", _platform_utils = "platform_utils")
 
@@ -44,7 +44,7 @@ def _copy_cmd(ctx, src, src_path, dst):
     # https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/copy
     cmd_tmpl = "@copy /Y \"{src}\" \"{dst}\" >NUL"
     mnemonic = "CopyFile"
-    progress_message = "Copying file %{input}"
+    progress_message = "Copying file %s" % _progress_path(src)
 
     ctx.actions.write(
         output = bat,
@@ -71,7 +71,7 @@ def _copy_cmd(ctx, src, src_path, dst):
 def _copy_bash(ctx, src, src_path, dst):
     cmd_tmpl = "cp -f \"$1\" \"$2\""
     mnemonic = "CopyFile"
-    progress_message = "Copying file %{input}"
+    progress_message = "Copying file %s" % _progress_path(src)
 
     ctx.actions.run_shell(
         tools = [src],

--- a/lib/private/copy_to_directory.bzl
+++ b/lib/private/copy_to_directory.bzl
@@ -1,7 +1,7 @@
 "copy_to_directory implementation"
 
 load("@bazel_skylib//lib:paths.bzl", skylib_paths = "paths")
-load(":copy_common.bzl", _COPY_EXECUTION_REQUIREMENTS = "COPY_EXECUTION_REQUIREMENTS")
+load(":copy_common.bzl", _COPY_EXECUTION_REQUIREMENTS = "COPY_EXECUTION_REQUIREMENTS", _progress_path = "progress_path")
 load(":paths.bzl", "paths")
 load(":directory_path.bzl", "DirectoryPathInfo")
 load(":glob_match.bzl", "glob_match", "is_glob")
@@ -518,7 +518,7 @@ fi
         outputs = [dst_dir],
         command = "\n".join(cmds),
         mnemonic = "CopyToDirectory",
-        progress_message = "Copying files to directory",
+        progress_message = "Copying files to directory %s" % _progress_path(dst_dir),
         use_default_shell_env = True,
         execution_requirements = _COPY_EXECUTION_REQUIREMENTS,
     )
@@ -586,7 +586,7 @@ if exist "{src}\\*" (
         executable = "cmd.exe",
         arguments = ["/C", bat.path.replace("/", "\\")],
         mnemonic = "CopyToDirectory",
-        progress_message = "Copying files to directory",
+        progress_message = "Copying files to directory %s" % _progress_path(dst_dir),
         use_default_shell_env = True,
         execution_requirements = _COPY_EXECUTION_REQUIREMENTS,
     )
@@ -838,7 +838,7 @@ def copy_to_directory_bin_action(
         executable = copy_to_directory_bin,
         arguments = [config_file.path],
         mnemonic = "CopyToDirectory",
-        progress_message = "Copying files to directory",
+        progress_message = "Copying files to directory %s" % _progress_path(dst),
         execution_requirements = _COPY_EXECUTION_REQUIREMENTS,
     )
 


### PR DESCRIPTION
I found this useful when I saw a lot of the messages and they were all the exact same. Now it shows things such as:
```
Copying files to directory client/shared/shared
```
(the BUILD is in 'client/shared', with an `npm_package` named 'shared')

Note the use of `short_path` instead of `%{output}` so it doesn't show `bazel-lib/darwin .../` at the start. The second commit changes the copy_file/directory to also use `short_path` for that reason.

Unlike copy_file/directory this PR makes copy_to_directory show the destination, not the source of the copied files because there might be many. We could show the target name, either instead of or in addition to the destination, but I figured the destination is decent?