### PR TITLE
Revert "Use coreutils toolchain for copy_file action (#622)"

### DIFF
--- a/lib/private/copy_to_bin.bzl
+++ b/lib/private/copy_to_bin.bzl
@@ -121,7 +121,6 @@ _copy_to_bin = rule(
     attrs = {
         "srcs": attr.label_list(mandatory = True, allow_files = True),
     },
-    toolchains = ["@aspect_bazel_lib//lib:coreutils_toolchain_type"],
 )
 
 def copy_to_bin(name, srcs, **kwargs):


### PR DESCRIPTION
This reverts commit 01ca8f94324f7bc0b2865173a58de06b82dccbac.

Using the coreutils toolchain for copy actions causes downstream issues in rules_js and rules_ts which use these actions. This is difficult to fix forward in rules_js and rules_ts without causing a breaking change by requiring WORKSPACE users to call the `register_coreutils_toolchains()` macro.

Reverting this should not be a breaking change for 2.0.0. If users were using the toolchain, the implementation will now just revert to bash.

### Type of change

- Bug fix (change which fixes an issue)
