### PR TITLE
fix: don't use aspect cli on bcr ci

### DIFF
--- a/.bcr/patches/rm_smoke_bazelisk_rc.patch
+++ b/.bcr/patches/rm_smoke_bazelisk_rc.patch
@@ -1,0 +1,8 @@
+diff --git a/e2e/smoke/.bazeliskrc b/e2e/smoke/.bazeliskrc
+deleted file mode 120000
+index 0fbe20f..0000000
+--- a/e2e/smoke/.bazeliskrc
++++ /dev/null
+@@ -1 +0,0 @@
+-../../.bazeliskrc
+\ No newline at end of file


### PR DESCRIPTION
Regressed in https://github.com/aspect-build/bazel-lib/pull/622. Now that we create e2e/smoke/.bazeliskrc, the bazel central registry ci fails when we push a release because there we don't publish cli windows binaries. Patch the file out of bcr releases.

### Type of change

- Bug fix (change which fixes an issue)

### Test plan
- Manual testing; please provide instructions so we can reproduce:
- Tested in https://github.com/bazelbuild/bazel-central-registry/pull/1124