### PR TITLE
fix: exclude bazeliskrc from smoke test

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -6,7 +6,5 @@ bcr_test_module:
     run_tests:
       name: "Run test module"
       platform: ${{ platform }}
-      environment:
-        BAZELISK_BASE_URL: "https://github.com/bazelbuild/bazel/releases/download/"
       test_targets:
         - "//..."

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,5 +8,10 @@ docs/*.md linguist-generated=true
 # Omit folders that users don't need, making the distribution artifact smaller
 lib/tests export-ignore
 
+# Omit the .bazeliskrc file for the smoke test that runs on the Bazel Central
+# Regsitry ci because we test on Windows but do not publish Aspect CLI Windows
+# binaries.
+e2e/smoke/.bazeliskrc export-ignore
+
 # Substitution for the _VERSION_PRIVATE placeholder
 tools/version.bzl export-subst


### PR DESCRIPTION
Regressed in https://github.com/aspect-build/bazel-lib/pull/622. The addition of e2e/smoke/.bazeliskrc causes the BCR ci to fail. It seems to have difficulty loading the root bazelrc from this symlinked file under Windows. The solution here is to just leave it out of the release archive. The purpose of the bazeliskrc file here is to use the Aspect CLI on our own ci, but we don't need to use it on the BCR.

### Type of change

- Bug fix (change which fixes an issue)