### PR TITLE
Presets cleanup

### DIFF
--- a/.aspect/bazelrc/convenience.bazelrc
+++ b/.aspect/bazelrc/convenience.bazelrc
@@ -1,7 +1,6 @@
 # Attempt to build & test every target whose prerequisites were successfully built.
 # Docs: https://bazel.build/docs/user-manual#keep-going
 build --keep_going
-test  --keep_going
 
 # Output test errors to stderr so users don't have to `cat` or open test failure log files when test
 # fail. This makes the log noiser in exchange for reducing the time-to-feedback on test failures for

--- a/.aspect/bazelrc/correctness.bazelrc
+++ b/.aspect/bazelrc/correctness.bazelrc
@@ -11,7 +11,6 @@ build --noremote_upload_local_results
 # Developers should tag targets with `tags=["requires-network"]` to opt-out of the enforcement.
 # Docs: https://bazel.build/reference/command-line-reference#flag--sandbox_default_allow_network
 build --sandbox_default_allow_network=false
-test --sandbox_default_allow_network=false
 
 # Warn if a test's timeout is significantly longer than the test's actual execution time.
 # Bazel's default for test_timeout is medium (5 min), but most tests should instead be short (1 min).

--- a/.aspect/bazelrc/performance.bazelrc
+++ b/.aspect/bazelrc/performance.bazelrc
@@ -41,8 +41,6 @@ build --experimental_reuse_sandbox_directories
 # author.
 # Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
 build --nolegacy_external_runfiles
-run --nolegacy_external_runfiles
-test --nolegacy_external_runfiles
 
 # Some actions are always IO-intensive but require little compute. It's wasteful to put the output
 # in the remote cache, it just saturates the network and fills the cache storage causing earlier

--- a/e2e/bzlmod/.aspect/bazelrc/convenience.bazelrc
+++ b/e2e/bzlmod/.aspect/bazelrc/convenience.bazelrc
@@ -1,7 +1,6 @@
 # Attempt to build & test every target whose prerequisites were successfully built.
 # Docs: https://bazel.build/docs/user-manual#keep-going
 build --keep_going
-test  --keep_going
 
 # Output test errors to stderr so users don't have to `cat` or open test failure log files when test
 # fail. This makes the log noiser in exchange for reducing the time-to-feedback on test failures for

--- a/e2e/bzlmod/.aspect/bazelrc/correctness.bazelrc
+++ b/e2e/bzlmod/.aspect/bazelrc/correctness.bazelrc
@@ -11,7 +11,6 @@ build --noremote_upload_local_results
 # Developers should tag targets with `tags=["requires-network"]` to opt-out of the enforcement.
 # Docs: https://bazel.build/reference/command-line-reference#flag--sandbox_default_allow_network
 build --sandbox_default_allow_network=false
-test --sandbox_default_allow_network=false
 
 # Warn if a test's timeout is significantly longer than the test's actual execution time.
 # Bazel's default for test_timeout is medium (5 min), but most tests should instead be short (1 min).

--- a/e2e/bzlmod/.aspect/bazelrc/performance.bazelrc
+++ b/e2e/bzlmod/.aspect/bazelrc/performance.bazelrc
@@ -41,8 +41,6 @@ build --experimental_reuse_sandbox_directories
 # author.
 # Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
 build --nolegacy_external_runfiles
-run --nolegacy_external_runfiles
-test --nolegacy_external_runfiles
 
 # Some actions are always IO-intensive but require little compute. It's wasteful to put the output
 # in the remote cache, it just saturates the network and fills the cache storage causing earlier

--- a/e2e/bzlmod_write_source_files_external/.aspect/bazelrc/convenience.bazelrc
+++ b/e2e/bzlmod_write_source_files_external/.aspect/bazelrc/convenience.bazelrc
@@ -1,7 +1,6 @@
 # Attempt to build & test every target whose prerequisites were successfully built.
 # Docs: https://bazel.build/docs/user-manual#keep-going
 build --keep_going
-test  --keep_going
 
 # Output test errors to stderr so users don't have to `cat` or open test failure log files when test
 # fail. This makes the log noiser in exchange for reducing the time-to-feedback on test failures for

--- a/e2e/bzlmod_write_source_files_external/.aspect/bazelrc/correctness.bazelrc
+++ b/e2e/bzlmod_write_source_files_external/.aspect/bazelrc/correctness.bazelrc
@@ -11,7 +11,6 @@ build --noremote_upload_local_results
 # Developers should tag targets with `tags=["requires-network"]` to opt-out of the enforcement.
 # Docs: https://bazel.build/reference/command-line-reference#flag--sandbox_default_allow_network
 build --sandbox_default_allow_network=false
-test --sandbox_default_allow_network=false
 
 # Warn if a test's timeout is significantly longer than the test's actual execution time.
 # Bazel's default for test_timeout is medium (5 min), but most tests should instead be short (1 min).

--- a/e2e/bzlmod_write_source_files_external/.aspect/bazelrc/performance.bazelrc
+++ b/e2e/bzlmod_write_source_files_external/.aspect/bazelrc/performance.bazelrc
@@ -41,8 +41,6 @@ build --experimental_reuse_sandbox_directories
 # author.
 # Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
 build --nolegacy_external_runfiles
-run --nolegacy_external_runfiles
-test --nolegacy_external_runfiles
 
 # Some actions are always IO-intensive but require little compute. It's wasteful to put the output
 # in the remote cache, it just saturates the network and fills the cache storage causing earlier

