### PR TITLE
feat: add consistent_label_str utility to generate consistent label strings for all Bazel versions

### DIFF
--- a/docs/utils.md
+++ b/docs/utils.md
@@ -2,6 +2,38 @@
 
 Public API
 
+<a id="consistent_label_str"></a>
+
+## consistent_label_str
+
+<pre>
+consistent_label_str(<a href="#consistent_label_str-ctx">ctx</a>, <a href="#consistent_label_str-label">label</a>)
+</pre>
+
+Generate a consistent label string for all Bazel versions.
+
+Starting in Bazel 6, the workspace name is empty for the local workspace and there's no other
+way to determine it. This behavior differs from Bazel 5 where the local workspace name was fully
+qualified in str(label).
+
+This utility function is meant for use in rules and requires the rule context to determine the
+user's workspace name (`ctx.workspace_name`).
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="consistent_label_str-ctx"></a>ctx |  The rule context.   |  none |
+| <a id="consistent_label_str-label"></a>label |  A Label.   |  none |
+
+**RETURNS**
+
+String representation of the label including the repository name if the label is from an
+  external repository. For labels in the user's repository the label will start with `@//`.
+
+
 <a id="default_timeout"></a>
 
 ## default_timeout

--- a/lib/private/utils.bzl
+++ b/lib/private/utils.bzl
@@ -67,6 +67,30 @@ def _to_label(param):
         msg = "Expected 'string' or 'Label' but got '{}'".format(param_type)
         fail(msg)
 
+def _consistent_label_str(ctx, label):
+    """Generate a consistent label string for all Bazel versions.
+
+    Starting in Bazel 6, the workspace name is empty for the local workspace and there's no other
+    way to determine it. This behavior differs from Bazel 5 where the local workspace name was fully
+    qualified in str(label).
+
+    This utility function is meant for use in rules and requires the rule context to determine the
+    user's workspace name (`ctx.workspace_name`).
+
+    Args:
+        ctx: The rule context.
+        label: A Label.
+
+    Returns:
+        String representation of the label including the repository name if the label is from an
+        external repository. For labels in the user's repository the label will start with `@//`.
+    """
+    return "@{}//{}:{}".format(
+        "" if label.workspace_name == ctx.workspace_name else label.workspace_name,
+        label.package,
+        label.name,
+    )
+
 def _is_external_label(param):
     """Returns True if the given Label (or stringy version of a label) represents a target outside of the workspace
 
@@ -226,4 +250,5 @@ utils = struct(
     path_to_workspace_root = _path_to_workspace_root,
     propagate_well_known_tags = _propagate_well_known_tags,
     to_label = _to_label,
+    consistent_label_str = _consistent_label_str,
 )

--- a/lib/tests/utils_test.bzl
+++ b/lib/tests/utils_test.bzl
@@ -71,6 +71,16 @@ def _propagate_well_known_tags_test_impl(ctx):
 
     return unittest.end(env)
 
+def _consistent_label_str_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, "@//foo:bar", utils.consistent_label_str(ctx, Label("//foo:bar")))
+    asserts.equals(env, "@//foo:bar", utils.consistent_label_str(ctx, Label("@//foo:bar")))
+    asserts.equals(env, "@//foo:bar", utils.consistent_label_str(ctx, Label("@aspect_bazel_lib//foo:bar")))
+    asserts.equals(env, "@external_workspace//foo:bar", utils.consistent_label_str(ctx, Label("@external_workspace//foo:bar")))
+
+    return unittest.end(env)
+
 to_label_test = unittest.make(
     _to_label_test_impl,
     attrs = {
@@ -93,9 +103,8 @@ is_external_label_test = unittest.make(
     },
 )
 
-propagate_well_known_tags_test = unittest.make(
-    _propagate_well_known_tags_test_impl,
-)
+propagate_well_known_tags_test = unittest.make(_propagate_well_known_tags_test_impl)
+consistent_label_str_test = unittest.make(_consistent_label_str_impl)
 
 # buildifier: disable=function-docstring
 def file_exists_test():
@@ -122,6 +131,11 @@ def utils_test_suite():
 
     propagate_well_known_tags_test(
         name = "propagate_well_known_tags_tests",
+        timeout = "short",
+    )
+
+    consistent_label_str_test(
+        name = "consistent_label_str_tests",
         timeout = "short",
     )
 

--- a/lib/utils.bzl
+++ b/lib/utils.bzl
@@ -11,3 +11,4 @@ maybe_http_archive = utils.maybe_http_archive
 path_to_workspace_root = utils.path_to_workspace_root
 propagate_well_known_tags = utils.propagate_well_known_tags
 to_label = utils.to_label
+consistent_label_str = utils.consistent_label_str


### PR DESCRIPTION
Addresses TODO in rules_js: https://github.com/aspect-build/rules_js/blob/c3682586eff8c1b8e7ba91484a16df2be1729b5f/js/private/js_binary.bzl#L251

This can get removed in the future once Bazel 5 is EOL