### PR TITLE
feat: add list utils

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -103,3 +103,10 @@ assert_contains(
     actual = ".bazelversion",
     expected = str(host.bazel_version),
 )
+
+bzl_library(
+    name = "deps",
+    srcs = ["deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_gazelle//:deps"],
+)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ For example to use commit `abc123`:
 - [expand_make_vars](docs/expand_make_vars.md) Perform make variable and location substitions in strings and templates.
 - [paths](docs/paths.md) Useful path resolution methods.
 - [transitions](docs/transitions.md) Transition sources to a provided platform.
+- [lists](docs/lists.md) Functional-style helpers for working with list data structures.
 - [utils](docs/utils.md) Various utils for labels and globs.
 - [params_file](docs/params_file.md) Generate encoded params file from a list of arguments.
 - [repo_utils](docs/repo_utils.md) Useful methods for repository rule implementations.

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -54,6 +54,11 @@ stardoc_with_diff_test(
 )
 
 stardoc_with_diff_test(
+    name = "lists",
+    bzl_library_target = "//lib:lists",
+)
+
+stardoc_with_diff_test(
     name = "utils",
     bzl_library_target = "//lib:utils",
 )

--- a/docs/lists.md
+++ b/docs/lists.md
@@ -1,0 +1,190 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Functions for lists
+
+<a id="every"></a>
+
+## every
+
+<pre>
+every(<a href="#every-f">f</a>, <a href="#every-arr">arr</a>)
+</pre>
+
+Check if every item of `arr` passes function `f`.
+
+Example:
+  every(lambda i: i.endswith(".js"), ["app.js", "lib.js"]) // True
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="every-f"></a>f |  function to execute on every item,   |  none |
+| <a id="every-arr"></a>arr |  list to iterate over,   |  none |
+
+**RETURNS**
+
+True or False
+
+
+<a id="filter"></a>
+
+## filter
+
+<pre>
+filter(<a href="#filter-f">f</a>, <a href="#filter-arr">arr</a>)
+</pre>
+
+Filter a list `arr` by applying a function `f` to each item.
+
+Example:
+  filter(lambda i: i.endswith(".js"), ["app.ts", "app.js", "lib.ts", "lib.js"]) // ["app.js", "lib.js"]
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="filter-f"></a>f |  function to execute on every item,   |  none |
+| <a id="filter-arr"></a>arr |  list to iterate over,   |  none |
+
+**RETURNS**
+
+A new list containing items that passed the filter function.
+
+
+<a id="find"></a>
+
+## find
+
+<pre>
+find(<a href="#find-f">f</a>, <a href="#find-arr">arr</a>)
+</pre>
+
+Find a particular item from list `arr` by a given function `f`.
+
+Unlike `pick`, the `find` method returns a tuple of the index and the value of first item passing by `f`.
+Furhermore `find` does not fail if no item passes `f`.
+In this case `(-1, None)` is returned.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="find-f"></a>f |  function to execute on every item,   |  none |
+| <a id="find-arr"></a>arr |  list to iterate over,   |  none |
+
+**RETURNS**
+
+Tuple (index, item)
+
+
+<a id="map"></a>
+
+## map
+
+<pre>
+map(<a href="#map-f">f</a>, <a href="#map-arr">arr</a>)
+</pre>
+
+Apply a function `f` with each item of `arr` and return a list with all items where said funtion returns truthy.
+
+Example:
+  map(lambda i: i*2, [1, 2, 3]) // [2, 4, 6]
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="map-f"></a>f |  function to execute on every item.   |  none |
+| <a id="map-arr"></a>arr |  list to iterate over.   |  none |
+
+**RETURNS**
+
+A new list with all mapped items.
+
+
+<a id="once"></a>
+
+## once
+
+<pre>
+once(<a href="#once-f">f</a>, <a href="#once-arr">arr</a>)
+</pre>
+
+Check if exactly one item in list `arr` passes the given function `f`.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="once-f"></a>f |  function to execute on every item,   |  none |
+| <a id="once-arr"></a>arr |  list to iterate over,   |  none |
+
+**RETURNS**
+
+True or False
+
+
+<a id="pick"></a>
+
+## pick
+
+<pre>
+pick(<a href="#pick-f">f</a>, <a href="#pick-arr">arr</a>)
+</pre>
+
+Pick a particular item in list `arr` by a given function `f`.
+
+Unlike `filter`, the `pick` method returns the first item _found_ by `f`.
+If no item has passed `f`, the function will _fail_.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="pick-f"></a>f |  function to execute on every item,   |  none |
+| <a id="pick-arr"></a>arr |  list to iterate over,   |  none |
+
+**RETURNS**
+
+item
+
+
+<a id="some"></a>
+
+## some
+
+<pre>
+some(<a href="#some-f">f</a>, <a href="#some-arr">arr</a>)
+</pre>
+
+Check if at least one item of `arr` passes function `f`.
+
+Example:
+  some(lambda i: i.endswith(".js"), ["app.js", "lib.ts"]) // True
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="some-f"></a>f |  function to execute on every item,   |  none |
+| <a id="some-arr"></a>arr |  list to iterate over,   |  none |
+
+**RETURNS**
+
+True or False
+
+

