### PR TITLE
chore: rules_go is a non-dev dep at HEAD

### DIFF
--- a/.bcr/patches/go_dev_dep.patch
+++ b/.bcr/patches/go_dev_dep.patch
@@ -1,0 +1,16 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index f05c57a..4cb6104 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -28,9 +28,9 @@ register_toolchains(
+ # To allow /tools to be built from source
+ # NOTE: when publishing to BCR, we patch this to be dev_dependency, as we publish pre-built binaries
+ # along with our releases.
+-bazel_dep(name = "rules_go", version = "0.41.0", repo_name = "io_bazel_rules_go")
++bazel_dep(name = "rules_go", version = "0.41.0", repo_name = "io_bazel_rules_go", dev_dependency = True)
+
+-go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
++go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps", dev_dependency = True)
+ go_deps.from_file(go_mod = "//:go.mod")
+ use_repo(
+     go_deps,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,10 +173,6 @@ jobs:
         if: matrix.bzlmodEnabled
         run: echo "bzlmod_flag=--enable_bzlmod" >> $GITHUB_OUTPUT
 
-      - name: Make dev dependencies available (bzlmod)
-        if: matrix.bzlmodEnabled
-        run: sed -i${{ matrix.os == 'macos-latest' && ' ""' || '' }} 's/dev_dependency = True/dev_dependency = False/g' MODULE.bazel
-
       - name: Write rbe credentials
         if: ${{ matrix.config == 'rbe' }}
         working-directory: ${{ matrix.folder }}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,13 +26,11 @@ register_toolchains(
 )
 
 # To allow /tools to be built from source
-bazel_dep(name = "rules_go", version = "0.41.0", dev_dependency = True, repo_name = "io_bazel_rules_go")
+# NOTE: when publishing to BCR, we patch this to be dev_dependency, as we publish pre-built binaries
+# along with our releases.
+bazel_dep(name = "rules_go", version = "0.41.0", repo_name = "io_bazel_rules_go")
 
-go_deps = use_extension(
-    "@gazelle//:extensions.bzl",
-    "go_deps",
-    dev_dependency = True,
-)
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 use_repo(
     go_deps,


### PR DESCRIPTION
This ensures if a bzlmod user were to fetch bazel-lib with a SHA or a `git_repository`, they don't need to patch our repo (similar to how CI was doing it) in order to build the tools/ from head