### PR TITLE
Fix `update_docs` with stardoc 0.6.0 and Bazel 7

### DIFF
--- a/lib/private/docs.bzl
+++ b/lib/private/docs.bzl
@@ -58,7 +58,7 @@ def update_docs(name = "update", **kwargs):
 
     update_files = {}
     for r in native.existing_rules().values():
-        if r["kind"] == "stardoc":
+        if r["generator_function"] == "stardoc_with_diff_test" and r["generator_name"] == r["name"]:
             for tag in r["tags"]:
                 if tag.startswith("package:"):
                     stardoc_name = r["name"]


### PR DESCRIPTION
Fixes `update_docs` `existing_rules` logic with stardoc 0.6.0 and Bazel 7 by making it independent of the name of the internal rules instantiated by the `stardoc` macro.

### Type of change

Bug fix

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce:
Update stardoc to 0.6.0 and run with USE_BAZEL_VERSION=last_green
