### PR TITLE
fix: strip 'v' prefix from tag when setting module version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ VERSION = "$Format:%(describe:tags=true)$"
 
 module(
     name = "aspect_bazel_lib",
-    version = "0.0.0" if VERSION.startswith("$Format") else VERSION,
+    version = "0.0.0" if VERSION.startswith("$Format") else VERSION.replace("v", "", 1),
     compatibility_level = 1,
 )
 


### PR DESCRIPTION
### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Manual testing; please provide instructions so we can reproduce:
This was exposed by the BCR PR