### PR TITLE
feat: semver parser

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -133,4 +133,9 @@ stardoc_with_diff_test(
     bzl_library_target = "//lib:bazelrc_presets",
 )
 
+stardoc_with_diff_test(
+    name = "semver",
+    bzl_library_target = "//lib:semver",
+)
+
 update_docs()

--- a/docs/semver.md
+++ b/docs/semver.md
@@ -1,0 +1,88 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Starlark utilties for semantic versioning
+
+<a id="semver.parse"></a>
+
+## semver.parse
+
+<pre>
+semver.parse(<a href="#semver.parse-version">version</a>)
+</pre>
+
+Parse a semver string into a struct containing info about the semver.
+
+E.g.
+```
+sv = semver.parse("v1.2.3-alpha1+1234")
+
+sv.major # "1"
+sv.minor # "2"
+sv.patch # "3"
+sv.prerelease # True
+sv.identifiers # "alpha1"
+sv.build_metadata # "1234"
+sv.v # True (whether prefixed with "v")
+
+```
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="semver.parse-version"></a>version |  Semver string   |  none |
+
+**RETURNS**
+
+Semver struct
+
+
+<a id="semver.sort"></a>
+
+## semver.sort
+
+<pre>
+semver.sort(<a href="#semver.sort-semvers">semvers</a>)
+</pre>
+
+Sort a list of semver structs in order of precedence.
+
+Precedence is defined by the semver spec: https://semver.org/.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="semver.sort-semvers"></a>semvers |  List of semver structs   |  none |
+
+**RETURNS**
+
+List of semvers sorted in order of precedence.
+
+
+<a id="semver.to_str"></a>
+
+## semver.to_str
+
+<pre>
+semver.to_str(<a href="#semver.to_str-semver">semver</a>)
+</pre>
+
+Convert a semver struct to a string.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="semver.to_str-semver"></a>semver |  Semver struct   |  none |
+
+**RETURNS**
+
+The semver in string form.
+
+

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -254,3 +254,9 @@ bzl_library(
     srcs = ["bazelrc_presets.bzl"],
     deps = [":write_source_files"],
 )
+
+bzl_library(
+    name = "semver",
+    srcs = ["semver.bzl"],
+    deps = ["//lib/private/docs:semver"],
+)

--- a/lib/private/docs/BUILD.bazel
+++ b/lib/private/docs/BUILD.bazel
@@ -243,3 +243,8 @@ bzl_library(
     name = "coreutils_toolchain",
     srcs = ["//lib/private:coreutils_toolchain.bzl"],
 )
+
+bzl_library(
+    name = "semver",
+    srcs = ["//lib/private:semver.bzl"],
+)

