### PR TITLE
fix: windows home directory

### DIFF
--- a/lib/private/repo_utils.bzl
+++ b/lib/private/repo_utils.bzl
@@ -48,9 +48,9 @@ def _get_env_var(rctx, name, default):
     """
 
     # On Windows, the HOME environment variable is named differently.
-    # See https://pureinfotech.com/list-environment-variables-windows-10/
+    # See https://en.wikipedia.org/wiki/Home_directory#Default_home_directory_per_operating_system
     if name == "HOME" and _is_windows(rctx):
-        name = "HOMEPATH"
+        name = "USERPROFILE"
     if name in rctx.os.environ:
         return rctx.os.environ[name]
     return default


### PR DESCRIPTION
HOMEPATH isn't always set. For example https://buildkite.com/bazel/bazel-bazel-examples/builds/2163#018b1a9d-0127-461f-8200-e89894397f35 USERPROFILE seems more widely documented as being the equivalent of HOME

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Manual testing; please provide instructions so we can reproduce:
Will verify downstream in a rules_oci usage