### PR TITLE
fix: isolate rules_lint dev dependency usage into its own Bazel package

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -65,7 +65,7 @@ buildifier(
 
 alias(
     name = "format",
-    actual = "//tools:format",
+    actual = "//tools/format",
 )
 
 bzl_library(

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@aspect_rules_lint//format:defs.bzl", "multi_formatter_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//lib:utils.bzl", "is_bazel_6_or_greater")
 load("//lib:write_source_files.bzl", "write_source_files")
@@ -7,36 +6,6 @@ exports_files([
     "create_release.sh",
     "create_version.sh",
 ])
-
-alias(
-    name = "shfmt",
-    actual = select({
-        "@bazel_tools//src/conditions:darwin_arm64": "@shfmt_darwin_aarch64//file:shfmt",
-        "@bazel_tools//src/conditions:darwin_x86_64": "@shfmt_darwin_x86_64//file:shfmt",
-        "@bazel_tools//src/conditions:linux_aarch64": "@shfmt_linux_aarch64//file:shfmt",
-        "@bazel_tools//src/conditions:linux_x86_64": "@shfmt_linux_x86_64//file:shfmt",
-    }),
-    visibility = ["//:__subpackages__"],
-)
-
-alias(
-    name = "terraform",
-    actual = select({
-        "@bazel_tools//src/conditions:darwin_arm64": "@terraform_macos_aarch64//:terraform",
-        "@bazel_tools//src/conditions:darwin_x86_64": "@terraform_macos_x86_64//:terraform",
-        "@bazel_tools//src/conditions:linux": "@terraform_linux_x86_64//:terraform",
-    }),
-    visibility = ["//:__subpackages__"],
-)
-
-multi_formatter_binary(
-    name = "format",
-    go = "@go_sdk//:bin/gofmt",
-    sh = ":shfmt",
-    starlark = "@buildifier_prebuilt//:buildifier",
-    terraform = ":terraform",
-    visibility = ["//:__subpackages__"],
-)
 
 write_source_files(
     name = "releases_versions_check_in",

--- a/tools/format/BUILD.bazel
+++ b/tools/format/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@aspect_rules_lint//format:defs.bzl", "multi_formatter_binary")
+
+alias(
+    name = "shfmt",
+    actual = select({
+        "@bazel_tools//src/conditions:darwin_arm64": "@shfmt_darwin_aarch64//file:shfmt",
+        "@bazel_tools//src/conditions:darwin_x86_64": "@shfmt_darwin_x86_64//file:shfmt",
+        "@bazel_tools//src/conditions:linux_aarch64": "@shfmt_linux_aarch64//file:shfmt",
+        "@bazel_tools//src/conditions:linux_x86_64": "@shfmt_linux_x86_64//file:shfmt",
+    }),
+    visibility = ["//:__subpackages__"],
+)
+
+alias(
+    name = "terraform",
+    actual = select({
+        "@bazel_tools//src/conditions:darwin_arm64": "@terraform_macos_aarch64//:terraform",
+        "@bazel_tools//src/conditions:darwin_x86_64": "@terraform_macos_x86_64//:terraform",
+        "@bazel_tools//src/conditions:linux": "@terraform_linux_x86_64//:terraform",
+    }),
+    visibility = ["//:__subpackages__"],
+)
+
+multi_formatter_binary(
+    name = "format",
+    go = "@go_sdk//:bin/gofmt",
+    sh = ":shfmt",
+    starlark = "@buildifier_prebuilt//:buildifier",
+    terraform = ":terraform",
+    visibility = ["//:__subpackages__"],
+)


### PR DESCRIPTION
Fixes #686.

This regressed when rules_lint was brought in for format.

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

Why wasn't this caught in CI and in bzlmod presumbit in #681 ?!?