### PR TITLE
copy: limit the number of go routines

### DIFF
--- a/tools/common/copy.go
+++ b/tools/common/copy.go
@@ -9,8 +9,14 @@ import (
 	"sync"
 )
 
+var MaxCopies = 1000
+var limiter = make(chan bool, MaxCopies)
+
 // From https://opensource.com/article/18/6/copying-files-go
 func CopyFile(src string, dst string) error {
+	limiter <- true
+	defer func() { <-limiter }()
+
 	source, err := os.Open(src)
 	if err != nil {
 		return err


### PR DESCRIPTION
@f0rmiga were you thinking similar?

I don't think it's worth getting too complicated, at least for now.

I assume by the time the number of concurrent copies reaches this number the OS/IO operations will far outweigh the go routines, so no point spawning more io operations just to make that worse?