### PR TITLE
refactor: remove to_workspace_path and to_manifest_path from paths

### DIFF
--- a/docs/paths.md
+++ b/docs/paths.md
@@ -32,49 +32,6 @@ For example, 'relative_file("../foo/foo.txt", "bar/bar.txt")' will return '../..
 The relative path from frm_file to to_file, including the file name
 
 
-<a id="to_manifest_path"></a>
-
-## to_manifest_path
-
-<pre>
-to_manifest_path(<a href="#to_manifest_path-ctx">ctx</a>, <a href="#to_manifest_path-file">file</a>)
-</pre>
-
-The rlocation path for a `File`
-
-This produces the same value as the `rlocationpath` predefined source/output path variable.
-
-From https://bazel.build/reference/be/make-variables#predefined_genrule_variables:
-
-> `rlocationpath`: The path a built binary can pass to the `Rlocation` function of a runfiles
-> library to find a dependency at runtime, either in the runfiles directory (if available)
-> or using the runfiles manifest.
-
-> This is similar to root path (a.k.a. [short_path](https://bazel.build/rules/lib/File#short_path))
-> in that it does not contain configuration prefixes, but differs in that it always starts with the
-> name of the repository.
-
-> The rlocation path of a `File` in an external repository repo will start with `repo/`, followed by the
-> repository-relative path.
-
-> Passing this path to a binary and resolving it to a file system path using the runfiles libraries
-> is the preferred approach to find dependencies at runtime. Compared to root path, it has the
-> advantage that it works on all platforms and even if the runfiles directory is not available.
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="to_manifest_path-ctx"></a>ctx |  starlark rule execution context   |  none |
-| <a id="to_manifest_path-file"></a>file |  a <code>File</code> object   |  none |
-
-**RETURNS**
-
-The rlocationpath for the `File`
-
-
 <a id="to_output_relative_path"></a>
 
 ## to_output_relative_path
@@ -166,33 +123,5 @@ From https://bazel.build/reference/be/make-variables#predefined_genrule_variable
 **RETURNS**
 
 The rlocationpath for the `File`
-
-
-<a id="to_workspace_path"></a>
-
-## to_workspace_path
-
-<pre>
-to_workspace_path(<a href="#to_workspace_path-file">file</a>)
-</pre>
-
-The repository relative path for a `File`
-
-This is the full runfiles path of a `File` excluding its workspace name.
-
-This differs from  root path (a.k.a. [short_path](https://bazel.build/rules/lib/File#short_path)) and
-rlocation path as it does not include the repository name if the `File` is from an external repository.
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="to_workspace_path-file"></a>file |  a <code>File</code> object   |  none |
-
-**RETURNS**
-
-The repository relative path for the `File`
 
 

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -292,4 +292,5 @@ bzl_library(
 bzl_library(
     name = "windows_utils",
     srcs = ["windows_utils.bzl"],
+    deps = ["//lib/private:paths"],
 )

--- a/lib/paths.bzl
+++ b/lib/paths.bzl
@@ -7,10 +7,6 @@ to_output_relative_path = paths.to_output_relative_path
 to_repository_relative_path = paths.to_repository_relative_path
 to_rlocation_path = paths.to_rlocation_path
 
-# deprecated namings
-to_manifest_path = paths.to_manifest_path  # equivalent to to_rlocation_path
-to_workspace_path = paths.to_workspace_path  # equivalent to to_repository_relative_path
-
 # Bash helper function for looking up runfiles.
 # See windows_utils.bzl for the cmd.exe equivalent.
 # Vendored from

--- a/lib/private/copy_to_directory.bzl
+++ b/lib/private/copy_to_directory.bzl
@@ -456,7 +456,7 @@ def copy_to_directory_bin_action(
             path = f.path,
             root_path = f.root.path,
             short_path = f.short_path,
-            workspace_path = paths.to_workspace_path(f),
+            workspace_path = paths.to_repository_relative_path(f),
         ))
     for t in targets:
         if not DirectoryPathInfo in t:
@@ -466,7 +466,7 @@ def copy_to_directory_bin_action(
             path = "/".join([t[DirectoryPathInfo].directory.path, t[DirectoryPathInfo].path]),
             root_path = t[DirectoryPathInfo].directory.root.path,
             short_path = "/".join([t[DirectoryPathInfo].directory.short_path, t[DirectoryPathInfo].path]),
-            workspace_path = "/".join([paths.to_workspace_path(t[DirectoryPathInfo].directory), t[DirectoryPathInfo].path]),
+            workspace_path = "/".join([paths.to_repository_relative_path(t[DirectoryPathInfo].directory), t[DirectoryPathInfo].path]),
         ))
 
     file_infos = []

--- a/lib/private/paths.bzl
+++ b/lib/private/paths.bzl
@@ -136,8 +136,4 @@ paths = struct(
     to_output_relative_path = _to_output_relative_path,
     to_repository_relative_path = _to_repository_relative_path,
     to_rlocation_path = _to_rlocation_path,
-    # TODO(2.0): remove to_workspace_path? it is replaced by to_repository_relative_path
-    to_workspace_path = _to_repository_relative_path,
-    # TODO(2.0): remove to_manifest_path? it is replaced by to_rlocation_path
-    to_manifest_path = _to_rlocation_path,
 )

--- a/lib/tests/paths_test.bzl
+++ b/lib/tests/paths_test.bzl
@@ -193,20 +193,12 @@ def _rlocation_path_test_impl(ctx):
     env = unittest.begin(ctx)
     asserts.equals(env, "bazel_skylib/LICENSE", paths.to_rlocation_path(ctx, ctx.file.f1))
     asserts.equals(env, "aspect_bazel_lib/lib/paths.bzl", paths.to_rlocation_path(ctx, ctx.file.f2))
-
-    # deprecated naming
-    asserts.equals(env, "bazel_skylib/LICENSE", paths.to_manifest_path(ctx, ctx.file.f1))
-    asserts.equals(env, "aspect_bazel_lib/lib/paths.bzl", paths.to_manifest_path(ctx, ctx.file.f2))
     return unittest.end(env)
 
 def _repository_relative_path_test_impl(ctx):
     env = unittest.begin(ctx)
     asserts.equals(env, "LICENSE", paths.to_repository_relative_path(ctx.file.f1))
     asserts.equals(env, "lib/paths.bzl", paths.to_repository_relative_path(ctx.file.f2))
-
-    # deprecated naming
-    asserts.equals(env, "LICENSE", paths.to_workspace_path(ctx.file.f1))
-    asserts.equals(env, "lib/paths.bzl", paths.to_workspace_path(ctx.file.f2))
     return unittest.end(env)
 
 def _output_relative_path_test_impl(ctx):

--- a/lib/windows_utils.bzl
+++ b/lib/windows_utils.bzl
@@ -14,6 +14,8 @@
 
 "Helpers for rules running on windows"
 
+load("//lib/private:paths.bzl", "paths")
+
 # cmd.exe function for looking up runfiles.
 # Equivalent of the BASH_RLOCATION_FUNCTION in paths.bzl.
 # Use this to write actions that don't require bash.
@@ -65,12 +67,6 @@ exit /b 0
 :: End of rlocation
 """
 
-def _to_manifest_path(ctx, file):
-    if file.short_path.startswith("../"):
-        return file.short_path[3:]
-    else:
-        return ctx.workspace_name + "/" + file.short_path
-
 def create_windows_native_launcher_script(ctx, shell_script):
     """Create a Windows Batch file to launch the given shell script.
 
@@ -106,7 +102,7 @@ if defined args (
 "{bash_bin}" -c "!run_script! !args!"
 """.format(
             bash_bin = ctx.toolchains["@bazel_tools//tools/sh:toolchain_type"].path,
-            sh_script = _to_manifest_path(ctx, shell_script),
+            sh_script = paths.to_rlocation_path(ctx, shell_script),
             rlocation_function = BATCH_RLOCATION_FUNCTION,
         ),
         is_executable = True,


### PR DESCRIPTION
Removes deprecated `to_workspace_path` and `to_manifest_path`. These functions were renamed to `to_repository_relative_path` and `to_rlocation_path` for clarity. The old names were kept around for backward compat in 1.x. This was a planned breaking change for the 2.0 release.

BREAKING CHANGES

- `to_workspace_path` helper function is removed from `paths`. Use `paths.to_repository_relative_path` instead.
- `to_manifest_path` helper function is removed from `paths`. Use `paths.to_rlocation_path` instead.