--- a/e2e/copy_to_directory/.aspect/bazelrc/convenience.bazelrc
+++ b/e2e/copy_to_directory/.aspect/bazelrc/convenience.bazelrc
@@ -1,7 +1,6 @@
 # Attempt to build & test every target whose prerequisites were successfully built.
 # Docs: https://bazel.build/docs/user-manual#keep-going
 build --keep_going
-test  --keep_going
 
 # Output test errors to stderr so users don't have to `cat` or open test failure log files when test
 # fail. This makes the log noiser in exchange for reducing the time-to-feedback on test failures for

--- a/e2e/copy_to_directory/.aspect/bazelrc/correctness.bazelrc
+++ b/e2e/copy_to_directory/.aspect/bazelrc/correctness.bazelrc
@@ -11,7 +11,6 @@ build --noremote_upload_local_results
 # Developers should tag targets with `tags=["requires-network"]` to opt-out of the enforcement.
 # Docs: https://bazel.build/reference/command-line-reference#flag--sandbox_default_allow_network
 build --sandbox_default_allow_network=false
-test --sandbox_default_allow_network=false
 
 # Warn if a test's timeout is significantly longer than the test's actual execution time.
 # Bazel's default for test_timeout is medium (5 min), but most tests should instead be short (1 min).

--- a/e2e/copy_to_directory/.aspect/bazelrc/performance.bazelrc
+++ b/e2e/copy_to_directory/.aspect/bazelrc/performance.bazelrc
@@ -41,8 +41,6 @@ build --experimental_reuse_sandbox_directories
 # author.
 # Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
 build --nolegacy_external_runfiles
-run --nolegacy_external_runfiles
-test --nolegacy_external_runfiles
 
 # Some actions are always IO-intensive but require little compute. It's wasteful to put the output
 # in the remote cache, it just saturates the network and fills the cache storage causing earlier

--- a/e2e/workspace/.aspect/bazelrc/convenience.bazelrc
+++ b/e2e/workspace/.aspect/bazelrc/convenience.bazelrc
@@ -1,7 +1,6 @@
 # Attempt to build & test every target whose prerequisites were successfully built.
 # Docs: https://bazel.build/docs/user-manual#keep-going
 build --keep_going
-test  --keep_going
 
 # Output test errors to stderr so users don't have to `cat` or open test failure log files when test
 # fail. This makes the log noiser in exchange for reducing the time-to-feedback on test failures for

--- a/e2e/workspace/.aspect/bazelrc/correctness.bazelrc
+++ b/e2e/workspace/.aspect/bazelrc/correctness.bazelrc
@@ -11,7 +11,6 @@ build --noremote_upload_local_results
 # Developers should tag targets with `tags=["requires-network"]` to opt-out of the enforcement.
 # Docs: https://bazel.build/reference/command-line-reference#flag--sandbox_default_allow_network
 build --sandbox_default_allow_network=false
-test --sandbox_default_allow_network=false
 
 # Warn if a test's timeout is significantly longer than the test's actual execution time.
 # Bazel's default for test_timeout is medium (5 min), but most tests should instead be short (1 min).

--- a/e2e/workspace/.aspect/bazelrc/performance.bazelrc
+++ b/e2e/workspace/.aspect/bazelrc/performance.bazelrc
@@ -41,8 +41,6 @@ build --experimental_reuse_sandbox_directories
 # author.
 # Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
 build --nolegacy_external_runfiles
-run --nolegacy_external_runfiles
-test --nolegacy_external_runfiles
 
 # Some actions are always IO-intensive but require little compute. It's wasteful to put the output
 # in the remote cache, it just saturates the network and fills the cache storage causing earlier

--- a/lib/tests/bazelrc_presets/all/convenience.bazelrc
+++ b/lib/tests/bazelrc_presets/all/convenience.bazelrc
@@ -1,7 +1,6 @@
 # Attempt to build & test every target whose prerequisites were successfully built.
 # Docs: https://bazel.build/docs/user-manual#keep-going
 build --keep_going
-test  --keep_going
 
 # Output test errors to stderr so users don't have to `cat` or open test failure log files when test
 # fail. This makes the log noiser in exchange for reducing the time-to-feedback on test failures for

--- a/lib/tests/bazelrc_presets/all/correctness.bazelrc
+++ b/lib/tests/bazelrc_presets/all/correctness.bazelrc
@@ -11,7 +11,6 @@ build --noremote_upload_local_results
 # Developers should tag targets with `tags=["requires-network"]` to opt-out of the enforcement.
 # Docs: https://bazel.build/reference/command-line-reference#flag--sandbox_default_allow_network
 build --sandbox_default_allow_network=false
-test --sandbox_default_allow_network=false
 
 # Warn if a test's timeout is significantly longer than the test's actual execution time.
 # Bazel's default for test_timeout is medium (5 min), but most tests should instead be short (1 min).

--- a/lib/tests/bazelrc_presets/all/performance.bazelrc
+++ b/lib/tests/bazelrc_presets/all/performance.bazelrc
@@ -41,8 +41,6 @@ build --experimental_reuse_sandbox_directories
 # author.
 # Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
 build --nolegacy_external_runfiles
-run --nolegacy_external_runfiles
-test --nolegacy_external_runfiles
 
 # Some actions are always IO-intensive but require little compute. It's wasteful to put the output
 # in the remote cache, it just saturates the network and fills the cache storage causing earlier


### PR DESCRIPTION
From https://bazel.build/run/bazelrc#option-defaults

"""
The inheritance (specificity) graph is:
- Every command inherits from common
- The following commands inherit from (and are more specific than) build: test, run, clean, mobile-install, info, print_action, config, cquery, and aquery
- coverage inherits from test
"""
