### PR TITLE
fix: allow for BUILD files in outputs of write_source_file

### DIFF
--- a/lib/private/write_source_file.bzl
+++ b/lib/private/write_source_file.bzl
@@ -372,4 +372,11 @@ def _is_file_missing(label):
     file_abs = "%s/%s" % (label.package, label.name)
     file_rel = file_abs[len(native.package_name()) + 1:]
     file_glob = native.glob([file_rel], exclude_directories = 0, allow_empty = True)
-    return len(file_glob) == 0
+
+    # Check for subpackages in case the expected output contains BUILD files,
+    # the above files glob will return empty.
+    subpackage_glob = []
+    if hasattr(native, "subpackages"):
+        subpackage_glob = native.subpackages(include = [file_rel], allow_empty = True)
+
+    return len(file_glob) == 0 and len(subpackage_glob) == 0

--- a/lib/tests/write_source_files/build_files_in_outs/BUILD.bazel
+++ b/lib/tests/write_source_files/build_files_in_outs/BUILD.bazel
@@ -1,0 +1,33 @@
+load("//lib:write_source_files.bzl", "write_source_file")
+load("//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+
+write_file(
+    name = "write_build",
+    out = "BUILD",
+    content = [
+        "# Marker for a package",
+        "",
+    ],
+)
+
+write_file(
+    name = "write_other",
+    out = "other.txt",
+    content = ["Another file"],
+)
+
+copy_to_directory(
+    name = "dir",
+    srcs = [
+        ":BUILD",
+        ":other.txt",
+    ],
+)
+
+# This will cause an analysis failure if "expected_out" is considered missing.
+write_source_file(
+    name = "build_files_in_outs",
+    in_file = ":dir",
+    out_file = ":expected_out",
+)

--- a/lib/tests/write_source_files/build_files_in_outs/expected_out/BUILD
+++ b/lib/tests/write_source_files/build_files_in_outs/expected_out/BUILD
@@ -1,0 +1,1 @@
+# Marker for a package

--- a/lib/tests/write_source_files/build_files_in_outs/expected_out/other.txt
+++ b/lib/tests/write_source_files/build_files_in_outs/expected_out/other.txt
@@ -1,0 +1,1 @@
+Another file


### PR DESCRIPTION
Handles the case in `write_source_file` where the generated output directory contains `BUILD` files, which can not be globbed through, resulting in incorrect failure states for missing output files.

Closes #536

---

### Type of change

- Bug fix (change which fixes an issue)

**For changes visible to end-users**

- Suggested release notes are provided below:

Handle `BUILD` files in the output of `write_source_file`

### Test plan

- New test cases added