### PR TITLE
feat: support jq 1.7 toolchain

### DIFF
--- a/docs/jq.md
+++ b/docs/jq.md
@@ -105,7 +105,7 @@ jq(
         # This 'as' syntax results in $stamp being null in unstamped builds.
         "$ARGS.named.STAMP as $stamp",
         # Provide a default using the "alternative operator" in case $stamp is null.
-        ".version = ($stamp.BUILD_EMBED_LABEL // "<unstamped>")",
+        ".version = ($stamp[0].BUILD_EMBED_LABEL // "<unstamped>")",
     ]),
 )
 ```

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -113,7 +113,7 @@ Registers jq toolchain and repositories
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="register_jq_toolchains-name"></a>name |  override the prefix for the generated toolchain repositories   |  <code>"jq"</code> |
-| <a id="register_jq_toolchains-version"></a>version |  the version of jq to execute (see https://github.com/stedolan/jq/releases)   |  <code>"1.6"</code> |
+| <a id="register_jq_toolchains-version"></a>version |  the version of jq to execute (see https://github.com/stedolan/jq/releases)   |  <code>"1.7"</code> |
 | <a id="register_jq_toolchains-register"></a>register |  whether to call through to native.register_toolchains. Should be True for WORKSPACE users, but false when used under bzlmod extension   |  <code>True</code> |
 
 

--- a/lib/jq.bzl
+++ b/lib/jq.bzl
@@ -104,7 +104,7 @@ def jq(name, srcs, filter = None, filter_file = None, args = [], out = None, **k
             # This 'as' syntax results in $stamp being null in unstamped builds.
             "$ARGS.named.STAMP as $stamp",
             # Provide a default using the "alternative operator" in case $stamp is null.
-            ".version = ($stamp.BUILD_EMBED_LABEL // \"<unstamped>\")",
+            ".version = ($stamp[0].BUILD_EMBED_LABEL // \"<unstamped>\")",
         ]),
     )
     ```

--- a/lib/private/jq.bzl
+++ b/lib/private/jq.bzl
@@ -57,14 +57,7 @@ def _jq_impl(ctx):
         )
         inputs.append(stamp_json)
 
-        # jq says of --argfile:
-        # > Do not use. Use --slurpfile instead.
-        # > (This option is like --slurpfile, but when the file has just one text,
-        # > then that is used, else an array of texts is used as in --slurpfile.)
-        # However there's no indication that it's deprecated. Maybe it's a style convention.
-        # For our purposes, "$STAMP.BUILD_TIMESTAMP" looks a lot more sensible in a BUILD file
-        # than "$STAMP[0].BUILD_TIMESTAMP".
-        args = args + ["--argfile", "STAMP", stamp_json.path]
+        args = args + ["--slurpfile", "STAMP", stamp_json.path]
 
     cmd = "{jq} {args} {filter} {sources} > {out}".format(
         jq = jq_bin.path,

--- a/lib/private/jq_toolchain.bzl
+++ b/lib/private/jq_toolchain.bzl
@@ -5,30 +5,31 @@ load(":repo_utils.bzl", "repo_utils")
 # Platform names follow the platform naming convention in @aspect_bazel_lib//:lib/private/repo_utils.bzl
 JQ_PLATFORMS = {
     "darwin_amd64": struct(
-        release_platform = "osx-amd64",
+        release_platform = "macos-amd64",
         compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
         ],
     ),
     "darwin_arm64": struct(
-        # JQ only ships a universal binary; it should work on
-        # Apple Silicon (aarch64) as well.
-        release_platform = "osx-amd64",
+        release_platform = "macos-arm64",
         compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:aarch64",
         ],
     ),
-    # There is currently no linux-arm64 JQ toolchain, as there is no upstream binary.
-    # The alternative is to either build JQ manually from source, or use YQ which has the same functionality as JQ,
-    # and bazel-lib provides an linux-arm64 toolchain for.
-    # See https://github.com/aspect-build/bazel-lib/issues/268
     "linux_amd64": struct(
-        release_platform = "linux64",
+        release_platform = "linux-amd64",
         compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
+        ],
+    ),
+    "linux_arm64": struct(
+        release_platform = "linux-arm64",
+        compatible_with = [
+            "@platforms//os:linux",
+            "@platforms//cpu:aarch64",
         ],
     ),
     "windows_amd64": struct(
@@ -40,22 +41,19 @@ JQ_PLATFORMS = {
     ),
 }
 
