### PR TITLE
refactor: use _mtree_line helper

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,0 +1,2 @@
+BAZELISK_BASE_URL=https://github.com/aspect-build/aspect-cli/releases/download
+USE_BAZEL_VERSION=aspect/5.7.2

--- a/lib/private/tar.bzl
+++ b/lib/private/tar.bzl
@@ -154,10 +154,7 @@ def _mtree_impl(ctx):
         runfiles_dir = _calculate_runfiles_dir(default_info)
         for file in depset(transitive = [s.default_runfiles.files]).to_list():
             destination = _runfile_path(ctx, file, runfiles_dir)
-            content.add("{} uid=0 gid=0 mode=0755 time=1672560000 type=file content={}".format(
-                destination,
-                file.path,
-            ))
+            content.add(_mtree_line(destination, file.path, "file"))
 
     ctx.actions.write(out, content = content)
 


### PR DESCRIPTION
Also restore the .bazeliskrc file I accidentally removed in 4bfe55711aaf64c724cd353c00459b9132d6e2bf
