### PR TITLE
chore: pull in https://github.com/bazel-contrib/rules-template/pull/93

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -2,6 +2,15 @@
 
 set -o errexit -o nounset -o pipefail
 
+# Configuration for 'git archive'
+# see https://git-scm.com/docs/git-archive/2.40.0#ATTRIBUTES
+cat >.git/info/attributes <<EOF
+# Substitution for the VERSION placeholder at the top of this file
+MODULE.bazel export-subst
+# Omit folders that users don't need, making the distribution artifact smaller
+lib/tests export-ignore
+EOF
+
 # Set by GH actions, see
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 TAG=${GITHUB_REF_NAME}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,8 +1,11 @@
 "aspect-build/bazel-lib"
 
+# replaced by export-subst during 'git archive'
+VERSION = "$Format:%(describe:tags=true)$"
+
 module(
     name = "aspect_bazel_lib",
-    version = "0.0.0",
+    version = "0.0.0" if VERSION.startswith("$Format") else VERSION,
     compatibility_level = 1,
 )
 


### PR DESCRIPTION
This means we won't need a module_dot_bazel.patch file on BCR anymore.