### PR TITLE
chore: update copy directory golang binary release versions to use

### DIFF
--- a/lib/private/copy_directory_toolchain.bzl
+++ b/lib/private/copy_directory_toolchain.bzl
@@ -3,16 +3,16 @@
 # https://github.com/aspect-build/bazel-lib/releases
 #
 # The integrity hashes can be automatically fetched for the latest copy_directory release by running
-# `tools/copy_directory_mirror_release.sh`. To calculate for a specific release run
-# `tools/copy_directory_mirror_release.sh <release_version>`
+# `tools/copy_directory/mirror_release.sh`. To calculate for a specific release run
+# `tools/copy_directory/mirror_release.sh <release_version>`
 
-COPY_DIRECTORY_VERSION = "1.24.1"
+COPY_DIRECTORY_VERSION = "1.31.0"
 COPY_DIRECTORY_INTEGRITY = {
-    "darwin_amd64": "sha256-ZY4K6g2GBoMghXawS0N00cFwJu+xk/IvZIssjwHrqDw=",
-    "darwin_arm64": "sha256-MR1mYnSDIdnuLgDhaUrePtf99hFExFzoKRCLyzKKQVQ=",
-    "linux_amd64": "sha256-SCEMzcA7CRFFJ6qLx4UjJ68Csr37acqzozNFYBu12KE=",
-    "linux_arm64": "sha256-ALRLEDEaxXUyAxBu173nDz72ou61H2WrmJxPXG7/j5o=",
-    "windows_amd64": "sha256-LIhTYXLhMl3B1ffYOwF+xHGy2dzZ+yCwVby0zgzoSe4=",
+    "darwin_amd64": "sha256-woit3x+tLBneR1uB2vgdBgoysLVjFKOIg0JQUvY31RE=",
+    "darwin_arm64": "sha256-lo40uEgpR47iR76xOuGJ8MTlo9OgGQaxlHSEFVYpBbs=",
+    "linux_amd64": "sha256-DsaFECaxpEzLbv3SfEXcKYpuRk+90FaSYSQuCLEE5i8=",
+    "linux_arm64": "sha256-IH5pYBe42O9iDZm9MdECvnp9e9PpOf6cEab71U0ktXY=",
+    "windows_amd64": "sha256-AWcKeRtEs2djr9Mh3ha5wW0kTq5JNPOBIJbcIKk+BGA=",
 }
 
 # Platform names follow the platform naming convention in @aspect_bazel_lib//:lib/private/repo_utils.bzl

--- a/lib/private/copy_to_directory_toolchain.bzl
+++ b/lib/private/copy_to_directory_toolchain.bzl
@@ -3,16 +3,16 @@
 # https://github.com/aspect-build/bazel-lib/releases
 #
 # The integrity hashes can be automatically fetched for the latest copy_to_directory release by running
-# `tools/copy_to_directory_mirror_release.sh`. To calculate for a specific release run
-# `tools/copy_to_directory_mirror_release.sh <release_version>`
+# `tools/copy_to_directory/mirror_release.sh`. To calculate for a specific release run
+# `tools/copy_to_directory/mirror_release.sh <release_version>`
 
-COPY_TO_DIRECTORY_VERSION = "1.24.1"
+COPY_TO_DIRECTORY_VERSION = "1.31.0"
 COPY_TO_DIRECTORY_INTEGRITY = {
-    "darwin_amd64": "sha256-Qq6RJ+wiPJEm90VFAMxUrJ+/atRs5TT/MSxq6MYxlOg=",
-    "darwin_arm64": "sha256-jDZ2zjj7UWG+FjjdZ1hiELvMp3kF0erbtxnzYDpKZck=",
-    "linux_amd64": "sha256-qPMHgZACh9yJquIMfvR8MP80F/CXWe5W0RFTQRnhEGA=",
-    "linux_arm64": "sha256-1E/4QPVAqrT5DBD1rMN3yyV1anFYAKfr0ErCzYfy2Ik=",
-    "windows_amd64": "sha256-fz7anSGKdVQ+V5yq3Oz5b9vG/728JGhnTSOMJwY9I5Q=",
+    "darwin_amd64": "sha256-L/vJ/RR+PIyX2yDdlqbnPQP3/3bWo6nncA6RIqGRVVQ=",
+    "darwin_arm64": "sha256-7qHbUZXWFgiDOgInegAGEaPOu0up1gtMurXw/uHy9ys=",
+    "linux_amd64": "sha256-lDFF2xCzHdDSbNlCSgZ+LkXhvceOZE8ghu5aahARcsw=",
+    "linux_arm64": "sha256-eGOZbQl0G0Fn74pjPOWVUwZwe0HkhZqoVen9XWQCuAg=",
+    "windows_amd64": "sha256-ctNXsZzsFb01cGMvYBEOpbtmOMezsorYWocKl34kqtY=",
 }
 
 # Platform names follow the platform naming convention in @aspect_bazel_lib//:lib/private/repo_utils.bzl


### PR DESCRIPTION
There shouldn't be any changes in the implementations of the golang binaries. Just bumping the version here since its an old one now. One day we'll include this in the release process.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Covered by existing test cases