-DEFAULT_JQ_VERSION = "1.6"
+DEFAULT_JQ_VERSION = "1.7"
 
 # https://github.com/stedolan/jq/releases
 #
 # The integrity hashes can be computed with
 # shasum -b -a 384 [downloaded file] | awk '{ print $1 }' | xxd -r -p | base64
 JQ_VERSIONS = {
-    "1.6": {
-        "linux64": "sha384-+K6tuwxrC/P4WBYRJ7YXcpeLS7GesbbnUhq4r9w7k0lCUC1KlhyXXf0sFQgOg0dI",
-        "osx-amd64": "sha384-ZLZljM9OyKCJbJbv7s1SRYSeMbVxfRc6kFNUlk9U/IL10Xm2xr4cxx3SZKv93QFO",
-        "win64": "sha384-O4qdyhb+0zU1XAuUKc1Mil5hlbSbCUcPQOGRtkJUqryv7X0IeKcMCIuZw97q9WGr",
-    },
-    "1.5": {
-        "linux64": "sha384-/Su0ihtb867nCQTzQlTHjve+KpwfzsPws5ILj6hl7k33Qw+FwnyxAVITDh/pOOYw",
-        "osx-amd64": "sha384-X3VGwLkqaLafis82SySkqFPGIiJMdWdzcHPWLJ0q87XF+MGVc/e2n65a1yMBW6Nf",
-        "win64": "sha384-NtaejeSFoKaXxxT1nPqxdOWRmIZAFF8wFTKjqs/4W0qYMYLohmO73AGKKR2XIg84",
+    "1.7": {
+        "linux-amd64": "sha384-4wJ15NoxFf7r1Zf5YVGUeMPx/pfWlSfMJWLFcu4fUcBFe5L4BOpF/njEK8AH58od",
+        "linux-arm64": "sha384-y9BwX+RyXf2a16xwtvcjHFfIBp3K3Ukyg4GjtmxBtynD/BKNf+0tuLtZx64TTI+/",
+        "macos-amd64": "sha384-N0WdpiD8zl1k9888yGxWW/dHzztOTU+RTlZrzOYJMXXUUMqjnqXq8GwnHDsC9Lk3",
+        "macos-arm64": "sha384-0nnKlrEAU7NCzTM63XYkhAGGapA/IT2O2jkU+H+ZbQFu3E+XEbgw5E/+o0oHjLGf",
+        "win64": "sha384-2QfBgUpi1I5KPVrKtZnPcur+Wn/iE+tZVPFKXiIPoBKTpqZKhzc/CdqjcBn+IPiy",
     },
 }
 

--- a/lib/tests/jq/BUILD.bazel
+++ b/lib/tests/jq/BUILD.bazel
@@ -105,8 +105,8 @@ diff_test(
             # Don't directly reference $STAMP as it's only set when stamping
             "$ARGS.named.STAMP as $stamp",
             # Provide a default using the "alternative operator"
-            ".foo = ($stamp.BUILD_EMBED_LABEL // \"<unstamped>\")",
-            ".value = ($stamp.BUILD_TIMESTAMP // 1 | tonumber)",
+            ".foo = ($stamp[0].BUILD_EMBED_LABEL // \"<unstamped>\")",
+            ".value = ($stamp[0].BUILD_TIMESTAMP // 1 | tonumber)",
         ]),
         stamp = stamp,
     )


### PR DESCRIPTION
Fixes https://github.com/aspect-build/bazel-lib/issues/268

### Type of change

- New feature or functionality (change which adds functionality)

**For changes visible to end-users**
- Suggested release notes are provided below:
- Jq 1.7 is now supported which has a wider selection of platform binaries
- BREAKING: jq stamp variables are now of the form `$stamp[0].MY_VARIABLE` rather than `$stamp.MY_VARIABLE`.
### Test plan

- Covered by existing test cases
