### PR TITLE
chore: remove expand_template re-export

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ For example to use commit `abc123`:
 
 ## Writing rules
 
-- [expand_make_vars](docs/expand_make_vars.md) Perform make variable and location substitions in strings and templates.
+- [expand_make_vars](docs/expand_make_vars.md) Perform make variable and location substitions in strings..
+- [expand_template](docs/expand_template.md) Substitute templates with make variables, location resolves, stamp variables, and arbitrary strings.
 - [paths](docs/paths.md) Useful path resolution methods.
 - [transitions](docs/transitions.md) Transition sources to a provided platform.
 - [lists](docs/lists.md) Functional-style helpers for working with list data structures.

--- a/docs/expand_make_vars.md
+++ b/docs/expand_make_vars.md
@@ -49,26 +49,6 @@ The deprecated `$(location)` and `$(locations)` expansions returns either the ex
 The expanded path or the original path
 
 
-<a id="expand_template"></a>
-
-## expand_template
-
-<pre>
-expand_template(<a href="#expand_template-name">name</a>, <a href="#expand_template-template">template</a>, <a href="#expand_template-kwargs">kwargs</a>)
-</pre>
-
-Wrapper macro for `expand_template_rule`.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="expand_template-name"></a>name |  name of resulting rule   |  none |
-| <a id="expand_template-template"></a>template |  the label of a template file, or a list of strings which are lines representing the content of the template.   |  none |
-| <a id="expand_template-kwargs"></a>kwargs |  other named parameters to <code>expand_template_rule</code>.   |  none |
-
-
 <a id="expand_variables"></a>
 
 ## expand_variables

--- a/lib/expand_make_vars.bzl
+++ b/lib/expand_make_vars.bzl
@@ -2,10 +2,6 @@
 
 load("//lib/private:expand_locations.bzl", _expand_locations = "expand_locations")
 load("//lib/private:expand_variables.bzl", _expand_variables = "expand_variables")
-load(":expand_template.bzl", _expand_template = "expand_template")
 
 expand_locations = _expand_locations
 expand_variables = _expand_variables
-
-# TODO: 2.0 remove re-export from this file.
-expand_template = _expand_template

--- a/lib/tests/BUILD.bazel
+++ b/lib/tests/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("//lib:expand_make_vars.bzl", "expand_template")
+load("//lib:expand_template.bzl", "expand_template")
 load("//lib:testing.bzl", "assert_contains")
 load(":base64_tests.bzl", "base64_test_suite")
 load(":expand_make_vars_test.bzl", "expand_make_vars_test_suite")

--- a/lib/tests/expand_template/BUILD.bazel
+++ b/lib/tests/expand_template/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
-load("@aspect_bazel_lib//lib:expand_make_vars.bzl", "expand_template")
+load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
 load("@aspect_bazel_lib//lib:testing.bzl", "assert_contains")
 
 expand_template(


### PR DESCRIPTION
### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config)
- Relevant documentation has been updated
- Suggested release notes are provided below:
- The import for `expand_template` has moved from `@aspect_bazel_lib//lib:expand_make_vars.bzl` to `@aspect_bazel_lib//lib:expand_template.bzl`.

### Test plan

- Covered by existing test cases


