### PR TITLE
fix: remove --experimental_guard_against_concurrent_changes from recommended correctness settings

### DIFF
--- a/.aspect/bazelrc/ci.bazelrc
+++ b/.aspect/bazelrc/ci.bazelrc
@@ -33,11 +33,11 @@ build --show_timestamps
 # https://bazel.build/reference/command-line-reference#flag--show_progress_rate_limit
 build --show_progress_rate_limit=5
 
-# Don't use cursor controls in its screen output.
+# Use cursor controls in screen output.
 # Docs: https://bazel.build/docs/user-manual#curses
 build --curses=yes
 
-# Use colors to highlight its output on the screen. Set to `no` if your CI does not display colors.
+# Use colors to highlight output on the screen. Set to `no` if your CI does not display colors.
 # Docs: https://bazel.build/docs/user-manual#color
 build --color=yes
 

--- a/.aspect/bazelrc/correctness.bazelrc
+++ b/.aspect/bazelrc/correctness.bazelrc
@@ -54,11 +54,6 @@ build --experimental_allow_tags_propagation
 fetch --experimental_allow_tags_propagation
 query --experimental_allow_tags_propagation
 
-# Checking the ctime of input files of an action before uploading it to a remote cache. Prevents
-# concurrent local file modification from poisoning the build cache.
-# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_guard_against_concurrent_changes
-build --experimental_guard_against_concurrent_changes
-
 # Do not automatically create `__init__.py` files in the runfiles of Python targets. Fixes the wrong
 # default that comes from Google's internal monorepo by using `__init__.py` to delimit a Python
 # package. Precisely, when a `py_binary` or `py_test` target has `legacy_create_init` set to `auto (the

--- a/e2e/bzlmod/.aspect/bazelrc/correctness.bazelrc
+++ b/e2e/bzlmod/.aspect/bazelrc/correctness.bazelrc
@@ -54,11 +54,6 @@ build --experimental_allow_tags_propagation
 fetch --experimental_allow_tags_propagation
 query --experimental_allow_tags_propagation
 
-# Checking the ctime of input files of an action before uploading it to a remote cache. Prevents
-# concurrent local file modification from poisoning the build cache.
-# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_guard_against_concurrent_changes
-build --experimental_guard_against_concurrent_changes
-
 # Do not automatically create `__init__.py` files in the runfiles of Python targets. Fixes the wrong
 # default that comes from Google's internal monorepo by using `__init__.py` to delimit a Python
 # package. Precisely, when a `py_binary` or `py_test` target has `legacy_create_init` set to `auto (the

--- a/e2e/bzlmod_write_source_files_external/.aspect/bazelrc/correctness.bazelrc
+++ b/e2e/bzlmod_write_source_files_external/.aspect/bazelrc/correctness.bazelrc
@@ -54,11 +54,6 @@ build --experimental_allow_tags_propagation
 fetch --experimental_allow_tags_propagation
 query --experimental_allow_tags_propagation
 
-# Checking the ctime of input files of an action before uploading it to a remote cache. Prevents
-# concurrent local file modification from poisoning the build cache.
-# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_guard_against_concurrent_changes
-build --experimental_guard_against_concurrent_changes
-
 # Do not automatically create `__init__.py` files in the runfiles of Python targets. Fixes the wrong
 # default that comes from Google's internal monorepo by using `__init__.py` to delimit a Python
 # package. Precisely, when a `py_binary` or `py_test` target has `legacy_create_init` set to `auto (the

--- a/e2e/copy_to_directory/.aspect/bazelrc/correctness.bazelrc
+++ b/e2e/copy_to_directory/.aspect/bazelrc/correctness.bazelrc
@@ -54,11 +54,6 @@ build --experimental_allow_tags_propagation
 fetch --experimental_allow_tags_propagation
 query --experimental_allow_tags_propagation
 
-# Checking the ctime of input files of an action before uploading it to a remote cache. Prevents
-# concurrent local file modification from poisoning the build cache.
-# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_guard_against_concurrent_changes
-build --experimental_guard_against_concurrent_changes
-
 # Do not automatically create `__init__.py` files in the runfiles of Python targets. Fixes the wrong
 # default that comes from Google's internal monorepo by using `__init__.py` to delimit a Python
 # package. Precisely, when a `py_binary` or `py_test` target has `legacy_create_init` set to `auto (the

--- a/e2e/workspace/.aspect/bazelrc/correctness.bazelrc
+++ b/e2e/workspace/.aspect/bazelrc/correctness.bazelrc
@@ -54,11 +54,6 @@ build --experimental_allow_tags_propagation
 fetch --experimental_allow_tags_propagation
 query --experimental_allow_tags_propagation
 
