### PR TITLE
fix(expand_template): correct output permissions

### DIFF
--- a/tools/expand_template/main.go
+++ b/tools/expand_template/main.go
@@ -68,9 +68,9 @@ func main() {
 		content = strings.ReplaceAll(content, key, value)
 	}
 
-	var mode os.FileMode = 0x666
+	var mode os.FileMode = 0666
 	if executable {
-		mode = 0o777
+		mode = 0777
 	}
 	err = os.WriteFile(args[1], []byte(content), mode)
 	if err != nil {


### PR DESCRIPTION
We used hexadecimal where we meant to use octal.
0x666 in binary is 11001100110 but 0666 is 110110110 (9 digits as expected)
so this was producing an output like
---xr--r-- 1 108 114 206 Sep  6 20:55 bazel-out/k8-opt/bin/stamped_labels.txt

we could fix both to explicit octal notation `0o666` and `0o777` but that's not what any of the "How to set permissions in Go" examples do. 

> An optional prefix sets a non-decimal base: 0b or 0B for binary, 0, 0o, or 0O for octal, and 0x or 0X for hexadecimal.

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

None, just visual inspection and reasoning