### PR TITLE
chore: use config.yml to indicate releaser

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,4 @@
+# See https://github.com/bazel-contrib/publish-to-bcr#a-note-on-release-automation
+fixedReleaser:
+  login: kormide
+  email: derek@aspect.dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,5 +50,4 @@ jobs:
             /tmp/aspect/release/*
             bazel-lib-*.tar.gz
           body_path: release_notes.txt
-          token: ${{ secrets.DEREK_BCR_PAT }}
           fail_on_unmatched_files: true


### PR DESCRIPTION
We want to cleanup our GitHub tokens, and this repo is different from all others by historical accident.
