### PR TITLE
feat: highest compatible version selection for bzlmod toolchains

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -133,4 +133,9 @@ stardoc_with_diff_test(
     bzl_library_target = "//lib:bazelrc_presets",
 )
 
+stardoc_with_diff_test(
+    name = "semver",
+    bzl_library_target = "//lib:semver",
+)
+
 update_docs()

--- a/docs/semver.md
+++ b/docs/semver.md
@@ -1,0 +1,93 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Starlark utilties for semantic versioning
+
+<a id="semver.parse"></a>
+
+## semver.parse
+
+<pre>
+semver.parse(<a href="#semver.parse-version">version</a>)
+</pre>
+
+Parse a semver string into a struct containing info about the semver.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="semver.parse-version"></a>version |  Semver string   |  none |
+
+**RETURNS**
+
+Semver struct
+
+
+<a id="semver.sort"></a>
+
+## semver.sort
+
+<pre>
+semver.sort(<a href="#semver.sort-semvers">semvers</a>)
+</pre>
+
+Sort a list of semver structs in order of precedence.
+
+Precedence is defined by the semver spec: https://semver.org/.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="semver.sort-semvers"></a>semvers |  List of semver structs   |  none |
+
+**RETURNS**
+
+List of semvers sorted in order of precedence.
+
+
+<a id="semver.key"></a>
+
+## semver.key
+
+<pre>
+semver.key(<a href="#semver.key-semver">semver</a>)
+</pre>
+
+Key function to pass to sorted() for semver objects.
+
+Sorts in order of precedence according to the spec: https://semver.org/.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="semver.key-semver"></a>semver |  <p align="center"> - </p>   |  none |
+
+
+<a id="semver.to_str"></a>
+
+## semver.to_str
+
+<pre>
+semver.to_str(<a href="#semver.to_str-semver">semver</a>)
+</pre>
+
+Convert a semver struct to a string.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="semver.to_str-semver"></a>semver |  Semver struct   |  none |
+
+**RETURNS**
+
+The semver in string form.
+
+

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -254,3 +254,9 @@ bzl_library(
     srcs = ["bazelrc_presets.bzl"],
     deps = [":write_source_files"],
 )
+
+bzl_library(
+    name = "semver",
+    srcs = ["semver.bzl"],
+    deps = ["//lib/private/docs:semver"],
+)

--- a/lib/extension_utils.bzl
+++ b/lib/extension_utils.bzl
@@ -1,0 +1,5 @@
+"Utilties for module extensions"
+
+load("//lib/private:extension_utils.bzl", _highest_compatible_toolchain_version = "highest_compatible_toolchain_version")
+
+highest_compatible_toolchain_version = _highest_compatible_toolchain_version

--- a/lib/private/docs/BUILD.bazel
+++ b/lib/private/docs/BUILD.bazel
@@ -243,3 +243,8 @@ bzl_library(
     name = "coreutils_toolchain",
     srcs = ["//lib/private:coreutils_toolchain.bzl"],
 )
+
+bzl_library(
+    name = "semver",
+    srcs = ["//lib/private:semver.bzl"],
+)

--- a/lib/private/extension_utils.bzl
+++ b/lib/private/extension_utils.bzl
@@ -1,0 +1,32 @@
+"Starlark utilities for module extensions"
+
+load("//lib:semver.bzl", "semver")
+
+def highest_compatible_toolchain_version(selected_version, all_versions):
+    """Select the highest compatible version for a toolchain.
+
+    This is useful in a module extension that registers a single toolchain
+    for a module dependency graph.
+
+    Al versions must follow semantic versioning. Preceeding 'v's are supported.
+
+    Args:
+        selected_version: Toolchain version used in the root module
+        all_versions: List of requested toolchain versions in the module dependency graph
+
+    Returns:
+        Most recent version compatible with the selected version.
+    """
+    selected_version = semver.parse(selected_version)
+    all_versions = sorted(
+        [semver.parse(v) for v in all_versions],
+        key = semver.key,
+    )
+
+    if selected_version.major < all_versions[-1].major:
+        fail("Incompatible version")
+
+    same_major_versions = [v for v in all_versions if v.major == selected_version.major]
+    highest_compatible = same_major_versions[-1]
+
+    return semver.to_str(highest_compatible)

