### PR TITLE
docs: add minimum pre-commit version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Starlark files should be formatted by buildifier.
 We suggest using a pre-commit hook to automate this.
-First [install pre-commit](https://pre-commit.com/#installation),
+First [install pre-commit](https://pre-commit.com/#installation) (>= v3.2.0),
 then run
 
 ```shell


### PR DESCRIPTION
ensure developers have the right version to run all used hooks.

I was running into an error when trying to commit after the latest changes to [`.pre-commit-config.yaml`](https://github.com/aspect-build/bazel-lib/pull/532/commits/de0b477a0b27779b8245adfd0e30683bf9ffbdab), so I thought it might be useful to document the minimum version of `pre-commit` needed to ensure all hooks fired properly.

BTW, I had version v.3.1.0 installed and could not handle the `pre-push` hook

---

### Type of change

- Documentation (updates to documentation or READMEs)