--- a/docs/lists.md
+++ b/docs/lists.md
@@ -13,7 +13,7 @@ every(<a href="#every-f">f</a>, <a href="#every-arr">arr</a>)
 Check if every item of `arr` passes function `f`.
 
 Example:
-  every(lambda i: i.endswith(".js"), ["app.js", "lib.js"]) // True
+  `every(lambda i: i.endswith(".js"), ["app.js", "lib.js"]) // True`
 
 
 **PARAMETERS**
@@ -21,8 +21,8 @@ Example:
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="every-f"></a>f |  function to execute on every item,   |  none |
-| <a id="every-arr"></a>arr |  list to iterate over,   |  none |
+| <a id="every-f"></a>f |  Function to execute on every item   |  none |
+| <a id="every-arr"></a>arr |  List to iterate over   |  none |
 
 **RETURNS**
 
@@ -40,7 +40,7 @@ filter(<a href="#filter-f">f</a>, <a href="#filter-arr">arr</a>)
 Filter a list `arr` by applying a function `f` to each item.
 
 Example:
-  filter(lambda i: i.endswith(".js"), ["app.ts", "app.js", "lib.ts", "lib.js"]) // ["app.js", "lib.js"]
+  `filter(lambda i: i.endswith(".js"), ["app.ts", "app.js", "lib.ts", "lib.js"]) // ["app.js", "lib.js"]`
 
 
 **PARAMETERS**
@@ -48,8 +48,8 @@ Example:
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="filter-f"></a>f |  function to execute on every item,   |  none |
-| <a id="filter-arr"></a>arr |  list to iterate over,   |  none |
+| <a id="filter-f"></a>f |  Function to execute on every item   |  none |
+| <a id="filter-arr"></a>arr |  List to iterate over   |  none |
 
 **RETURNS**
 
@@ -76,8 +76,8 @@ In this case `(-1, None)` is returned.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="find-f"></a>f |  function to execute on every item,   |  none |
-| <a id="find-arr"></a>arr |  list to iterate over,   |  none |
+| <a id="find-f"></a>f |  Function to execute on every item   |  none |
+| <a id="find-arr"></a>arr |  List to iterate over   |  none |
 
 **RETURNS**
 
@@ -92,10 +92,10 @@ Tuple (index, item)
 map(<a href="#map-f">f</a>, <a href="#map-arr">arr</a>)
 </pre>
 
-Apply a function `f` with each item of `arr` and return a list with all items where said funtion returns truthy.
+Apply a function `f` with each item of `arr` and return a new list.
 
 Example:
-  map(lambda i: i*2, [1, 2, 3]) // [2, 4, 6]
+  `map(lambda i: i*2, [1, 2, 3]) // [2, 4, 6]`
 
 
 **PARAMETERS**
@@ -103,8 +103,8 @@ Example:
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="map-f"></a>f |  function to execute on every item.   |  none |
-| <a id="map-arr"></a>arr |  list to iterate over.   |  none |
+| <a id="map-f"></a>f |  Function to execute on every item   |  none |
+| <a id="map-arr"></a>arr |  List to iterate over   |  none |
 
 **RETURNS**
 
@@ -126,8 +126,8 @@ Check if exactly one item in list `arr` passes the given function `f`.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="once-f"></a>f |  function to execute on every item,   |  none |
-| <a id="once-arr"></a>arr |  list to iterate over,   |  none |
+| <a id="once-f"></a>f |  Function to execute on every item   |  none |
+| <a id="once-arr"></a>arr |  List to iterate over   |  none |
 
 **RETURNS**
 
@@ -153,8 +153,8 @@ If no item has passed `f`, the function will _fail_.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="pick-f"></a>f |  function to execute on every item,   |  none |
-| <a id="pick-arr"></a>arr |  list to iterate over,   |  none |
+| <a id="pick-f"></a>f |  Function to execute on every item   |  none |
+| <a id="pick-arr"></a>arr |  List to iterate over   |  none |
 
 **RETURNS**
 
