### PR TITLE
chore(typos): Add typos hook plus some fixes

### DIFF
--- a/.aspect/bazelrc/correctness.bazelrc
+++ b/.aspect/bazelrc/correctness.bazelrc
@@ -68,7 +68,7 @@ build --incompatible_default_to_explicit_init_py
 common --incompatible_disallow_empty_glob
 
 # Always download coverage files for tests from the remote cache. By default, coverage files are not
-# downloaded on test result cahce hits when --remote_download_minimal is enabled, making it impossible
+# downloaded on test result cache hits when --remote_download_minimal is enabled, making it impossible
 # to generate a full coverage report.
 # Docs: https://bazel.build/reference/command-line-reference#flag--experimental_fetch_all_coverage_outputs
 # detching remote cache results

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,15 @@ repos:
         exclude: &exclude_pattern "^(docs|e2e|lib/tests)/"
       - id: mixed-line-ending
       - id: trailing-whitespace
+  - repo: https://github.com/crate-ci/typos
+    rev: typos-dict-v0.11.2
+    hooks:
+      - id: typos
+        exclude: |
+          (?x)^(
+            docs/|
+            lib/
+          )
   - repo: local
     hooks:
       - id: aspect_rules_lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/crate-ci/typos
-    rev: typos-dict-v0.11.2
+    rev: v1.23.2
     hooks:
       - id: typos
         exclude: |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For example to use commit `abc123`:
 
 ## Writing rules
 
-- [expand_make_vars](docs/expand_make_vars.md) Perform make variable and location substitions in strings..
+- [expand_make_vars](docs/expand_make_vars.md) Perform make variable and location substitutions in strings..
 - [expand_template](docs/expand_template.md) Substitute templates with make variables, location resolves, stamp variables, and arbitrary strings.
 - [paths](docs/paths.md) Useful path resolution methods.
 - [transitions](docs/transitions.md) Transition sources to a provided platform.


### PR DESCRIPTION
---

A the typos pre-commit hook to automatically detect and mostly fix typos. Reading your documentation, I found one and wanted to provide a general solution. Follow up PRs can cleanup the excluded folders.

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

**For changes visible to end-users**

### Test plan
