### PR TITLE
feat(presets): always fetch all coverage files on coverage runs

### DIFF
--- a/.aspect/bazelrc/correctness.bazelrc
+++ b/.aspect/bazelrc/correctness.bazelrc
@@ -66,3 +66,10 @@ build --incompatible_default_to_explicit_init_py
 # because it contains a BUILD file. See https://github.com/bazelbuild/bazel/issues/8195.
 # Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_disallow_empty_glob
 common --incompatible_disallow_empty_glob
+
+# Always download coverage files for tests from the remote cache. By default, coverage files are not
+# downloaded on test result cahce hits when --remote_download_minimal is enabled, making it impossible
+# to generate a full coverage report.
+# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_fetch_all_coverage_outputs
+# detching remote cache results
+test --experimental_fetch_all_coverage_outputs

--- a/lib/tests/bazelrc_presets/all/correctness.bazelrc
+++ b/lib/tests/bazelrc_presets/all/correctness.bazelrc
@@ -66,3 +66,10 @@ build --incompatible_default_to_explicit_init_py
 # because it contains a BUILD file. See https://github.com/bazelbuild/bazel/issues/8195.
 # Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_disallow_empty_glob
 common --incompatible_disallow_empty_glob
+
+# Always download coverage files for tests from the remote cache. By default, coverage files are not
+# downloaded on test result cahce hits when --remote_download_minimal is enabled, making it impossible
+# to generate a full coverage report.
+# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_fetch_all_coverage_outputs
+# detching remote cache results
+test --experimental_fetch_all_coverage_outputs


### PR DESCRIPTION
So that combined coverage reports make sense when build without the bytes is enabled.

### Type of change

- New feature or functionality (change which adds functionality)

**For changes visible to end-users**
- Suggested release notes are provided below:
- `--experimental_fetch_all_coverage_outputs` is now enabled in the correctness bazelrc presets
### Test plan

- Covered by existing test cases