### PR TITLE
fix: avoid breaking Bazel 5 users

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -116,10 +116,12 @@ stardoc_with_diff_test(
     bzl_library_target = "//lib:host_repo",
 )
 
-stardoc_with_diff_test(
-    name = "platform_utils",
-    bzl_library_target = "//lib:platform_utils",
-)
+# NB: we don't bother documenting this, because it just has three trivial functions,
+# and the dependency on @local_config_platform makes the load() break for Bazel 5 users.
+# stardoc_with_diff_test(
+#     name = "platform_utils",
+#     bzl_library_target = "//lib:platform_utils",
+# )
 
 stardoc_with_diff_test(
     name = "stamping",

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -5,6 +5,8 @@ load("//lib/private:copy_common.bzl", "copy_options")
 load("//lib/private:stamping.bzl", "stamp_build_setting")
 
 # Ensure that users building their own rules can dep on our bzl_library targets for their stardoc
+# This file has a dependency on @local_config_platform which is breaking for Bazel 5 users.
+# gazelle:exclude platform_utils.bzl
 package(default_visibility = ["//visibility:public"])
 
 exports_files(
@@ -275,12 +277,6 @@ bzl_library(
     deps = [
         "@bazel_skylib//lib:paths",
     ],
-)
-
-bzl_library(
-    name = "platform_utils",
-    srcs = ["platform_utils.bzl"],
-    deps = ["//lib/private:platform_utils"],
 )
 
 bzl_library(

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
+# This file has a dependency on @local_config_platform which is breaking for Bazel 5 users.
+# gazelle:exclude platform_utils.bzl
 exports_files(
     [
         "diff_test_tmpl.sh",
@@ -248,16 +250,6 @@ bzl_library(
     srcs = ["yq_toolchain.bzl"],
     visibility = ["//lib:__subpackages__"],
     deps = [":repo_utils"],
-)
-
-bzl_library(
-    name = "platform_utils",
-    srcs = [
-        "platform_utils.bzl",
-        "@local_config_platform//:constraints.bzl",  # keep
-    ],
-    visibility = ["//lib:__subpackages__"],
-    deps = [],  # keep
 )
 
 bzl_library(


### PR DESCRIPTION
Related to #584 which removed a Bazel 5 workaround

Makes `platform_utils` harder to discover, but the generated doc for it was useless, and this is the simplest way to ease the bazel-lib 2.0 rollout.

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

### Test plan

None