### PR TITLE
feat: expose toolchains used for copy actions

### DIFF
--- a/docs/copy_file.md
+++ b/docs/copy_file.md
@@ -62,6 +62,27 @@ the TreeArtifact to the file to copy.
 This helper is used by copy_file. It is exposed as a public API so it can be used within
 other rule implementations.
 
+To use `copy_file_action` in your own rules, you need to include the toolchains it uses
+in your rule definition. For example:
+
+```starlark
+load("@aspect_bazel_lib//lib:copy_file.bzl", "COPY_FILE_TOOLCHAINS")
+
+my_rule = rule(
+    ...,
+    toolchains = COPY_FILE_TOOLCHAINS,
+)
+```
+
+Additionally, you must ensure that the coreutils toolchain is has been registered in your
+WORKSPACE if you are not using bzlmod:
+
+```starlark
+load("@aspect_bazel_lib//lib:repositories.bzl", "register_coreutils_toolchains")
+
+register_coreutils_toolchains()
+```
+
 
 **PARAMETERS**
 

--- a/docs/copy_to_bin.md
+++ b/docs/copy_to_bin.md
@@ -25,6 +25,27 @@ returned.
 If the file passed in is already in the output tree is then it is returned
 without a copy action.
 
+To use `copy_file_to_bin_action` in your own rules, you need to include the toolchains it uses
+in your rule definition. For example:
+
+```starlark
+load("@aspect_bazel_lib//lib:copy_file.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS")
+
+my_rule = rule(
+    ...,
+    toolchains = COPY_FILE_TO_BIN_TOOLCHAINS,
+)
+```
+
+Additionally, you must ensure that the coreutils toolchain is has been registered in your
+WORKSPACE if you are not using bzlmod:
+
+```starlark
+load("@aspect_bazel_lib//lib:repositories.bzl", "register_coreutils_toolchains")
+
+register_coreutils_toolchains()
+```
+
 
 **PARAMETERS**
 

--- a/lib/copy_file.bzl
+++ b/lib/copy_file.bzl
@@ -31,9 +31,11 @@ copy_file in the same package.
 
 load(
     "//lib/private:copy_file.bzl",
+    _COPY_FILE_TOOLCHAINS = "COPY_FILE_TOOLCHAINS",
     _copy_file = "copy_file",
     _copy_file_action = "copy_file_action",
 )
 
 copy_file = _copy_file
 copy_file_action = _copy_file_action
+COPY_FILE_TOOLCHAINS = _COPY_FILE_TOOLCHAINS

--- a/lib/copy_to_bin.bzl
+++ b/lib/copy_to_bin.bzl
@@ -9,6 +9,7 @@ https://github.com/bazelbuild/rules_nodejs/blob/8b5d27400db51e7027fe95ae413eeabe
 
 load(
     "//lib/private:copy_to_bin.bzl",
+    _COPY_FILE_TO_BIN_TOOLCHAINS = "COPY_FILE_TO_BIN_TOOLCHAINS",
     _copy_file_to_bin_action = "copy_file_to_bin_action",
     _copy_files_to_bin_actions = "copy_files_to_bin_actions",
     _copy_to_bin = "copy_to_bin",
@@ -17,3 +18,4 @@ load(
 copy_file_to_bin_action = _copy_file_to_bin_action
 copy_files_to_bin_actions = _copy_files_to_bin_actions
 copy_to_bin = _copy_to_bin
+COPY_FILE_TO_BIN_TOOLCHAINS = _COPY_FILE_TO_BIN_TOOLCHAINS

--- a/lib/private/copy_to_bin.bzl
+++ b/lib/private/copy_to_bin.bzl
@@ -15,7 +15,9 @@
 """Implementation of copy_to_bin macro and underlying rules."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load(":copy_file.bzl", "copy_file_action")
+load(":copy_file.bzl", "COPY_FILE_TOOLCHAINS", "copy_file_action")
+
+COPY_FILE_TO_BIN_TOOLCHAINS = COPY_FILE_TOOLCHAINS
 
 def copy_file_to_bin_action(ctx, file):
     """Factory function that creates an action to copy a file to the output tree.
@@ -25,6 +27,27 @@ def copy_file_to_bin_action(ctx, file):
 
     If the file passed in is already in the output tree is then it is returned
     without a copy action.
+
+    To use `copy_file_to_bin_action` in your own rules, you need to include the toolchains it uses
+    in your rule definition. For example:
+
+    ```starlark
+    load("@aspect_bazel_lib//lib:copy_file.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS")
+
+    my_rule = rule(
+        ...,
+        toolchains = COPY_FILE_TO_BIN_TOOLCHAINS,
+    )
+    ```
+
+    Additionally, you must ensure that the coreutils toolchain is has been registered in your
+    WORKSPACE if you are not using bzlmod:
+
+    ```starlark
+    load("@aspect_bazel_lib//lib:repositories.bzl", "register_coreutils_toolchains")
+
+    register_coreutils_toolchains()
+    ```
 
     Args:
         ctx: The rule context.
@@ -121,7 +144,7 @@ _copy_to_bin = rule(
     attrs = {
         "srcs": attr.label_list(mandatory = True, allow_files = True),
     },
-    toolchains = ["@aspect_bazel_lib//lib:coreutils_toolchain_type"],
+    toolchains = COPY_FILE_TO_BIN_TOOLCHAINS,
 )
 
 def copy_to_bin(name, srcs, **kwargs):

--- a/lib/private/extension_utils.bzl
+++ b/lib/private/extension_utils.bzl
@@ -93,11 +93,11 @@ def _toolchain_repos_bfs(mctx, get_tag_fn, toolchain_name, toolchain_repos_fn, d
             else:
                 registrations[name] = version
 
-        for name, version in registrations.items():
-            toolchain_repos_fn(
-                name = name,
-                version = version,
-            )
+    for name, version in registrations.items():
+        toolchain_repos_fn(
+            name = name,
+            version = version,
+        )
 
 extension_utils = struct(
     toolchain_repos_bfs = _toolchain_repos_bfs,

--- a/lib/repositories.bzl
+++ b/lib/repositories.bzl
@@ -14,6 +14,7 @@ load("//tools:version.bzl", "VERSION")
 # buildifier: disable=unnamed-macro
 def aspect_bazel_lib_dependencies():
     "Load dependencies required by aspect rules"
+
     http_archive(
         name = "bazel_skylib",
         sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",


### PR DESCRIPTION
For downstream rulesets to use bazel-lib 1.x and 2.x, some additions/fixes need to be included in the next 2.0 release. These include:
* copy action toolchain declarations
* toolchains module extension fix

### Type of change

- New feature or functionality (change which adds functionality

### Test plan

Manual testing against against rules_js and rules_ts overriden to point to this PR.
* https://github.com/aspect-build/rules_js/pull/1356
* https://github.com/aspect-build/rules_ts/pull/485