@@ -172,7 +172,7 @@ some(<a href="#some-f">f</a>, <a href="#some-arr">arr</a>)
 Check if at least one item of `arr` passes function `f`.
 
 Example:
-  some(lambda i: i.endswith(".js"), ["app.js", "lib.ts"]) // True
+  `some(lambda i: i.endswith(".js"), ["app.js", "lib.ts"]) // True`
 
 
 **PARAMETERS**
@@ -180,8 +180,8 @@ Example:
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="some-f"></a>f |  function to execute on every item,   |  none |
-| <a id="some-arr"></a>arr |  list to iterate over,   |  none |
+| <a id="some-f"></a>f |  Function to execute on every item   |  none |
+| <a id="some-arr"></a>arr |  List to iterate over   |  none |
 
 **RETURNS**
 

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -248,11 +248,6 @@ bzl_library(
 )
 
 bzl_library(
-    name = "windows_utils",
-    srcs = ["windows_utils.bzl"],
-)
-
-bzl_library(
     name = "platform_utils",
     srcs = ["platform_utils.bzl"],
     deps = ["//lib/private/docs:platform_utils"],
@@ -274,4 +269,15 @@ bzl_library(
     name = "strings",
     srcs = ["strings.bzl"],
     deps = ["//lib/private/docs:strings"],
+)
+
+bzl_library(
+    name = "lists",
+    srcs = ["lists.bzl"],
+    deps = ["//lib/private/docs:lists"],
+)
+
+bzl_library(
+    name = "windows_utils",
+    srcs = ["windows_utils.bzl"],
 )

--- a/lib/lists.bzl
+++ b/lib/lists.bzl
@@ -1,0 +1,11 @@
+"Functions for lists"
+
+load("//lib/private:lists.bzl", _every = "every", _filter = "filter", _find = "find", _map = "map", _once = "once", _pick = "pick", _some = "some")
+
+every = _every
+filter = _filter
+find = _find
+map = _map
+once = _once
+pick = _pick
+some = _some

--- a/lib/private/docs/BUILD.bazel
+++ b/lib/private/docs/BUILD.bazel
@@ -115,6 +115,13 @@ bzl_library(
 )
 
 bzl_library(
+    name = "lists",
+    srcs = [
+        "//lib/private:lists.bzl",
+    ],
+)
+
+bzl_library(
     name = "utils",
     srcs = [
         "//lib/private:utils.bzl",

--- a/lib/private/lists.bzl
+++ b/lib/private/lists.bzl
@@ -4,11 +4,11 @@ def every(f, arr):
     """Check if every item of `arr` passes function `f`.
 
     Example:
-      every(lambda i: i.endswith(".js"), ["app.js", "lib.js"]) // True
+      `every(lambda i: i.endswith(".js"), ["app.js", "lib.js"]) // True`
 
     Args:
-      f: function to execute on every item,
-      arr: list to iterate over,
+      f: Function to execute on every item
+      arr: List to iterate over
 
     Returns:
       True or False
@@ -19,11 +19,11 @@ def filter(f, arr):
     """Filter a list `arr` by applying a function `f` to each item.
 
     Example:
-      filter(lambda i: i.endswith(".js"), ["app.ts", "app.js", "lib.ts", "lib.js"]) // ["app.js", "lib.js"]
+      `filter(lambda i: i.endswith(".js"), ["app.ts", "app.js", "lib.ts", "lib.js"]) // ["app.js", "lib.js"]`
 
     Args:
-      f: function to execute on every item,
-      arr: list to iterate over,
+      f: Function to execute on every item
+      arr: List to iterate over
 
     Returns:
       A new list containing items that passed the filter function.
@@ -42,8 +42,8 @@ def find(f, arr):
     In this case `(-1, None)` is returned.
 
     Args:
-      f: function to execute on every item,
-      arr: list to iterate over,
+      f: Function to execute on every item
+      arr: List to iterate over
 
     Returns:
       Tuple (index, item)
@@ -56,14 +56,14 @@ def find(f, arr):
     return (-1, None)
 
 def map(f, arr):
-    """Apply a function `f` with each item of `arr` and return a list with all items where said funtion returns truthy.
+    """Apply a function `f` with each item of `arr` and return a new list.
 
     Example:
-      map(lambda i: i*2, [1, 2, 3]) // [2, 4, 6]
+      `map(lambda i: i*2, [1, 2, 3]) // [2, 4, 6]`
 
     Args:
-      f: function to execute on every item.
-      arr: list to iterate over.
+      f: Function to execute on every item
+      arr: List to iterate over
 
     Returns:
       A new list with all mapped items.
@@ -74,8 +74,8 @@ def once(f, arr):
     """Check if exactly one item in list `arr` passes the given function `f`.
 
     Args:
-      f: function to execute on every item,
-      arr: list to iterate over,
+      f: Function to execute on every item
+      arr: List to iterate over
 
     Returns:
       True or False
@@ -89,8 +89,8 @@ def pick(f, arr):
     If no item has passed `f`, the function will _fail_.
 
     Args:
-      f: function to execute on every item,
-      arr: list to iterate over,
+      f: Function to execute on every item
+      arr: List to iterate over
 
     Returns:
       item
@@ -104,13 +104,16 @@ def some(f, arr):
     """Check if at least one item of `arr` passes function `f`.
 
     Example:
-      some(lambda i: i.endswith(".js"), ["app.js", "lib.ts"]) // True
+      `some(lambda i: i.endswith(".js"), ["app.js", "lib.ts"]) // True`
 
     Args:
-      f: function to execute on every item,
-      arr: list to iterate over,
+      f: Function to execute on every item
+      arr: List to iterate over
 
     Returns:
       True or False
     """
-    return len(filter(f, arr)) > 0
+    for a in arr:
+        if f(a):
+            return True
+    return False

--- a/lib/private/lists.bzl
+++ b/lib/private/lists.bzl
@@ -1,0 +1,116 @@
+"Function definitions for working with lists"
+
+def every(f, arr):
+    """Check if every item of `arr` passes function `f`.
+
+    Example:
+      every(lambda i: i.endswith(".js"), ["app.js", "lib.js"]) // True
+
+    Args:
+      f: function to execute on every item,
+      arr: list to iterate over,
+
+    Returns:
+      True or False
+    """
+    return len(filter(f, arr)) == len(arr)
+
+def filter(f, arr):
+    """Filter a list `arr` by applying a function `f` to each item.
+
+    Example:
+      filter(lambda i: i.endswith(".js"), ["app.ts", "app.js", "lib.ts", "lib.js"]) // ["app.js", "lib.js"]
+
+    Args:
+      f: function to execute on every item,
+      arr: list to iterate over,
+
+    Returns:
+      A new list containing items that passed the filter function.
+    """
+    res = []
+    for a in arr:
+        if f(a):
+            res.append(a)
+    return res
+
+def find(f, arr):
+    """Find a particular item from list `arr` by a given function `f`.
+
+    Unlike `pick`, the `find` method returns a tuple of the index and the value of first item passing by `f`.
+    Furhermore `find` does not fail if no item passes `f`.
+    In this case `(-1, None)` is returned.
+
+    Args:
+      f: function to execute on every item,
+      arr: list to iterate over,
+
+    Returns:
+      Tuple (index, item)
+    """
+    i = 0
+    for a in arr:
+        if f(a):
+            return (i, a)
+        i += 1
+    return (-1, None)
+
+def map(f, arr):
+    """Apply a function `f` with each item of `arr` and return a list with all items where said funtion returns truthy.
+
+    Example:
+      map(lambda i: i*2, [1, 2, 3]) // [2, 4, 6]
+
+    Args:
+      f: function to execute on every item.
+      arr: list to iterate over.
+
+    Returns:
+      A new list with all mapped items.
+    """
+    return [f(a) for a in arr]
+
+def once(f, arr):
+    """Check if exactly one item in list `arr` passes the given function `f`.
+
+    Args:
+      f: function to execute on every item,
+      arr: list to iterate over,
+
+    Returns:
+      True or False
+    """
+    return len(filter(f, arr)) == 1
+
+def pick(f, arr):
+    """Pick a particular item in list `arr` by a given function `f`.
+
+    Unlike `filter`, the `pick` method returns the first item _found_ by `f`.
+    If no item has passed `f`, the function will _fail_.
+
+    Args:
+      f: function to execute on every item,
+      arr: list to iterate over,
+
+    Returns:
+      item
+    """
+    for a in arr:
+        if f(a):
+            return a
+    fail("Could not find any item")
+
+def some(f, arr):
+    """Check if at least one item of `arr` passes function `f`.
+
+    Example:
+      some(lambda i: i.endswith(".js"), ["app.js", "lib.ts"]) // True
+
+    Args:
+      f: function to execute on every item,
+      arr: list to iterate over,
+
+    Returns:
+      True or False
+    """
+    return len(filter(f, arr)) > 0

--- a/lib/tests/BUILD.bazel
+++ b/lib/tests/BUILD.bazel
@@ -10,6 +10,7 @@ load(":paths_test.bzl", "paths_test_suite")
 load(":glob_match_test.bzl", "glob_match_test_suite")
 load(":base64_tests.bzl", "base64_test_suite")
 load(":strings_tests.bzl", "strings_test_suite")
+load(":lists_test.bzl", "lists_test_suite")
 
 config_setting(
     name = "experimental_allow_unresolved_symlinks",
@@ -28,6 +29,8 @@ glob_match_test_suite()
 base64_test_suite()
 
 strings_test_suite()
+
+lists_test_suite()
 
 write_file(
     name = "gen_template",

--- a/lib/tests/bazelrc_presets/all/BUILD.bazel
+++ b/lib/tests/bazelrc_presets/all/BUILD.bazel
@@ -1,3 +1,14 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":write_aspect_bazelrc_presets.bzl", "write_aspect_bazelrc_presets")
 
 write_aspect_bazelrc_presets(name = "update_aspect_bazelrc_presets")
+
+bzl_library(
+    name = "write_aspect_bazelrc_presets",
+    srcs = ["write_aspect_bazelrc_presets.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@aspect_bazel_lib//lib:bazelrc_presets",
+        "@aspect_bazel_lib_host//:defs",
+    ],
+)

--- a/lib/tests/lists_test.bzl
+++ b/lib/tests/lists_test.bzl
@@ -1,0 +1,83 @@
+"""unit tests for lists"""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//lib/private:lists.bzl", "every", "filter", "find", "map", "once", "pick", "some")
+
+def _every_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, every(lambda i: i.endswith(".js"), ["app.js", "lib.js"]), True)
+    asserts.equals(env, every(lambda i: i.endswith(".ts"), ["app.js", "lib.ts"]), False)
+
+    return unittest.end(env)
+
+every_test = unittest.make(_every_test_impl)
+
+def _filter_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, filter(lambda i: i.endswith(".js"), ["app.ts", "app.js", "lib.ts", "lib.js"]), ["app.js", "lib.js"])
+
+    return unittest.end(env)
+
+filter_test = unittest.make(_filter_test_impl)
+
+def _find_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, find(lambda i: i.endswith(".js"), ["app.ts", "app.js", "lib.ts", "lib.js"]), (1, "app.js"))
+    asserts.equals(env, find(lambda i: i.endswith(".exe"), ["app.ts", "app.js", "lib.ts", "lib.js"]), (-1, None))
+
+    return unittest.end(env)
+
+find_test = unittest.make(_find_test_impl)
+
+def _map_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, map(lambda i: i * 2, [1, 2, 3]), [2, 4, 6])
+
+    return unittest.end(env)
+
+map_test = unittest.make(_map_test_impl)
+
+def _once_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, once(lambda i: i == 1, [1, 2, 3]), True)
+    asserts.equals(env, once(lambda i: i > 1, [1, 2, 3]), False)
+
+    return unittest.end(env)
+
+once_test = unittest.make(_once_test_impl)
+
+def _pick_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, pick(lambda i: i > 1, [1, 2, 3]), 2)
+
+    return unittest.end(env)
+
+pick_test = unittest.make(_pick_test_impl)
+
+def _some_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, some(lambda i: i.endswith(".js"), ["app.ts", "app.js"]), True)
+    asserts.equals(env, some(lambda i: i.endswith(".js"), ["app.ts", "lib.ts"]), False)
+
+    return unittest.end(env)
+
+some_test = unittest.make(_some_test_impl)
+
+def lists_test_suite():
+    unittest.suite(
+        "lists_tests",
+        every_test,
+        filter_test,
+        find_test,
+        map_test,
+        once_test,
+        pick_test,
+        some_test,
+    )

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":release.bzl", "multi_platform_go_binaries", "release")
 
 exports_files([
@@ -30,4 +31,10 @@ release(
         ":copy_to_directory",
         ":expand_template",
     ],
+)
+
+bzl_library(
+    name = "hashes",
+    srcs = ["hashes.bzl"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This adds functions to work with lists from [bzlparty/lib_common](https://github.com/bzlparty/lib_common/blob/main/defs.bzl) as discussed in #495.

I removed the `occurs` functions, this is not needed because of the `in`-operator.

Please let me know if I should add more tests/documentation.

### Type of change

- New feature or functionality (change which adds functionality)

**For changes visible to end-users**

- Relevant documentation has been updated

### Test plan

- New test cases added
