### PR TITLE
chore: remove unnecessary call to register_coreutils_toolchains() in e2e/coreutils

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,14 +162,13 @@ jobs:
             rm -Force .aspect/bazelrc/bazel6.bazelrc
           }
 
-          
       - name: Set bzlmod flag
         # Store the --enable_bzlmod flag that we add to the test command below
         # only when we're running bzlmod in our test matrix.
         id: set_bzlmod_flag
         if: matrix.bzlmodEnabled
         run: echo "bzlmod_flag=--enable_bzlmod" >> $GITHUB_OUTPUT
-        
+
       - name: Write engflow credentials
         if: ${{ matrix.config == 'rbe' }}
         working-directory: ${{ matrix.folder }}
@@ -206,7 +205,7 @@ jobs:
             --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc `
             --bazelrc=${{ github.workspace }}/.aspect/bazelrc/bazel$BAZEL_MAJOR_VERSION.bazelrc `
             --bazelrc=.bazelrc `
-            ${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }} 
+            ${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }}
             test --config=${{ matrix.config }} //...
         env:
           # Bazelisk will download bazel to here

--- a/e2e/coreutils/WORKSPACE
+++ b/e2e/coreutils/WORKSPACE
@@ -3,8 +3,6 @@ local_repository(
     path = "../..",
 )
 
-load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "register_coreutils_toolchains")
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
 
 aspect_bazel_lib_dependencies()
-
-register_coreutils_toolchains()


### PR DESCRIPTION
`aspect_bazel_lib_dependencies()` already makes the call implicitly