### PR TITLE
refactor: invert the conditional for setting version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ VERSION = "$Format:%(describe:tags=true)$"
 
 module(
     name = "aspect_bazel_lib",
-    version = "0.0.0" if VERSION.startswith("$Format") else VERSION.replace("v", "", 1),
+    version = VERSION.replace("v", "", 1) if not VERSION.startswith("$Format") else "0.0.0",
     compatibility_level = 1,
 )
 


### PR DESCRIPTION
This evaluates the same way, but tricks the parser in Publish-to-BCR app into skipping any replacements
