### PR TITLE
fix: limit copy concurrency

### DIFF
--- a/tools/common/copy.go
+++ b/tools/common/copy.go
@@ -26,38 +26,61 @@ func CopyFile(src string, dst string) error {
 	return err
 }
 
-func Copy(src string, dst string, info fs.FileInfo, link bool, verbose bool, wg *sync.WaitGroup) {
-	if wg != nil {
-		defer wg.Done()
+func Copy(opts CopyOpts) {
+	if !opts.info.Mode().IsRegular() {
+		log.Fatalf("%s is not a regular file", opts.src)
 	}
-	if !info.Mode().IsRegular() {
-		log.Fatalf("%s is not a regular file", src)
-	}
-	if link {
+	if opts.hardlink {
 		// hardlink this file
-		if verbose {
-			fmt.Printf("hardlink %v => %v\n", src, dst)
+		if opts.verbose {
+			fmt.Printf("hardlink %v => %v\n", opts.src, opts.dst)
 		}
-		err := os.Link(src, dst)
+		err := os.Link(opts.src, opts.dst)
 		if err != nil {
 			// fallback to copy
-			if verbose {
+			if opts.verbose {
 				fmt.Printf("hardlink failed: %v\n", err)
-				fmt.Printf("copy (fallback) %v => %v\n", src, dst)
+				fmt.Printf("copy (fallback) %v => %v\n", opts.src, opts.dst)
 			}
-			err = CopyFile(src, dst)
+			err = CopyFile(opts.src, opts.dst)
 			if err != nil {
 				log.Fatal(err)
 			}
 		}
 	} else {
 		// copy this file
-		if verbose {
-			fmt.Printf("copy %v => %v\n", src, dst)
+		if opts.verbose {
+			fmt.Printf("copy %v => %v\n", opts.src, opts.dst)
 		}
-		err := CopyFile(src, dst)
+		err := CopyFile(opts.src, opts.dst)
 		if err != nil {
 			log.Fatal(err)
 		}
 	}
+}
+
+type CopyWorker struct {
+	queue <-chan CopyOpts
+}
+
+func NewCopyWorker(queue <-chan CopyOpts) *CopyWorker {
+	return &CopyWorker{queue: queue}
+}
+
+func (w *CopyWorker) Run(wg *sync.WaitGroup) {
+	defer wg.Done()
+	for opts := range w.queue {
+		Copy(opts)
+	}
+}
+
+type CopyOpts struct {
+	src, dst string
+	info     fs.FileInfo
+	hardlink bool
+	verbose  bool
+}
+
+func NewCopyOpts(src string, dst string, info fs.FileInfo, hardlink bool, verbose bool) CopyOpts {
+	return CopyOpts{src: src, dst: dst, info: info, hardlink: hardlink, verbose: verbose}
 }


### PR DESCRIPTION
On very large directories, the copy functions were creating unbound concurrent copies, which could reach OS limits quickly or even exhaust hardware resources. This patch solves this issue by implementing a queue and a worker pattern.