### PR TITLE
fix: disable stardoc under bzlmod and windows by default

### DIFF
--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("//lib/private:stamping.bzl", "stamp_build_setting")
 
 # Ensure that users building their own rules can dep on our bzl_library targets for their stardoc
@@ -14,6 +15,23 @@ exports_files(
 
 # Macro that creates targets enabling the use of `--stamp` in Starlark rules
 stamp_build_setting(name = "stamp")
+
+# Add a flag indicating that bzlmod is enabled so that we can use select()
+# to skip bzlmod-incompatible targets. Note that Bazel does not currently
+# support declaring a config_setting directly on --enable_bzlmod, so we
+# must use set this flag instead.
+
+config_setting(
+    name = "bzlmod",
+    flag_values = {
+        ":flag_bzlmod": "true",
+    },
+)
+
+bool_flag(
+    name = "flag_bzlmod",
+    build_setting_default = False,
+)
 
 toolchain_type(
     name = "jq_toolchain_type",


### PR DESCRIPTION
We've been making these exceptions in downstream repos