--- a/lib/private/semver.bzl
+++ b/lib/private/semver.bzl
@@ -1,0 +1,158 @@
+"Implementation for semantic versioning utilities"
+
+def _invalid_semver(version):
+    fail("Invalid semver: %s" % version)
+
+def _parse(version):
+    """Parse a semver string into a struct containing info about the semver.
+
+    E.g.
+    ```
+    sv = semver.parse("v1.2.3-alpha1+1234")
+
+    sv.major # "1"
+    sv.minor # "2"
+    sv.patch # "3"
+    sv.prerelease # True
+    sv.identifiers # "alpha1"
+    sv.build_metadata # "1234"
+    sv.v # True (whether prefixed with "v")
+
+    ```
+
+    Args:
+        version: Semver string
+
+    Returns:
+        Semver struct
+    """
+    if type(version) != "string":
+        _invalid_semver(version)
+
+    v = False
+    if version.startswith("v"):
+        v = True
+        version = version[1:]
+
+    components = version.split(".", 2)
+    if len(components) != 3:
+        _invalid_semver(version)
+
+    major = components[0]
+    if not major.isdigit():
+        _invalid_semver(version)
+
+    minor = components[1]
+    if not minor.isdigit():
+        _invalid_semver(version)
+
+    patch = components[2]
+    identifiers = None
+    build_metadata = None
+    dash_index = patch.find("-")
+    plus_index = patch.find("+")
+    prerelease = dash_index != -1
+    has_build_metadata = plus_index != -1
+
+    patch_version = patch
+    if prerelease:
+        patch_version = patch[0:dash_index]
+    elif has_build_metadata:
+        patch_version = patch[0:plus_index]
+
+    if not patch_version.isdigit():
+        _invalid_semver(version)
+
+    if prerelease:
+        if not has_build_metadata:
+            identifiers = patch[dash_index + 1:]
+        else:
+            identifiers = patch[dash_index + 1:plus_index]
+
+        for identifier in identifiers.split("."):
+            _validate_identifier(identifier, version)
+
+    if has_build_metadata:
+        build_metadata = patch[plus_index + 1:]
+        for identifier in build_metadata.split("."):
+            _validate_identifier(identifier, version)
+
+    return struct(
+        v = v,
+        major = major,
+        minor = minor,
+        patch = patch_version,
+        prerelease = prerelease,
+        identifiers = identifiers,
+        build_metadata = build_metadata,
+    )
+
+def _validate_identifier(identifier, version):
+    # Identifiers may not be empty
+    if len(identifier) == 0:
+        _invalid_semver(version)
+
+    # Identifiers may not start with leading 0
+    if identifier.startswith("0"):
+        _invalid_semver(version)
+
+    # Identifiers must be comprised of alphanumeric chars or dashes
+    if not identifier.replace("-", "").isalnum():
+        _invalid_semver(version)
+
+def _key(semver):
+    values = [semver.major, semver.minor, semver.patch, not semver.prerelease]
+    if semver.prerelease:
+        values.extend([semver.identifiers.split(".")])
+    return tuple(values)
+
+def _sort(semvers):
+    """Sort a list of semver structs in order of precedence.
+
+    Precedence is defined by the semver spec: https://semver.org/.
+
+    Args:
+        semvers: List of semver structs
+
+    Returns:
+        List of semvers sorted in order of precedence.
+    """
+    return sorted(
+        semvers,
+        key = _key,
+    )
+
+def _to_str(semver):
+    """Convert a semver struct to a string.
+
+    Args:
+        semver: Semver struct
+
+    Returns:
+        The semver in string form.
+    """
+    return "{maybe_v}{major}.{minor}.{patch}{maybe_identifiers}{maybe_build_metadata}".format(
+        maybe_v = "v" if semver.v else "",
+        major = semver.major,
+        minor = semver.minor,
+        patch = semver.patch,
+        maybe_identifiers = "-%s" % semver.identifiers if semver.identifiers else "",
+        maybe_build_metadata = "+%s" % semver.build_metadata if semver.build_metadata else "",
+    )
+
+def make(major, minor, patch, identifiers = None, build_metadata = None, v = False):
+    return struct(
+        v = v,
+        major = major,
+        minor = minor,
+        patch = patch,
+        prerelease = identifiers != None,
+        identifiers = identifiers,
+        build_metadata = build_metadata,
+    )
+
+semver = struct(
+    parse = _parse,
+    sort = _sort,
+    to_str = _to_str,
+)

--- a/lib/semver.bzl
+++ b/lib/semver.bzl
@@ -1,0 +1,5 @@
+"Starlark utilties for semantic versioning"
+
+load("//lib/private:semver.bzl", _semver = "semver")
+
+semver = _semver

--- a/lib/tests/BUILD.bazel
+++ b/lib/tests/BUILD.bazel
@@ -9,6 +9,7 @@ load(":utils_test.bzl", "utils_test_suite")
 load(":paths_test.bzl", "paths_test_suite")
 load(":glob_match_test.bzl", "glob_match_test_suite")
 load(":base64_tests.bzl", "base64_test_suite")
