### PR TITLE
refactor: use list utils

### DIFF
--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -113,7 +113,10 @@ bzl_library(
 bzl_library(
     name = "directory_path",
     srcs = ["directory_path.bzl"],
-    deps = ["//lib/private/docs:directory_path"],
+    deps = [
+        "//lib/private/docs:directory_path",
+        "//lib/private/docs:lists",
+    ],
 )
 
 bzl_library(
@@ -181,7 +184,10 @@ bzl_library(
 bzl_library(
     name = "yq",
     srcs = ["yq.bzl"],
-    deps = ["//lib/private/docs:yq"],
+    deps = [
+        "//lib/private/docs:lists",
+        "//lib/private/docs:yq",
+    ],
 )
 
 bzl_library(

--- a/lib/private/directory_path.bzl
+++ b/lib/private/directory_path.bzl
@@ -2,6 +2,7 @@
 with a path nested within that directory
 """
 
+load("//lib:lists.bzl", "map")
 load("//lib:utils.bzl", _to_label = "to_label")
 
 DirectoryPathInfo = provider(
@@ -116,8 +117,7 @@ def make_directory_paths(name, dict, **kwargs):
     pairs = []
     for directory, val in dict.items():
         if type(val) == "list":
-            for path in val:
-                pairs.append((directory, path))
+            pairs.extend(map(lambda path: (directory, path), val))
         elif type(val) == "string":
             pairs.append((directory, val))
         else:

--- a/lib/private/docs/BUILD.bazel
+++ b/lib/private/docs/BUILD.bazel
@@ -164,7 +164,10 @@ bzl_library(
 bzl_library(
     name = "directory_path",
     srcs = ["//lib/private:directory_path.bzl"],
-    deps = ["//lib:utils"],
+    deps = [
+        "//lib:lists",
+        "//lib:utils",
+    ],
 )
 
 bzl_library(
@@ -179,6 +182,9 @@ bzl_library(
         "//lib:utils",
         "//lib/private:diff_test.bzl",
         "//lib/private:directory_path.bzl",
+    ],
+    deps = [
+        "//lib:lists",
     ],
 )
 
@@ -224,7 +230,10 @@ bzl_library(
 bzl_library(
     name = "yq",
     srcs = ["//lib/private:yq.bzl"],
-    deps = ["//lib:stamping"],
+    deps = [
+        "//lib:lists",
+        "//lib:stamping",
+    ],
 )
 
 bzl_library(

--- a/lib/private/write_source_file.bzl
+++ b/lib/private/write_source_file.bzl
@@ -3,6 +3,7 @@
 load(":directory_path.bzl", "DirectoryPathInfo")
 load(":diff_test.bzl", _diff_test = "diff_test")
 load(":fail_with_message_test.bzl", "fail_with_message_test")
+load(":lists.bzl", "map")
 load(":utils.bzl", "utils")
 
 WriteSourceFileInfo = provider(
@@ -177,9 +178,7 @@ def _write_source_file_sh(ctx, paths):
         ctx.label.name + "_update.sh",
     )
 
-    additional_update_scripts = []
-    for target in ctx.attr.additional_update_targets:
-        additional_update_scripts.append(target[WriteSourceFileInfo].executable)
+    additional_update_scripts = map(lambda t: t[WriteSourceFileInfo].executable, ctx.attr.additional_update_targets)
 
     contents = ["""#!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail

--- a/lib/private/yq.bzl
+++ b/lib/private/yq.bzl
@@ -1,5 +1,6 @@
 """Implementation for yq rule"""
 
+load("//lib:lists.bzl", "map", "some")
 load("//lib:stamping.bzl", "STAMP_ATTRS", "maybe_stamp")
 
 _yq_attrs = dict({
@@ -18,13 +19,13 @@ _yq_attrs = dict({
 }, **STAMP_ATTRS)
 
 def is_split_operation(args):
-    for arg in args:
-        if arg.startswith("-s") or arg.startswith("--split-exp"):
-            return True
-    return False
+    return some(lambda arg: arg.startswith("-s") or arg.startswith("--split-exp"), args)
+
+def _map_to(value, arr):
+    return map(lambda _: value, arr)
 
 def _escape_path(path):
-    return "/".join([".." for t in path.split("/")]) + "/"
+    return "/".join(_map_to("..", path.split("/"))) + "/"
 
 def _yq_impl(ctx):
     yq_bin = ctx.toolchains["@aspect_bazel_lib//lib:yq_toolchain_type"].yqinfo.bin

--- a/lib/private/yq.bzl
+++ b/lib/private/yq.bzl
@@ -1,6 +1,6 @@
 """Implementation for yq rule"""
 
-load("//lib:lists.bzl", "map", "some")
+load("//lib:lists.bzl", "some")
 load("//lib:stamping.bzl", "STAMP_ATTRS", "maybe_stamp")
 
 _yq_attrs = dict({
@@ -21,11 +21,8 @@ _yq_attrs = dict({
 def is_split_operation(args):
     return some(lambda arg: arg.startswith("-s") or arg.startswith("--split-exp"), args)
 
-def _map_to(value, arr):
-    return map(lambda _: value, arr)
-
 def _escape_path(path):
-    return "/".join(_map_to("..", path.split("/"))) + "/"
+    return "/".join(["../" * len(path.split("/"))])
 
 def _yq_impl(ctx):
     yq_bin = ctx.toolchains["@aspect_bazel_lib//lib:yq_toolchain_type"].yqinfo.bin

--- a/lib/private/yq.bzl
+++ b/lib/private/yq.bzl
@@ -22,7 +22,7 @@ def is_split_operation(args):
     return some(lambda arg: arg.startswith("-s") or arg.startswith("--split-exp"), args)
 
 def _escape_path(path):
-    return "/".join(["../" * len(path.split("/"))])
+    return "../" * len(path.split("/"))
 
 def _yq_impl(ctx):
     yq_bin = ctx.toolchains["@aspect_bazel_lib//lib:yq_toolchain_type"].yqinfo.bin


### PR DESCRIPTION
from https://github.com/aspect-build/bazel-lib/issues/495#issuecomment-1675960410:

> We should figure out a place to "dogfood" this so we have the experience of being a user of the new API. Maybe we can refactor other code in bazel-lib to use these.

Both refactorings use lambda expressions. These are available from [bazel 5.0](https://blog.bazel.build/2022/01/19/bazel-5.0.html#highlights). Is there a minimum version of bazel that bazel-lib needs to support?

---

<!-- Delete this comment! Follow our PR template instructions: https://github.com/aspect-build/.github/blob/main/pull_requests.md -->

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

### Test plan

- Covered by existing test cases
