### PR TITLE
Avoid expanding mtree spec during analysis phase

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, 2.x]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bazel-*
 **/.terraform/*
 test-out/
+.DS_Store

--- a/lib/private/tar.bzl
+++ b/lib/private/tar.bzl
@@ -118,9 +118,6 @@ def _mtree_impl(ctx):
     content = ctx.actions.args()
     content.set_param_file_format("multiline")
     content.add_all(ctx.files.srcs, map_each = _default_mtree_line)
-    # TODO(zbarsky): do we need this blank line? Tests pass on OSX without it for me.
-    #content.add("")
-
     ctx.actions.write(out, content = content)
 
     return DefaultInfo(files = depset([out]), runfiles = ctx.runfiles([out]))


### PR DESCRIPTION
Seeing what CI thinks, I didn't see why we need the empty line at the end of the file

### Type of change

- Bug fix (change which fixes an issue)
- New feature or functionality (change which adds functionality)
- Style (white-space, formatting, etc...)
- Refactor (a code change that neither fixes a bug or adds a new feature)
**- Performance (a code change that improves performance)**
- Documentation (updates to documentation or READMEs)
- Chore (any other change that doesn't affect source or test files, such as configuration)

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config)
- Relevant documentation has been updated
- Suggested release notes are provided below:

### Test plan

**- Covered by existing test cases**
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
