### PR TITLE
feat: give version.bzl public visibility

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -16,7 +16,7 @@ bzl_library(
 bzl_library(
     name = "version",
     srcs = [":version.bzl"],
-    visibility = ["//lib/private/docs:__pkg__"],
+    visibility = ["//visibility:public"],
 )
 
 write_source_files(


### PR DESCRIPTION
The version is exposed in 2.x. Backporting it here so we can switch on it to support bazel-lib 1.x/2.x in downstream rulesets.

### Type of change

- New feature or functionality (change which adds functionality)
