### PR TITLE
Correctly handle empty directory when checking for missing file

### DIFF
--- a/lib/private/write_source_file.bzl
+++ b/lib/private/write_source_file.bzl
@@ -371,5 +371,5 @@ def _is_file_missing(label):
     """
     file_abs = "%s/%s" % (label.package, label.name)
     file_rel = file_abs[len(native.package_name()) + 1:]
-    file_glob = native.glob([file_rel], exclude_directories = 0)
+    file_glob = native.glob([file_rel], exclude_directories = 0, allow_empty = True)
     return len(file_glob) == 0


### PR DESCRIPTION
# Description

The `_is_file_missing()` function uses a glob to determine if a file is missing. However, it has `allow_empty = False`, which
means an error will occur if an empty directory is searched.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or functionality (non-breaking change which adds functionality)
- [ ] Style (white-space, formatting, etc...)
- [ ] Refactor (a code change that neither fixes a bug or adds a new feature)
- [ ] Performance (a code change that improves performance)
- [ ] Documentation (updates to documentation or READMEs)
- [ ] Chore (any other change that doesn't affect source or test files)

# Properties of change

- [ ] Breaking change (this change will cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Test plan

How has this been tested?

- [ ] Covered by existing tests cases
- [ ] New test cases added
- [x] Local testing

If part of the test plan included local testing, please provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

Using `write_source_file()` with an empty directory results in the following erro:

```
Traceback (most recent call last):

File "/Users/alister/example/BUILD.bazel", line 22, column 17, in <toplevel>

example(

File "/Users/alister/example/rules.bzl", line 595, column 22, in example

write_source_file(

File "/private/var/tmp/_bazel_alister/fb38e376d8efddf3cdb91fd1e4a65c39/external/aspect_bazel_lib/lib/private/write_source_file.bzl", line 82, column 40, in 
write_source_file

out_file_missing = _is_file_missing(out_file)

File "/private/var/tmp/_bazel_alister/fb38e376d8efddf3cdb91fd1e4a65c39/external/aspect_bazel_lib/lib/private/write_source_file.bzl", line 374, column 28, in 
_is_file_missing

file_glob = native.glob([file_rel], exclude_directories = 0)

Error in glob: glob pattern 'empty_directory/foobar.txt' didn't match anything, but allow_empty is set to False (the default value of allow_empty can be set with 
--incompatible_disallow_empty_glob).
```

I believe the correct behaviour should be that `_is_file_missing()` returns false.