+load(":semver_test.bzl", "semver_test_suite")
 
 config_setting(
     name = "experimental_allow_unresolved_symlinks",
@@ -25,6 +26,8 @@ utils_test_suite()
 glob_match_test_suite()
 
 base64_test_suite()
+
+semver_test_suite()
 
 write_file(
     name = "gen_template",

--- a/lib/tests/semver_test.bzl
+++ b/lib/tests/semver_test.bzl
@@ -1,0 +1,93 @@
+"Unit tests for semvers"
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//lib:semver.bzl", "semver")
+load("//lib/private:semver.bzl", "make")
+
+def _parse_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, make("1", "2", "3"), semver.parse("1.2.3"))
+    asserts.equals(env, make("1", "2", "3", v = True), semver.parse("v1.2.3"))
+    asserts.equals(env, make("1", "23", "49"), semver.parse("1.23.49"))
+    asserts.equals(env, make("0", "0", "0"), semver.parse("0.0.0"))
+    asserts.equals(env, make("0", "0", "0"), semver.parse("0.0.0"))
+
+    asserts.equals(env, make("1", "2", "3", "a"), semver.parse("1.2.3-a"))
+    asserts.equals(env, make("1", "2", "3", "alpha.1"), semver.parse("1.2.3-alpha.1"))
+    asserts.equals(env, make("1", "2", "3", "alpha.12-foo.bar"), semver.parse("1.2.3-alpha.12-foo.bar"))
+
+    asserts.equals(env, make("1", "0", "0", build_metadata = "abc123"), semver.parse("1.0.0+abc123"))
+    asserts.equals(env, make("1", "0", "0", "alpha.4", build_metadata = "abc.12-3"), semver.parse("1.0.0-alpha.4+abc.12-3"))
+
+    asserts.true(env, semver.parse("1.2.3-alpha1").prerelease)
+    asserts.false(env, semver.parse("1.2.3").prerelease)
+
+    return unittest.end(env)
+
+def _sort_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    v1_0_0__alpha_1 = make("1", "0", "0", "alpha.1")
+    v1_0_0__alpha_2 = make("1", "0", "0", "alpha.2")
+    v1_0_0__45 = make("1", "0", "0", "45")
+    v1_0_0__4a5 = make("1", "0", "0", "4a5")
+    v1_0_0 = make("1", "0", "0")
+    v1_0_0_plus_1 = make("1", "0", "0", build_metadata = "1")
+    v1_1_0 = make("1", "1", "0")
+    v1_1_1 = make("1", "1", "1")
+    v2_0_0 = make("2", "0", "0")
+
+    # Lower major before higher major
+    asserts.equals(env, [v1_0_0, v2_0_0], semver.sort([v2_0_0, v1_0_0]))
+
+    # Lower minor before higher minor
+    asserts.equals(env, [v1_0_0, v1_1_0], semver.sort([v1_1_0, v1_0_0]))
+
+    # Lower patch before higher patch
+    asserts.equals(env, [v1_1_0, v1_1_1], semver.sort([v1_1_1, v1_1_0]))
+
+    # Prerelease before release
+    asserts.equals(env, [v1_0_0__alpha_1, v1_0_0__alpha_2], semver.sort([v1_0_0__alpha_2, v1_0_0__alpha_1]))
+
+    # Lower numeric prerelease segment before higher numeric segment
+    asserts.equals(env, [v1_0_0__alpha_1, v1_0_0], semver.sort([v1_0_0, v1_0_0__alpha_1]))
+
+    # Numeric prerelease segment before alphanumeric segment
+    asserts.equals(env, [v1_0_0__45, v1_0_0__alpha_1], semver.sort([v1_0_0__alpha_1, v1_0_0__45]))
+    asserts.equals(env, [v1_0_0__45, v1_0_0__4a5], semver.sort([v1_0_0__4a5, v1_0_0__45]))
+
+    # Build metadata does not affect precedence
+    asserts.equals(env, [v1_0_0, v1_0_0_plus_1], semver.sort([v1_0_0, v1_0_0_plus_1]))
+    asserts.equals(env, [v1_0_0_plus_1, v1_0_0], semver.sort([v1_0_0_plus_1, v1_0_0]))
+
+    return unittest.end(env)
+
+def _to_str_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, "1.2.3", semver.to_str(make(make("1", "2", "3"))))
+    asserts.equals(env, "v1.2.3", semver.to_str(make(make("1", "2", "3", v = True))))
+    asserts.equals(env, "v1.2.3-alpha1.beta2", semver.to_str(make(make("1", "2", "3", "alpha1.beta2", v = True))))
+    asserts.equals(env, "v1.2.3+123", semver.to_str(make(make("1", "2", "3", build_metadata = "123"))))
+    asserts.equals(env, "v1.2.3-alpha1+123", semver.to_str(make(make("1", "2", "3", "alpha1", build_metadata = "123"))))
+
+    return unittest.end(env)
+
+parse_test = unittest.make(
+    _parse_test_impl,
+    attrs = {},
+)
+
+sort_test = unittest.make(
+    _sort_test_impl,
+    attrs = {},
+)
+
+to_str_test = unittest.make(
+    _to_str_test_impl,
+    attrs = {},
+)
+
+def semver_test_suite():
+    unittest.suite("semver_tests", parse_test, sort_test)


### PR DESCRIPTION
Prefactor for https://github.com/aspect-build/bazel-lib/pull/399.

I figure we'll need some form of semver support in Starlark to do any sort of version selection scheme for toolchains in bzlmod extensions.