### PR TITLE
fix: rewrite glob implementation to follow standard glob specs

### DIFF
--- a/lib/tests/glob_match_test.bzl
+++ b/lib/tests/glob_match_test.bzl
@@ -75,6 +75,11 @@ def _globstar(ctx):
 
 globstar_test = unittest.make(_globstar)
 
+def _globstar_slash(ctx):
+    return _glob_match_test(ctx, "**/*", ["@eslint/plugin-foo", "express"], [])
+
+globstar_slash_test = unittest.make(_globstar_slash)
+
 def _qmark(ctx):
     return _glob_match_test(
         ctx,
@@ -164,7 +169,7 @@ def _mixed_trailing_globstar(ctx):
     return _glob_match_test(
         ctx,
         "foo*/**",
-        matches = ["foo/fum/bar", "foostar/fum/bar", "foo/a", "foob/c"],
+        matches = ["foo/fum/bar", "foostar/fum/bar", "foo/a", "foob/c", "foo/", "fooa/"],
         non_matches = ["fo/fum/bar", "fostar/fum/bar", "foo", "foostar", "afoo", "b/foo/c"],
     )
 
@@ -174,8 +179,8 @@ def _mixed_leading_globstar(ctx):
     return _glob_match_test(
         ctx,
         "**/foo*",
-        matches = ["fum/bar/foo", "fum/bar/foostar"],
-        non_matches = ["fum/bar/fo", "fum/bar/fostar", "foo", "foostar"],
+        matches = ["fum/bar/foo", "fum/bar/foostar", "foo", "foostar", "as/foo"],
+        non_matches = ["fum/bar/fo", "fum/bar/fostar"],
     )
 
 mixed_leading_globstar_test = unittest.make(_mixed_leading_globstar)
@@ -184,7 +189,7 @@ def _mixed_leading_globstar2(ctx):
     return _glob_match_test(
         ctx,
         "**/*foo",
-        matches = ["fum/bar/foo", "fum/bar/starfoo"],
+        matches = ["fum/bar/foo", "fum/bar/starfoo", "foo", "xfoo"],
         non_matches = ["fum/bar/foox", "fum/bar/foo/y"],
     )
 
@@ -194,7 +199,7 @@ def _mixed_wrapping_globstar(ctx):
     return _glob_match_test(
         ctx,
         "**/foo*/**",
-        matches = ["fum/bar/foo/fum/bar", "fum/bar/foostar/fum/bar"],
+        matches = ["fum/bar/foo/fum/bar", "fum/bar/foostar/fum/bar", "foo/a", "foob/c", "foo/"],
         non_matches = ["fum/bar/fo/fum/bar", "fum/bar/fostar/fum/bar", "foo", "foostar"],
     )
 
@@ -204,8 +209,8 @@ def _all_of_ext(ctx):
     return _glob_match_test(
         ctx,
         "**/*.tf",
-        matches = ["a/b.tf", "ab/cd/e.tf"],
-        non_matches = ["a/b.tfg", "a/tf", "a/b.tf/g"],
+        matches = ["a.tf", "a/b.tf", "ab/cd/e.tf"],
+        non_matches = ["a/b.tfg", "a/tf", "a/b.tf/g"],  #TODO: "a/.tf", ".tf"
     )
 
 all_of_ext_test = unittest.make(_all_of_ext)
@@ -214,7 +219,7 @@ def _all_of_name(ctx):
     return _glob_match_test(
         ctx,
         "**/foo",
-        matches = ["a/b/c/foo", "foo/foo", "a/foo/foo"],
+        matches = ["a/b/c/foo", "foo/foo", "a/foo/foo", "foo"],
         non_matches = ["foox", "foo/x"],
     )
 
@@ -257,6 +262,7 @@ def glob_match_test_suite():
         partial.make(star_test, timeout = "short"),
         partial.make(trailing_star_test, timeout = "short"),
         partial.make(globstar_test, timeout = "short"),
+        partial.make(globstar_slash_test, timeout = "short"),
         partial.make(qmark_test, timeout = "short"),
         partial.make(qmark_qmark_test, timeout = "short"),
         partial.make(wrapped_qmark_test, timeout = "short"),


### PR DESCRIPTION
This is basically a rewrite that @thesayyn and I did using the [go doublestar](https://github.com/bmatcuk/doublestar/blob/465a339d8daa03b8620e49b8ae541f71651426ad/match.go#L74) implementation as a guide. Probably not worth looking at the diff in the second commit and just looking at the code.

### Type of change

- Bug fix (change which fixes an issue)
- Refactor (a code change that neither fixes a bug or adds a new feature)
- Performance (a code change that improves performance)

### Test plan

- Covered by existing test cases
- New test cases added
