### PR TITLE
Use coreutils toolchain for copy_file action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,12 +58,12 @@ jobs:
         run: echo "os=macos-latest" >> $GITHUB_OUTPUT
         # Only run on main branch (or PR branches that contain 'macos') to minimize macOS minutes (billed at 10X)
         # https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes
-        if: ${{ github.ref == 'refs/heads/main' || contains(github.head_ref, 'macos') }}
+        #if: ${{ github.ref == 'refs/heads/main' || contains(github.head_ref, 'macos') }}
       - id: windows
         run: echo "os=windows-latest" >> $GITHUB_OUTPUT
         # Only run on main branch (or PR branches that contain 'windows') to minimize Windows minutes (billed at 2X)
         # https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes
-        if: ${{ github.ref == 'refs/heads/main' || contains(github.head_ref, 'windows') }}
+        #if: ${{ github.ref == 'refs/heads/main' || contains(github.head_ref, 'windows') }}
     outputs:
       # Will look like ["ubuntu-latest", "macos-latest", "windows-latest"]
       os: ${{ toJSON(steps.*.outputs.os) }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,12 +58,12 @@ jobs:
         run: echo "os=macos-latest" >> $GITHUB_OUTPUT
         # Only run on main branch (or PR branches that contain 'macos') to minimize macOS minutes (billed at 10X)
         # https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes
-        #if: ${{ github.ref == 'refs/heads/main' || contains(github.head_ref, 'macos') }}
+        if: ${{ github.ref == 'refs/heads/main' || contains(github.head_ref, 'macos') }}
       - id: windows
         run: echo "os=windows-latest" >> $GITHUB_OUTPUT
         # Only run on main branch (or PR branches that contain 'windows') to minimize Windows minutes (billed at 2X)
         # https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes
-        #if: ${{ github.ref == 'refs/heads/main' || contains(github.head_ref, 'windows') }}
+        if: ${{ github.ref == 'refs/heads/main' || contains(github.head_ref, 'windows') }}
     outputs:
       # Will look like ["ubuntu-latest", "macos-latest", "windows-latest"]
       os: ${{ toJSON(steps.*.outputs.os) }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,10 +121,10 @@ jobs:
       - name: Configure Bazel version
         if: ${{ matrix.os != 'windows-latest' }}
         working-directory: ${{ matrix.folder }}
-        # Overwrite the .bazelversion instead of using USE_BAZEL_VERSION so that Bazelisk
+        # - Overwrite the .bazelversion instead of using USE_BAZEL_VERSION so that Bazelisk
         # still bootstraps Aspect CLI from configuration in .bazeliskrc. Aspect CLI will
         # then use .bazelversion to determine which Bazel version to use.
-        # Also delete the .aspect/bazelrc/bazel6.bazelrc file if we are not testing
+        # - Delete the .aspect/bazelrc/bazel6.bazelrc file if we are not testing
         # against Bazel 6 which has a try-import in the root .bazelrc for local development.
         run: |
           BAZEL_VERSION=${{ matrix.bazelversion }}
@@ -134,17 +134,19 @@ jobs:
       - name: Configure Bazel version (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
         working-directory: ${{ matrix.folder }}
-        # Overwrite the .bazelversion instead of using USE_BAZEL_VERSION so that Bazelisk
+        # - Overwrite the .bazelversion instead of using USE_BAZEL_VERSION so that Bazelisk
         # still bootstraps Aspect CLI from configuration in .bazeliskrc. Aspect CLI will
         # then use .bazelversion to determine which Bazel version to use.
-        # Also delete the .aspect/bazelrc/bazel6.bazelrc file if we are not testing
+        # - Delete the .aspect/bazelrc/bazel6.bazelrc file if we are not testing
         # against Bazel 6 which has a try-import in the root .bazelrc for local development.
+        # - Delete the .bazeliskrc file since Aspect CLI doesn't current ship Windows binaries
         run: |
           echo "${{ matrix.bazelversion }}" > .bazelversion
           $BAZEL_MAJOR_VERSION = "${{ matrix.bazelversion }}".substring(0, 1)
           if ($BAZEL_MAJOR_VERSION -ne "6") {
             rm -Force .aspect/bazelrc/bazel6.bazelrc
           }
+          rm -Force .bazeliskrc
 
       - name: Set bzlmod flag
         # Store the --enable_bzlmod flag that we add to the test command below

--- a/e2e/copy_to_directory/.bazeliskrc
+++ b/e2e/copy_to_directory/.bazeliskrc
@@ -1,0 +1,1 @@
+../../.bazeliskrc

--- a/e2e/coreutils/.bazeliskrc
+++ b/e2e/coreutils/.bazeliskrc
@@ -1,0 +1,1 @@
+../../.bazeliskrc

--- a/e2e/external_copy_to_directory/.bazeliskrc
+++ b/e2e/external_copy_to_directory/.bazeliskrc
@@ -1,0 +1,1 @@
+../../.bazeliskrc

--- a/e2e/smoke/.bazeliskrc
+++ b/e2e/smoke/.bazeliskrc
@@ -1,0 +1,1 @@
+../../.bazeliskrc

--- a/e2e/write_source_files/.bazeliskrc
+++ b/e2e/write_source_files/.bazeliskrc
@@ -1,0 +1,1 @@
+../../.bazeliskrc

--- a/lib/private/copy_file.bzl
+++ b/lib/private/copy_file.bzl
@@ -57,6 +57,7 @@ def copy_file_action(ctx, src, dst, dir_path = None):
     ctx.actions.run(
         executable = coreutils.bin,
         arguments = ["cp", src_path, dst.path],
+        inputs = [src],
         outputs = [dst],
         mnemonic = "CopyFile",
         progress_message = "Copying file %s" % _progress_path(src),

--- a/lib/private/copy_file.bzl
+++ b/lib/private/copy_file.bzl
@@ -26,63 +26,6 @@ cmd.exe (on Windows). `_copy_xfile` marks the resulting file executable,
 
 load(":copy_common.bzl", _COPY_EXECUTION_REQUIREMENTS = "COPY_EXECUTION_REQUIREMENTS", _progress_path = "progress_path")
 load(":directory_path.bzl", "DirectoryPathInfo")
-load(":platform_utils.bzl", _platform_utils = "platform_utils")
-
-def _copy_cmd(ctx, src, src_path, dst):
-    # Most Windows binaries built with MSVC use a certain argument quoting
-    # scheme. Bazel uses that scheme too to quote arguments. However,
-    # cmd.exe uses different semantics, so Bazel's quoting is wrong here.
-    # To fix that we write the command to a .bat file so no command line
-    # quoting or escaping is required.
-    # Put a hash of the file name into the name of the generated batch file to
-    # make it unique within the package, so that users can define multiple copy_file's.
-    # The label of the target is intentionally not included so that two different targets
-    # can copy the same file to the output tree.
-    bat = ctx.actions.declare_file("%s-cmd.bat" % hash(src_path + dst.short_path))
-
-    # Flags are documented at
-    # https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/copy
-    cmd_tmpl = "@copy /Y \"{src}\" \"{dst}\" >NUL"
-    mnemonic = "CopyFile"
-    progress_message = "Copying file %s" % _progress_path(src)
-
-    ctx.actions.write(
-        output = bat,
-        # Do not use lib/shell.bzl's shell.quote() method, because that uses
-        # Bash quoting syntax, which is different from cmd.exe's syntax.
-        content = cmd_tmpl.format(
-            src = src_path.replace("/", "\\"),
-            dst = dst.path.replace("/", "\\"),
-        ),
-        is_executable = True,
-    )
-    ctx.actions.run(
-        inputs = [src],
-        tools = [bat],
-        outputs = [dst],
-        executable = "cmd.exe",
-        arguments = ["/C", bat.path.replace("/", "\\")],
-        mnemonic = mnemonic,
-        progress_message = progress_message,
-        use_default_shell_env = True,
-        execution_requirements = _COPY_EXECUTION_REQUIREMENTS,
-    )
-
-def _copy_bash(ctx, src, src_path, dst):
-    cmd_tmpl = "cp -f \"$1\" \"$2\""
-    mnemonic = "CopyFile"
-    progress_message = "Copying file %s" % _progress_path(src)
-
-    ctx.actions.run_shell(
-        tools = [src],
-        outputs = [dst],
-        command = cmd_tmpl,
-        arguments = [src_path, dst.path],
-        mnemonic = mnemonic,
-        progress_message = progress_message,
-        use_default_shell_env = True,
-        execution_requirements = _COPY_EXECUTION_REQUIREMENTS,
-    )
 
 def copy_file_action(ctx, src, dst, dir_path = None):
     """Factory function that creates an action to copy a file from src to dst.
@@ -109,13 +52,16 @@ def copy_file_action(ctx, src, dst, dir_path = None):
     else:
         src_path = src.path
 
-    # Because copy actions have "local" execution requirements, we can safely assume
-    # the execution is the same as the host platform and generate different actions for Windows
-    # and non-Windows host platforms
-    if _platform_utils.host_platform_is_windows():
-        _copy_cmd(ctx, src, src_path, dst)
-    else:
-        _copy_bash(ctx, src, src_path, dst)
+    coreutils = ctx.toolchains["@aspect_bazel_lib//lib:coreutils_toolchain_type"].coreutils_info
+
+    ctx.actions.run(
+        executable = coreutils.bin,
+        arguments = ["cp", src_path, dst.path],
+        outputs = [dst],
+        mnemonic = "CopyFile",
+        progress_message = "Copying file %s" % _progress_path(src),
+        execution_requirements = _COPY_EXECUTION_REQUIREMENTS,
+    )
 
 def _copy_file_impl(ctx):
     if ctx.attr.allow_symlink:
@@ -160,6 +106,7 @@ _copy_file = rule(
     implementation = _copy_file_impl,
     provides = [DefaultInfo],
     attrs = _ATTRS,
+    toolchains = ["@aspect_bazel_lib//lib:coreutils_toolchain_type"],
 )
 
 _copy_xfile = rule(
@@ -167,6 +114,7 @@ _copy_xfile = rule(
     executable = True,
     provides = [DefaultInfo],
     attrs = _ATTRS,
+    toolchains = ["@aspect_bazel_lib//lib:coreutils_toolchain_type"],
 )
 
 def copy_file(name, src, out, is_executable = False, allow_symlink = False, **kwargs):

--- a/lib/private/copy_to_bin.bzl
+++ b/lib/private/copy_to_bin.bzl
@@ -121,6 +121,7 @@ _copy_to_bin = rule(
     attrs = {
         "srcs": attr.label_list(mandatory = True, allow_files = True),
     },
+    toolchains = ["@aspect_bazel_lib//lib:coreutils_toolchain_type"],
 )
 
 def copy_to_bin(name, srcs, **kwargs):


### PR DESCRIPTION
Use the coreutils toolchain rather than bash/batch scripts to perform the copy.

### Type of change
- Refactor (a code change that neither fixes a bug or adds a new feature)**

- Relevant documentation has been updated
- Suggested release notes are provided below:
- Breaking change (this change will force users to change their own code or config)
Might require toolchain registration where previously it wasn't needed, if users did their own toolchain registration instead of calling `aspect_bazel_lib_register_toolchains` as the docs recommend

### Test plan
- Covered by existing test cases

