### PR TITLE
Use actual newline (instead of "\n") to split strings in yq rule

### DIFF
--- a/lib/private/parse_status_file.yq
+++ b/lib/private/parse_status_file.yq
@@ -1,3 +1,4 @@
-load_str(filename) | split("\n") | .[] | select(length!=0)
+load_str(filename) | split("
+") | .[] | select(length!=0)
     | [capture("(?P<key>[^\s]+)\s+(?P<value>.*)")]
     | from_entries


### PR DESCRIPTION
Fixes d79f4d4
Fixes #463

This is required since versions of yq older than 4.30.3 do not parse "\n" correctly. See https://github.com/mikefarah/yq/issues/1430 and https://github.com/mikefarah/yq/commit/e02bb7194897edb916a6787fb8f8e5a7f432dd94

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Manual testing; please provide instructions so we can reproduce:

1. Build any yq rule: `bazel build //lib/tests/yq:stamped`
2. Look at the processed stamping yaml: `cat bazel-bin/lib/tests/yq/_stamped_stamp.yaml`

Without this fix, the file only contains the first item of `bazel-out/stable-status.txt` and `bazel-out/volatile-status.txt` respectively. With the fix, every item appears in the yaml.
