### PR TITLE
fix(yq): restore default version, reverting #405

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -114,7 +114,7 @@ Registers yq toolchain and repositories
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="register_yq_toolchains-name"></a>name |  override the prefix for the generated toolchain repositories   |  <code>"yq"</code> |
-| <a id="register_yq_toolchains-version"></a>version |  the version of yq to execute (see https://github.com/mikefarah/yq/releases)   |  <code>"4.33.3"</code> |
+| <a id="register_yq_toolchains-version"></a>version |  the version of yq to execute (see https://github.com/mikefarah/yq/releases)   |  <code>"4.25.2"</code> |
 | <a id="register_yq_toolchains-register"></a>register |  whether to call through to native.register_toolchains. Should be True for WORKSPACE users, but false when used under bzlmod extension   |  <code>True</code> |
 
 

--- a/lib/private/yq_toolchain.bzl
+++ b/lib/private/yq_toolchain.bzl
@@ -48,7 +48,9 @@ YQ_PLATFORMS = {
     ),
 }
 
-DEFAULT_YQ_VERSION = "4.33.3"
+# Note: this is not the latest release, because it has significant breaking changes.
+# See https://github.com/aspect-build/bazel-lib/pull/421
+DEFAULT_YQ_VERSION = "4.25.2"
 
 # https://github.com/mikefarah/yq/releases
 #

--- a/lib/tests/yq/BUILD.bazel
+++ b/lib/tests/yq/BUILD.bazel
@@ -66,7 +66,7 @@ diff_test(
 yq(
     name = "case_convert_json_to_yaml",
     srcs = ["//lib/tests/jq:a_pretty.json"],
-    args = ["-p=json"],
+    args = ["-P"],
     expression = ".",
 )
 
@@ -252,7 +252,7 @@ diff_test(
 yq(
     name = "case_convert_xml_to_yaml",
     srcs = ["sample.xml"],
-    args = ["-p=xml --xml-skip-proc-inst"],
+    args = ["-p=xml"],
     expression = ".",
 )
 
@@ -298,7 +298,7 @@ yq(
         "//lib/tests/jq:a.json",
         "//lib/tests/jq:b.json",
     ],
-    args = ["-p=json"],
+    args = ["-P"],
     expression = ". as $item ireduce ({}; . * $item )",
 )
 


### PR DESCRIPTION
The new version of yq is quite breaking, as it requires '-oj -r' for continued operation in rules_oci. We can do a default version flip later when more downstream projects are compatible.


---

### Type of change

- Bug fix (change which fixes an issue)

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config)
Anyone relying on the new version being the default will have to opt-in. This has been live only four days so I think that's okay. I'll yank the prior release from BCR.

### Test plan

None