--- a/lib/private/semver.bzl
+++ b/lib/private/semver.bzl
@@ -1,0 +1,149 @@
+"Implementation for semantic versioning utilities"
+
+def _invalid_semver(version):
+    fail("Invalid semver: %s" % version)
+
+def _parse(version):
+    """Parse a semver string into a struct containing info about the semver.
+
+    Args:
+        version: Semver string
+
+    Returns:
+        Semver struct
+    """
+    if type(version) != "string":
+        _invalid_semver(version)
+
+    v = False
+    if version.startswith("v"):
+        v = True
+        version = version[1:]
+
+    components = version.split(".", 2)
+    if len(components) != 3:
+        _invalid_semver(version)
+
+    major = components[0]
+    if not major.isdigit():
+        _invalid_semver(version)
+
+    minor = components[1]
+    if not minor.isdigit():
+        _invalid_semver(version)
+
+    patch = components[2]
+    identifiers = None
+    build_metadata = None
+    dash_index = patch.find("-")
+    plus_index = patch.find("+")
+    prerelease = dash_index != -1
+    has_build_metadata = plus_index != -1
+
+    patch_version = patch
+    if prerelease:
+        patch_version = patch[0:dash_index]
+    elif has_build_metadata:
+        patch_version = patch[0:plus_index]
+
+    if not patch_version.isdigit():
+        _invalid_semver(version)
+
+    if prerelease:
+        if not has_build_metadata:
+            identifiers = patch[dash_index + 1:]
+        else:
+            identifiers = patch[dash_index + 1:plus_index]
+
+        for identifier in identifiers.split("."):
+            _validate_identifier(identifier, version)
+
+    if has_build_metadata:
+        build_metadata = patch[plus_index + 1:]
+        for identifier in build_metadata.split("."):
+            _validate_identifier(identifier, version)
+
+    return struct(
+        v = v,
+        major = major,
+        minor = minor,
+        patch = patch_version,
+        prerelease = prerelease,
+        identifiers = identifiers,
+        build_metadata = build_metadata,
+    )
+
+def _validate_identifier(identifier, version):
+    # Identifiers may not be empty
+    if len(identifier) == 0:
+        _invalid_semver(version)
+
+    # Identifiers may not start with leading 0
+    if identifier.startswith("0"):
+        _invalid_semver(version)
+
+    # Identifiers must be comprised of alphanumeric chars or dashes
+    if not identifier.replace("-", "").isalnum():
+        _invalid_semver(version)
+
+def _key(semver):
+    """Key function to pass to sorted() for semver objects.
+
+    Sorts in order of precedence according to the spec: https://semver.org/.
+    """
+    values = [semver.major, semver.minor, semver.patch, not semver.prerelease]
+    if semver.prerelease:
+        values.extend([semver.identifiers.split(".")])
+    return tuple(values)
+
+def _sort(semvers):
+    """Sort a list of semver structs in order of precedence.
+
+    Precedence is defined by the semver spec: https://semver.org/.
+
+    Args:
+        semvers: List of semver structs
+
+    Returns:
+        List of semvers sorted in order of precedence.
+    """
+    return sorted(
+        semvers,
+        key = semver.key,
+    )
+
+def _to_str(semver):
+    """Convert a semver struct to a string.
+
+    Args:
+        semver: Semver struct
+
+    Returns:
+        The semver in string form.
+    """
+    return "{maybe_v}{major}.{minor}.{patch}{maybe_identifiers}{maybe_build_metadata}".format(
+        maybe_v = "v" if semver.v else "",
+        major = semver.major,
+        minor = semver.minor,
+        patch = semver.patch,
+        maybe_identifiers = "-%s" % semver.identifiers if semver.identifiers else "",
+        maybe_build_metadata = "+%s" % semver.build_metadata if semver.build_metadata else "",
+    )
+
+def make(major, minor, patch, identifiers = None, build_metadata = None, v = False):
+    return struct(
+        v = v,
+        major = major,
+        minor = minor,
+        patch = patch,
+        prerelease = identifiers != None,
+        identifiers = identifiers,
+        build_metadata = build_metadata,
+    )
+
+semver = struct(
+    parse = _parse,
+    sort = _sort,
+    key = _key,
+    to_str = _to_str,
+)

--- a/lib/semver.bzl
+++ b/lib/semver.bzl
@@ -1,0 +1,5 @@
+"Starlark utilties for semantic versioning"
+
+load("//lib/private:semver.bzl", _semver = "semver")
+
+semver = _semver

--- a/lib/tests/BUILD.bazel
+++ b/lib/tests/BUILD.bazel
@@ -9,6 +9,8 @@ load(":utils_test.bzl", "utils_test_suite")
 load(":paths_test.bzl", "paths_test_suite")
 load(":glob_match_test.bzl", "glob_match_test_suite")
 load(":base64_tests.bzl", "base64_test_suite")
