### PR TITLE
chore: remove useless check for stamped binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,6 @@ jobs:
           fi
           rm -rf /tmp/aspect/release
           bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc run //tools:release -- /tmp/aspect/release
-          if /tmp/aspect/release/copy_to_directory-linux_amd64 version | grep '(with local changes)'; then
-            >&2 echo "ERROR: the release contained changes in the git state and the release will not be produced"
-            exit 1
-          fi
       - name: Prepare workspace snippet
         run: .github/workflows/release_prep.sh ${{ env.GITHUB_REF_NAME }} > release_notes.txt
       - name: Release


### PR DESCRIPTION
Since we stopped `--stamp`ing our releases, this check can never fail.
