### PR TITLE
chore: drop GHA CI for linux

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,6 +92,10 @@ jobs:
           - "e2e/copy_to_directory"
           - "e2e/smoke"
         exclude:
+          # This runs on Aspect Workflows
+          - bazelversion: 6.3.2
+            os: ubuntu-latest
+            bzlmodEnabled: false
           # Don't test Bazel 5.3 with bzlmod. (Unrecognized option: --enable_bzlmod)
           - bzlmodEnabled: true
             bazelversion: 5.4.1
@@ -128,15 +132,6 @@ jobs:
     steps:
       # Checks-out your repository under ${{ github.workspace }} , so your job can access it
       - uses: actions/checkout@v4
-
-      - name: Mount bazel caches
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/bazel
-            ~/.cache/bazel-repo
-          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
-          restore-keys: bazel-cache-
 
       - name: Configure Bazel version
         if: ${{ matrix.os != 'windows-latest' }}


### PR DESCRIPTION
We are using Aspect Workflows so it's redundant
