### PR TITLE
feat: implement path transforms

### DIFF
--- a/docs/tar.md
+++ b/docs/tar.md
@@ -25,10 +25,30 @@ TODO:
 ## mtree_spec
 
 <pre>
-mtree_spec(<a href="#mtree_spec-name">name</a>, <a href="#mtree_spec-out">out</a>, <a href="#mtree_spec-srcs">srcs</a>)
+mtree_spec(<a href="#mtree_spec-name">name</a>, <a href="#mtree_spec-out">out</a>, <a href="#mtree_spec-srcs">srcs</a>, <a href="#mtree_spec-transform">transform</a>)
 </pre>
 
 Create an mtree specification to map a directory hierarchy. See https://man.freebsd.org/cgi/man.cgi?mtree(8)
+
+Supports `$` and `^` RegExp tokens, which may be used together.
+
+* for stripping prefix, use `^path/to/strip`
+* for stripping suffix, use `path/to/strip$`
+* for exact match and replace, use `^path/to/strip$`
+* for partial match and replace, use `replace_anywhere`
+
+
+An example of stripping package path relative to the workspace
+
+```starlark
+tar(
+    srcs = ["PKGINFO"],
+    transform = {
+        "^{}".format(package_name()): ""
+    }
+)
+```
+
 
 **ATTRIBUTES**
 
@@ -38,6 +58,7 @@ Create an mtree specification to map a directory hierarchy. See https://man.free
 | <a id="mtree_spec-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="mtree_spec-out"></a>out |  Resulting specification file to write   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |  |
 | <a id="mtree_spec-srcs"></a>srcs |  Files that are placed into the tar   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
+| <a id="mtree_spec-transform"></a>transform |  A dict for path transforming. These are applied serially in respect to their orders.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 
 
 <a id="tar_rule"></a>

--- a/lib/tests/tar/BUILD.bazel
+++ b/lib/tests/tar/BUILD.bazel
@@ -199,3 +199,30 @@ diff_test(
     file1 = "src_file",
     file2 = "cat_src_file_output",
 )
+
+tar(
+    name = "transform",
+    srcs = [
+        "pkg/debian-binary",
+        "src_file",
+    ],
+    out = "transform.tar",
+    transform = {
+        "^lib/tests/": "",
+        "src_file$": "PKGINFO",
+        "^tar": "package",
+        # will flatten pkg/debian-binary to be inside package
+        "pkg/debian-binary": "debian-binary",
+    },
+)
+
+assert_tar_listing(
+    name = "test_transform",
+    actual = "transform",
+    expected = [
+        #
+        # TODO: https://github.com/aspect-build/bazel-lib/issues/625
+        "-rwxr-xr-x  0 0      0           0 Jan  1  2023 package/debian-binary",
+        "-rwxr-xr-x  0 0      0          21 Jan  1  2023 package/PKGINFO",
+    ],
+)


### PR DESCRIPTION
Adds support for path transforming for the tar rule. Effectively making pkg_tar do everything pkg_tar can do and more. 

### Type of change

- New feature or functionality (change which adds functionality)

**For changes visible to end-users**
- Relevant documentation has been updated

### Test plan

- New test cases added

