### PR TITLE
fix: don't use aspect cli on bcr ci runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,7 +146,9 @@ jobs:
           if ($BAZEL_MAJOR_VERSION -ne "6") {
             rm -Force .aspect/bazelrc/bazel6.bazelrc
           }
-          rm -Force .bazeliskrc
+          if (Test-Path .bazeliskrc) {
+            rm -Force .bazeliskrc
+          }
 
       - name: Set bzlmod flag
         # Store the --enable_bzlmod flag that we add to the test command below

--- a/e2e/smoke/.bazeliskrc
+++ b/e2e/smoke/.bazeliskrc
@@ -1,1 +1,0 @@
-../../.bazeliskrc


### PR DESCRIPTION
Regressed in https://github.com/aspect-build/bazel-lib/pull/622. Now that we create e2e/smoke/.bazeliskrc, the bazel central registry ci fails when we push a release because there we don't publish cli windows binaries. Remove this file so that the bcr never uses it. This has the consequence that on our ci we will not use the aspect cli for this test on non-windows platforms, but this is closer the bcr environment for which this test was created so it makes sense.

### Type of change

- Bug fix (change which fixes an issue)