### PR TITLE
chore: green up Windows CI

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,2 +1,2 @@
 BAZELISK_BASE_URL=https://github.com/aspect-build/aspect-cli/releases/download
-USE_BAZEL_VERSION=aspect/5.7.2
+USE_BAZEL_VERSION=aspect/5.8.5

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -6,5 +6,7 @@ bcr_test_module:
     run_tests:
       name: "Run test module"
       platform: ${{ platform }}
+      environment:
+        BAZELISK_BASE_URL: "https://github.com/bazelbuild/bazel/releases/download/"
       test_targets:
         - "//..."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,10 +121,10 @@ jobs:
       - name: Configure Bazel version
         if: ${{ matrix.os != 'windows-latest' }}
         working-directory: ${{ matrix.folder }}
-        # Overwrite the .bazelversion instead of using USE_BAZEL_VERSION so that Bazelisk
+        # - Overwrite the .bazelversion instead of using USE_BAZEL_VERSION so that Bazelisk
         # still bootstraps Aspect CLI from configuration in .bazeliskrc. Aspect CLI will
         # then use .bazelversion to determine which Bazel version to use.
-        # Also delete the .aspect/bazelrc/bazel6.bazelrc file if we are not testing
+        # - Delete the .aspect/bazelrc/bazel6.bazelrc file if we are not testing
         # against Bazel 6 which has a try-import in the root .bazelrc for local development.
         run: |
           BAZEL_VERSION=${{ matrix.bazelversion }}
@@ -134,17 +134,19 @@ jobs:
       - name: Configure Bazel version (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
         working-directory: ${{ matrix.folder }}
-        # Overwrite the .bazelversion instead of using USE_BAZEL_VERSION so that Bazelisk
+        # - Overwrite the .bazelversion instead of using USE_BAZEL_VERSION so that Bazelisk
         # still bootstraps Aspect CLI from configuration in .bazeliskrc. Aspect CLI will
         # then use .bazelversion to determine which Bazel version to use.
-        # Also delete the .aspect/bazelrc/bazel6.bazelrc file if we are not testing
+        # - Delete the .aspect/bazelrc/bazel6.bazelrc file if we are not testing
         # against Bazel 6 which has a try-import in the root .bazelrc for local development.
+        # - Delete the .bazeliskrc file since Aspect CLI doesn't current ship Windows binaries
         run: |
           echo "${{ matrix.bazelversion }}" > .bazelversion
           $BAZEL_MAJOR_VERSION = "${{ matrix.bazelversion }}".substring(0, 1)
           if ($BAZEL_MAJOR_VERSION -ne "6") {
             rm -Force .aspect/bazelrc/bazel6.bazelrc
           }
+          rm -Force .bazeliskrc
 
       - name: Set bzlmod flag
         # Store the --enable_bzlmod flag that we add to the test command below

--- a/e2e/copy_to_directory/.bazeliskrc
+++ b/e2e/copy_to_directory/.bazeliskrc
@@ -1,0 +1,1 @@
+../../.bazeliskrc

--- a/e2e/coreutils/.bazeliskrc
+++ b/e2e/coreutils/.bazeliskrc
@@ -1,0 +1,1 @@
+../../.bazeliskrc

--- a/e2e/external_copy_to_directory/.bazeliskrc
+++ b/e2e/external_copy_to_directory/.bazeliskrc
@@ -1,0 +1,1 @@
+../../.bazeliskrc

--- a/e2e/smoke/.bazeliskrc
+++ b/e2e/smoke/.bazeliskrc
@@ -1,0 +1,1 @@
+../../.bazeliskrc

--- a/e2e/write_source_files/.bazeliskrc
+++ b/e2e/write_source_files/.bazeliskrc
@@ -1,0 +1,1 @@
+../../.bazeliskrc


### PR DESCRIPTION
Windows CI is currently red at HEAD since Aspect CLI does not currently ship with Windows binaries: https://github.com/aspect-build/bazel-lib/actions/runs/6749471057/job/18349889696