### PR TITLE
docs: Add --incompatible_disallow_empty_glob to correctness.bazelrc

### DIFF
--- a/.aspect/bazelrc/correctness.bazelrc
+++ b/.aspect/bazelrc/correctness.bazelrc
@@ -60,3 +60,9 @@ query --experimental_allow_tags_propagation
 # https://github.com/bazelbuild/bazel/issues/10076.
 # Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_default_to_explicit_init_py
 build --incompatible_default_to_explicit_init_py
+
+# Set default value of `allow_empty` to `False` in `glob()`. This prevents a common mistake when
+# attempting to use `glob()` to match files in a subdirectory that is opaque to the current package
+# because it contains a BUILD file. See https://github.com/bazelbuild/bazel/issues/8195.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_disallow_empty_glob
+common --incompatible_disallow_empty_glob

--- a/e2e/smoke/.aspect/bazelrc/correctness.bazelrc
+++ b/e2e/smoke/.aspect/bazelrc/correctness.bazelrc
@@ -60,3 +60,9 @@ query --experimental_allow_tags_propagation
 # https://github.com/bazelbuild/bazel/issues/10076.
 # Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_default_to_explicit_init_py
 build --incompatible_default_to_explicit_init_py
+
+# Set default value of `allow_empty` to `False` in `glob()`. This prevents a common mistake when
+# attempting to use `glob()` to match files in a subdirectory that is opaque to the current packages
+# because it contains a BUILD file. See https://github.com/bazelbuild/bazel/issues/8195.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_disallow_empty_glob
+common --incompatible_disallow_empty_glob

--- a/e2e/smoke/.aspect/bazelrc/correctness.bazelrc
+++ b/e2e/smoke/.aspect/bazelrc/correctness.bazelrc
@@ -62,7 +62,7 @@ query --experimental_allow_tags_propagation
 build --incompatible_default_to_explicit_init_py
 
 # Set default value of `allow_empty` to `False` in `glob()`. This prevents a common mistake when
-# attempting to use `glob()` to match files in a subdirectory that is opaque to the current packages
+# attempting to use `glob()` to match files in a subdirectory that is opaque to the current package
 # because it contains a BUILD file. See https://github.com/bazelbuild/bazel/issues/8195.
 # Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_disallow_empty_glob
 common --incompatible_disallow_empty_glob

--- a/lib/private/utils.bzl
+++ b/lib/private/utils.bzl
@@ -133,7 +133,7 @@ def _file_exists(path):
     label = _to_label(path)
     file_abs = "%s/%s" % (label.package, label.name)
     file_rel = file_abs[len(native.package_name()) + 1:]
-    file_glob = native.glob([file_rel], exclude_directories = 1)
+    file_glob = native.glob([file_rel], exclude_directories = 1, allow_empty=True)
     return len(file_glob) > 0
 
 def _default_timeout(size, timeout):

--- a/lib/private/utils.bzl
+++ b/lib/private/utils.bzl
@@ -133,7 +133,7 @@ def _file_exists(path):
     label = _to_label(path)
     file_abs = "%s/%s" % (label.package, label.name)
     file_rel = file_abs[len(native.package_name()) + 1:]
-    file_glob = native.glob([file_rel], exclude_directories = 1, allow_empty=True)
+    file_glob = native.glob([file_rel], exclude_directories = 1, allow_empty = True)
     return len(file_glob) > 0
 
 def _default_timeout(size, timeout):

--- a/lib/tests/bazelrc_presets/all/correctness.bazelrc
+++ b/lib/tests/bazelrc_presets/all/correctness.bazelrc
@@ -60,3 +60,9 @@ query --experimental_allow_tags_propagation
 # https://github.com/bazelbuild/bazel/issues/10076.
 # Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_default_to_explicit_init_py
 build --incompatible_default_to_explicit_init_py
+
+# Set default value of `allow_empty` to `False` in `glob()`. This prevents a common mistake when
+# attempting to use `glob()` to match files in a subdirectory that is opaque to the current package
+# because it contains a BUILD file. See https://github.com/bazelbuild/bazel/issues/8195.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_disallow_empty_glob
+common --incompatible_disallow_empty_glob


### PR DESCRIPTION
This is a good flag to enable by default because it prevents a common mistake and usually is what users expect.

---
### Type of change
- Documentation (updates to documentation or READMEs)

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config)
  - When updating their bazelrc to include this, some users may need to fix broken BUILD files or specify `allow_empty=True` when they were intentionally relying on the previous behavior.
### Test plan
Not sure this applies here.