+load(":semver_test.bzl", "semver_test_suite")
+load(":extension_utils_test.bzl", "extension_utils_test_suite")
 
 config_setting(
     name = "experimental_allow_unresolved_symlinks",
@@ -25,6 +27,10 @@ utils_test_suite()
 glob_match_test_suite()
 
 base64_test_suite()
+
+semver_test_suite()
+
+extension_utils_test_suite()
 
 write_file(
     name = "gen_template",

--- a/lib/tests/extension_utils_test.bzl
+++ b/lib/tests/extension_utils_test.bzl
@@ -1,0 +1,21 @@
+"Unit tests for module extension utils"
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//lib:extension_utils.bzl", "highest_compatible_toolchain_version")
+
+def _highest_compatible_toolchain_version_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, "1.2.0", highest_compatible_toolchain_version("1.2.0", ["1.2.0"]))
+    asserts.equals(env, "1.4.5", highest_compatible_toolchain_version("1.2.0", ["1.0.0", "1.4.5", "1.2.0", "1.1.1"]))
+    asserts.equals(env, "v1.0.0", highest_compatible_toolchain_version("v1.0.0-alpha1", ["v1.0.0", "v1.0.0-alpha1"]))
+
+    return unittest.end(env)
+
+highest_compatible_toolchain_version_test = unittest.make(
+    _highest_compatible_toolchain_version_test_impl,
+    attrs = {},
+)
+
+def extension_utils_test_suite():
+    unittest.suite("extension_utils_tests", highest_compatible_toolchain_version_test)

--- a/lib/tests/semver_test.bzl
+++ b/lib/tests/semver_test.bzl
@@ -1,0 +1,77 @@
+"Unit tests for semvers"
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//lib:semver.bzl", "semver")
+load("//lib/private:semver.bzl", "make")
+
+def _parse_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, make("1", "2", "3"), semver.parse("1.2.3"))
+    asserts.equals(env, make("1", "2", "3", v = True), semver.parse("v1.2.3"))
+    asserts.equals(env, make("1", "23", "49"), semver.parse("1.23.49"))
+    asserts.equals(env, make("0", "0", "0"), semver.parse("0.0.0"))
+    asserts.equals(env, make("0", "0", "0"), semver.parse("0.0.0"))
+
+    asserts.equals(env, make("1", "2", "3", "a"), semver.parse("1.2.3-a"))
+    asserts.equals(env, make("1", "2", "3", "alpha.1"), semver.parse("1.2.3-alpha.1"))
+    asserts.equals(env, make("1", "2", "3", "alpha.12-foo.bar"), semver.parse("1.2.3-alpha.12-foo.bar"))
+
+    asserts.equals(env, make("1", "0", "0", build_metadata = "abc123"), semver.parse("1.0.0+abc123"))
+    asserts.equals(env, make("1", "0", "0", "alpha.4", build_metadata = "abc.12-3"), semver.parse("1.0.0-alpha.4+abc.12-3"))
+
+    asserts.true(env, semver.parse("1.2.3-alpha1").prerelease)
+    asserts.false(env, semver.parse("1.2.3").prerelease)
+
+    return unittest.end(env)
+
+def _key_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    v1_0_0__alpha_1 = make("1", "0", "0", "alpha.1")
+    v1_0_0__alpha_2 = make("1", "0", "0", "alpha.2")
+    v1_0_0__45 = make("1", "0", "0", "45")
+    v1_0_0__4a5 = make("1", "0", "0", "4a5")
+    v1_0_0 = make("1", "0", "0")
+    v1_0_0_plus_1 = make("1", "0", "0", build_metadata = "1")
+    v1_1_0 = make("1", "1", "0")
+    v1_1_1 = make("1", "1", "1")
+    v2_0_0 = make("2", "0", "0")
+
+    # Lower major before higher major
+    asserts.equals(env, [v1_0_0, v2_0_0], sorted([v2_0_0, v1_0_0], key = semver.key))
+
+    # Lower minor before higher minor
+    asserts.equals(env, [v1_0_0, v1_1_0], sorted([v1_1_0, v1_0_0], key = semver.key))
+
+    # Lower patch before higher patch
+    asserts.equals(env, [v1_1_0, v1_1_1], sorted([v1_1_1, v1_1_0], key = semver.key))
+
+    # Prerelease before release
+    asserts.equals(env, [v1_0_0__alpha_1, v1_0_0__alpha_2], sorted([v1_0_0__alpha_2, v1_0_0__alpha_1], key = semver.key))
+
+    # Lower numeric prerelease segment before higher numeric segment
+    asserts.equals(env, [v1_0_0__alpha_1, v1_0_0], sorted([v1_0_0, v1_0_0__alpha_1], key = semver.key))
+
+    # Numeric prerelease segment before alphanumeric segment
+    asserts.equals(env, [v1_0_0__45, v1_0_0__alpha_1], sorted([v1_0_0__alpha_1, v1_0_0__45], key = semver.key))
+    asserts.equals(env, [v1_0_0__45, v1_0_0__4a5], sorted([v1_0_0__4a5, v1_0_0__45], key = semver.key))
+
+    # Build metadata does not affect precedence
+    asserts.equals(env, [v1_0_0, v1_0_0_plus_1], sorted([v1_0_0, v1_0_0_plus_1], key = semver.key))
+    asserts.equals(env, [v1_0_0_plus_1, v1_0_0], sorted([v1_0_0_plus_1, v1_0_0], key = semver.key))
+
+    return unittest.end(env)
+
+parse_test = unittest.make(
+    _parse_test_impl,
+    attrs = {},
+)
+
+key_test = unittest.make(
+    _key_test_impl,
+    attrs = {},
+)
+
+def semver_test_suite():
+    unittest.suite("semver_tests", parse_test, key_test)


### PR DESCRIPTION
Smarter way to select toolchain versions in a bzlmod extension. Was thinking we could use this to select our toolchains such as node.

A module extension implementation that uses this would probably want an option to override the version to what the user has in their root module, in case they want to fix it.

Still a WIP.