### PR TITLE
fix: incorrect 'find -type' argument used on MacOS

### DIFF
--- a/lib/private/write_source_file.bzl
+++ b/lib/private/write_source_file.bzl
@@ -196,7 +196,7 @@ fi"""]
         executable_file = "chmod -x \"$out\""
         if is_macos:
             # -x+X doesn't work on macos so we have to find files and remove the execute bits only from those
-            executable_dir = "find \"$out\" -type file | xargs chmod -x"
+            executable_dir = "find \"$out\" -type f | xargs chmod -x"
         else:
             # Remove execute/search bit recursively from files bit not directories: https://superuser.com/a/434418
             executable_dir = "chmod -R -x+X \"$out\"/*"


### PR DESCRIPTION
Within `write_source_file()`, an incorrect `find` argument is being used on MacOS to iterate over the copied files. Instead of `find -type f`, it is using `find -type file`, which produces an error:
```
find: Must separate multiple arguments to -type using: ','
```