-# Checking the ctime of input files of an action before uploading it to a remote cache. Prevents
-# concurrent local file modification from poisoning the build cache.
-# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_guard_against_concurrent_changes
-build --experimental_guard_against_concurrent_changes
-
 # Do not automatically create `__init__.py` files in the runfiles of Python targets. Fixes the wrong
 # default that comes from Google's internal monorepo by using `__init__.py` to delimit a Python
 # package. Precisely, when a `py_binary` or `py_test` target has `legacy_create_init` set to `auto (the

--- a/lib/tests/bazelrc_presets/all/ci.bazelrc
+++ b/lib/tests/bazelrc_presets/all/ci.bazelrc
@@ -33,11 +33,11 @@ build --show_timestamps
 # https://bazel.build/reference/command-line-reference#flag--show_progress_rate_limit
 build --show_progress_rate_limit=5
 
-# Don't use cursor controls in its screen output.
+# Use cursor controls in screen output.
 # Docs: https://bazel.build/docs/user-manual#curses
 build --curses=yes
 
-# Use colors to highlight its output on the screen. Set to `no` if your CI does not display colors.
+# Use colors to highlight output on the screen. Set to `no` if your CI does not display colors.
 # Docs: https://bazel.build/docs/user-manual#color
 build --color=yes
 

--- a/lib/tests/bazelrc_presets/all/correctness.bazelrc
+++ b/lib/tests/bazelrc_presets/all/correctness.bazelrc
@@ -54,11 +54,6 @@ build --experimental_allow_tags_propagation
 fetch --experimental_allow_tags_propagation
 query --experimental_allow_tags_propagation
 
-# Checking the ctime of input files of an action before uploading it to a remote cache. Prevents
-# concurrent local file modification from poisoning the build cache.
-# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_guard_against_concurrent_changes
-build --experimental_guard_against_concurrent_changes
-
 # Do not automatically create `__init__.py` files in the runfiles of Python targets. Fixes the wrong
 # default that comes from Google's internal monorepo by using `__init__.py` to delimit a Python
 # package. Precisely, when a `py_binary` or `py_test` target has `legacy_create_init` set to `auto (the


### PR DESCRIPTION
We have observed that this settings leads to WARNINGS in npm package directory artifacts in the symlinked node_modules output tree created by rules_js for some npm packages.

For example,

```
WARNING: /private/tmp/f2/execroot/__main__/bazel-out/darwin-fastbuild/bin/node_modules/.aspect_rules_js/anymatch@3.1.3/node_modules/anymatch/LICENSE was modified during execution
WARNING: /private/tmp/f2/execroot/__main__/bazel-out/darwin-fastbuild/bin/node_modules/.aspect_rules_js/@ampproject+remapping@2.1.2/node_modules/@ampproject/remapping/LICENSE was modified during execution
WARNING: /private/tmp/f2/execroot/__main__/bazel-out/darwin-fastbuild/bin/node_modules/.aspect_rules_js/@esbuild+darwin-x64@0.17.8/node_modules/@esbuild/darwin-x64/bin/esbuild was modified during execution
WARNING: /private/tmp/f2/execroot/__main__/bazel-out/darwin-fastbuild/bin/node_modules/.aspect_rules_js/@apidevtools+json-schema-ref-parser@9.0.6/node_modules/@apidevtools/json-schema-ref-parser/CHANGELOG.md was modified during execution
WARNING: /private/tmp/f2/execroot/__main__/bazel-out/darwin-fastbuild/bin/node_modules/.aspect_rules_js/@cspotcode+source-map-support@0.8.1/node_modules/@cspotcode/source-[17[17,284 / 17,383] 26 actions running
    Compiling client/shared:shared_lib; 25s remote-cache, darwin-sandbox
WARNING: /private/tmp/f2/execroot/__main__/bazel-out/darwin-fastbuild/bin/node_modules/.aspect_rules_js/ansi-regex@2.1.1/node_modules/ansi-regex/aspect_rules_js_metadata.json was modified during execution
WARNING: /private/tmp/f2/execroot/__main__/bazel-out/darwin-fastbuild/bin/node_modules/.aspect_rules_js/@babel+runtime@7.20.6/node_modules/@babel/runtime/LICENSE was modified during execution
WARNING: /private/tmp/f2/execroot/__main__/bazel-out/darwin-fastbuild/bin/node_modules/.aspect_rules_js/@reach+auto-id@0.16.0_ef5jwxihqo6n7gxfmzogljlgcm/node_modules/@reach/utils was modified during execution
WARNING: /private/tmp/f2/execroot/__main__/bazel-out/darwin-fastbuild/bin/node_modules/.aspect_rules_js/@types+node@18.11.18/node_modules/@types/node/LICENSE was modified during execution
```

When this happens, it appears to make all downstream actions of that tree artifact the WARNING is for be cache misses.

Possibly related to https://github.com/bazelbuild/bazel/issues/5566