### PR TITLE
chore: Switch to buildbuddy for RBE

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -13,16 +13,8 @@ build:rbe --genrule_strategy=remote
 build:rbe --host_platform=@aspect_bazel_lib//platforms:x86_64_linux_remote
 build:rbe --jobs=32
 
-# EngFlow remote cache
-build:rbe --bes_backend=grpcs://tourmaline.cluster.engflow.com
-build:rbe --bes_results_url=https://tourmaline.cluster.engflow.com/invocation/
-build:rbe --remote_cache=grpcs://tourmaline.cluster.engflow.com
-
-# EngFlow remote build execution
-build:rbe --remote_executor=grpcs://tourmaline.cluster.engflow.com
-
-# TODO: remove workaround for failure
-build:rbe --modify_execution_info=GoCompilePkg=+no-remote-exec
-
-# These files are written during CI setup, using secrets registered with the CI platforms
-build:rbe --tls_client_certificate=engflow.crt --tls_client_key=engflow.key
+# BuildBuddy remote exec
+build:rbe --bes_results_url=https://app.buildbuddy.io/invocation/
+build:rbe --bes_backend=grpcs://remote.buildbuddy.io
+build:rbe --remote_timeout=3600
+build:rbe --remote_executor=grpcs://remote.buildbuddy.io

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,14 +22,14 @@ jobs:
     # Prepares the 'config' axis of the test matrix
     runs-on: ubuntu-latest
     env:
-      ENGFLOW_PRIVATE_KEY: ${{ secrets.ENGFLOW_PRIVATE_KEY }}
+      BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
     steps:
       - id: local
         run: echo "config=local" >> $GITHUB_OUTPUT
       - id: rbe
         run: echo "config=rbe" >> $GITHUB_OUTPUT
-        # Don't run RBE if there are no EngFlow creds which is the case on forks
-        if: ${{ env.ENGFLOW_PRIVATE_KEY != '' }}
+        # Don't run RBE if there is no API key which is the case on forks
+        if: ${{ env.BUILDBUDDY_API_KEY != '' }}
     outputs:
       # Will look like '["local", "rbe"]'
       configs: ${{ toJSON(steps.*.outputs.config) }}
@@ -177,17 +177,15 @@ jobs:
         if: matrix.bzlmodEnabled
         run: echo "bzlmod_flag=--enable_bzlmod" >> $GITHUB_OUTPUT
 
-      - name: Write engflow credentials
+      - name: Write rbe credentials
         if: ${{ matrix.config == 'rbe' }}
         working-directory: ${{ matrix.folder }}
         run: |
-          touch engflow.crt engflow.key
-          chmod 0600 engflow.crt engflow.key
-          echo "$ENGFLOW_CLIENT_CRT" > engflow.crt
-          echo "$ENGFLOW_PRIVATE_KEY" > engflow.key
+          touch $HOME/.bazelrc
+          chmod 0600 $HOME/.bazelrc
+          echo "build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY" > $HOME/.bazelrc
         env:
-          ENGFLOW_CLIENT_CRT: ${{ secrets.ENGFLOW_CLIENT_CRT }}
-          ENGFLOW_PRIVATE_KEY: ${{ secrets.ENGFLOW_PRIVATE_KEY }}
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: bazel test //...
         if: ${{ matrix.os != 'windows-latest' }}


### PR DESCRIPTION
Our Engflow cluster seems to be down.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Covered by existing test cases
