### PR TITLE
chore: remove bazel5 presets

### DIFF
--- a/.aspect/bazelrc/bazel5.bazelrc
+++ b/.aspect/bazelrc/bazel5.bazelrc
@@ -1,5 +1,0 @@
-# Performance improvement for WORKSPACE evaluation
-# of slow rulesets, for example rules_k8s has been
-# observed to take 10 seconds without this flag.
-# See https://github.com/bazelbuild/bazel/issues/13907
-common --incompatible_existing_rules_immutable_view

--- a/docs/bazelrc_presets.md
+++ b/docs/bazelrc_presets.md
@@ -27,7 +27,7 @@ See https://docs.aspect.build/guides/bazelrc for more info.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="write_aspect_bazelrc_presets-name"></a>name |  a unique name for this target   |  none |
-| <a id="write_aspect_bazelrc_presets-presets"></a>presets |  a list of preset names to keep up-to-date<br><br>For example,<br><br><pre><code> write_aspect_bazelrc_presets(   name = "update_aspect_bazelrc_presets",   presets = [     "bazel6",     "ci",     "convenience",     "correctness",     "debug",     "javascript",     "performance",   ], ) </code></pre>   |  <code>["bazel5", "bazel6", "ci", "convenience", "correctness", "debug", "javascript", "performance"]</code> |
+| <a id="write_aspect_bazelrc_presets-presets"></a>presets |  a list of preset names to keep up-to-date<br><br>For example,<br><br><pre><code> write_aspect_bazelrc_presets(   name = "update_aspect_bazelrc_presets",   presets = [     "bazel6",     "ci",     "convenience",     "correctness",     "debug",     "javascript",     "performance",   ], ) </code></pre>   |  <code>["bazel6", "ci", "convenience", "correctness", "debug", "javascript", "performance"]</code> |
 | <a id="write_aspect_bazelrc_presets-kwargs"></a>kwargs |  Additional arguments to pass to <code>write_source_files</code>   |  none |
 
 

--- a/lib/bazelrc_presets.bzl
+++ b/lib/bazelrc_presets.bzl
@@ -3,7 +3,6 @@
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 
 ALL_PRESETS = [
-    "bazel5",
     "bazel6",
     "ci",
     "convenience",

--- a/lib/tests/bazelrc_presets/all/bazel5.bazelrc
+++ b/lib/tests/bazelrc_presets/all/bazel5.bazelrc
@@ -1,5 +1,0 @@
-# Performance improvement for WORKSPACE evaluation
-# of slow rulesets, for example rules_k8s has been
-# observed to take 10 seconds without this flag.
-# See https://github.com/bazelbuild/bazel/issues/13907
-common --incompatible_existing_rules_immutable_view

--- a/lib/tests/bazelrc_presets/subset/BUILD.bazel
+++ b/lib/tests/bazelrc_presets/subset/BUILD.bazel
@@ -4,7 +4,7 @@ write_aspect_bazelrc_presets(
     name = "update_aspect_bazelrc_presets",
     presets = [
         # Just pick a few to test the `presets` attribute
-        "bazel5",
+        "convenience",
         "javascript",
     ],
 )

--- a/lib/tests/bazelrc_presets/subset/bazel5.bazelrc
+++ b/lib/tests/bazelrc_presets/subset/bazel5.bazelrc
@@ -1,5 +1,0 @@
-# Performance improvement for WORKSPACE evaluation
-# of slow rulesets, for example rules_k8s has been
-# observed to take 10 seconds without this flag.
-# See https://github.com/bazelbuild/bazel/issues/13907
-common --incompatible_existing_rules_immutable_view

--- a/lib/tests/bazelrc_presets/subset/convenience.bazelrc
+++ b/lib/tests/bazelrc_presets/subset/convenience.bazelrc
@@ -1,0 +1,28 @@
+# Attempt to build & test every target whose prerequisites were successfully built.
+# Docs: https://bazel.build/docs/user-manual#keep-going
+build --keep_going
+
+# Output test errors to stderr so users don't have to `cat` or open test failure log files when test
+# fail. This makes the log noiser in exchange for reducing the time-to-feedback on test failures for
+# users.
+# Docs: https://bazel.build/docs/user-manual#test-output
+test --test_output=errors
+
+# Show the output files created by builds that requested more than one target. This helps users
+# locate the build outputs in more cases
+# Docs: https://bazel.build/docs/user-manual#show-result
+build --show_result=20
+
+# Bazel picks up host-OS-specific config lines from bazelrc files. For example, if the host OS is
+# Linux and you run bazel build, Bazel picks up lines starting with build:linux. Supported OS
+# identifiers are `linux`, `macos`, `windows`, `freebsd`, and `openbsd`. Enabling this flag is
+# equivalent to using `--config=linux` on Linux, `--config=windows` on Windows, etc.
+# Docs: https://bazel.build/reference/command-line-reference#flag--enable_platform_specific_config
+common --enable_platform_specific_config
+
+# Output a heap dump if an OOM is thrown during a Bazel invocation
+# (including OOMs due to `--experimental_oom_more_eagerly_threshold`).
+# The dump will be written to `<output_base>/<invocation_id>.heapdump.hprof`.
+# You may need to configure CI to capture this artifact and upload for later use.
+# Docs: https://bazel.build/reference/command-line-reference#flag--heap_dump_on_oom
+common --heap_dump_on_oom


### PR DESCRIPTION
Because bazel-lib 2.0 has a minimum Bazel compatibility set to 6.0.0.

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Covered by existing test cases
