### PR TITLE
chore: drop Bazel 5 support for 2.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,10 +43,8 @@ jobs:
         run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
       - id: bazel_7
         run: echo "bazelversion=7.0.0-pre.20230530.3" >> $GITHUB_OUTPUT
-      - id: bazel_5
-        run: echo "bazelversion=5.4.1" >> $GITHUB_OUTPUT
     outputs:
-      # Will look like '["<version from .bazelversion>", "7.0.0-pre.*", "5.4.1"]'
+      # Will look like '["<version from .bazelversion>", "7.0.0-pre.*"]'
       bazelversions: ${{ toJSON(steps.*.outputs.bazelversion) }}
 
   matrix-prep-os:
@@ -92,23 +90,14 @@ jobs:
           - "e2e/copy_to_directory"
           - "e2e/smoke"
         exclude:
-          # Don't test Bazel 5.3 with bzlmod. (Unrecognized option: --enable_bzlmod)
-          - bzlmodEnabled: true
-            bazelversion: 5.4.1
           # Don't test MacOS with RBE to minimize MacOS minutes (billed at 10X)
           - config: rbe
-            os: macos-latest
-          # Don't test MacOS with Bazel 5 to minimize MacOS minutes (billed at 10X)
-          - bazelversion: 5.4.1
             os: macos-latest
           # Don't test MacOS with Bazel 7 to minimize MacOS minutes (billed at 10X)
           - bazelversion: 7.0.0-pre.20230530.3
             os: macos-latest
           # Don't test Windows with RBE to minimize Windows minutes (billed at 2X)
           - config: rbe
-            os: windows-latest
-          # Don't test Windows with Bazel 5 to minimize Windows minutes (billed at 2X)
-          - bazelversion: 5.4.1
             os: windows-latest
           # Don't test Windows with Bazel 7 to minimize Windows minutes (billed at 2X)
           - bazelversion: 7.0.0-pre.20230530.3

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,6 +3,7 @@
 module(
     name = "aspect_bazel_lib",
     version = "0.0.0",
+    bazel_compatibility = [">=6.0.0"],
     compatibility_level = 1,
 )
 


### PR DESCRIPTION
### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

**For changes visible to end-users**

- Suggested release notes are provided below:
Bazel 5 is no longer officially supported by bazel-lib starting with 2.0.

### Test plan

- Covered by existing test cases
