### PR TITLE
Fix Realpath relying on path.IsAbs which does not work on windows

### DIFF
--- a/tools/common/file.go
+++ b/tools/common/file.go
@@ -26,7 +26,7 @@ func Realpath(p string) (string, error) {
 		return "", fmt.Errorf("readlink %s failed: %w", p, err)
 	}
 
-	if !path.IsAbs(t) {
+	if !filepath.IsAbs(t) {
 		t = path.Join(path.Dir(p), t)
 	}
 


### PR DESCRIPTION
On windows, I was receiving this error from rules_js from my build (I think using the npm_package rule):

```
2023/02/07 11:01:59 lstat bazel-out/x64_windows-fastbuild/bin/packages/wnd-shared-react-config/node_modules/@babel/plugin-proposal-object-rest-spread failed: CreateFile bazel-out/x64_windows-fastbuild/bin/packages/wnd-shared-react-config/node_modules/@babel/C:\tmp\hlntwacp\execroot\_main\bazel-out\x64_windows-fastbuild\bin\node_modules\.aspect_rules_js\@babel+plugin-proposal-object-rest-spread@7.17.3_@babel+core@7.20.12\node_modules\@babel\plugin-proposal-object-rest-spread: The filename, directory name, or volume label syntax is incorrect.
```

Turns out that `path.IsAbs` does not work on Windows, but `filepath.IsAbs` does so it was incorrectly determining absolute paths as relative and joining them to a directory and making strange, incorrect paths. 

I made the change here locally and my build succeeded. I'm a go noob, so let me know if there's anything else I need to do for this to get in. 