### PR TITLE
fix(tar): propagate testonly attr to mtree_spec

### DIFF
--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -99,6 +99,7 @@ bzl_library(
     name = "tar",
     srcs = ["tar.bzl"],
     deps = [
+        "//lib:utils",
         "//lib/private:tar",
         "@bazel_skylib//lib:types",
         "@bazel_skylib//rules:write_file",

--- a/lib/tar.bzl
+++ b/lib/tar.bzl
@@ -20,6 +20,7 @@ TODO:
 
 load("@bazel_skylib//lib:types.bzl", "types")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("//lib:utils.bzl", "propagate_common_rule_attributes")
 load("//lib/private:tar.bzl", _tar = "tar", _tar_lib = "tar_lib")
 
 mtree_spec = rule(
@@ -71,6 +72,7 @@ def tar(name, mtree = "auto", **kwargs):
             name = mtree_target,
             srcs = kwargs["srcs"],
             out = "{}.txt".format(mtree_target),
+            **propagate_common_rule_attributes(kwargs)
         )
     elif types.is_list(mtree):
         write_file(
@@ -79,6 +81,7 @@ def tar(name, mtree = "auto", **kwargs):
             # Ensure there's a trailing newline, as bsdtar will ignore a last line without one
             content = mtree + [""],
             newline = "unix",
+            **propagate_common_rule_attributes(kwargs)
         )
     else:
         mtree_target = mtree

--- a/lib/tests/tar/BUILD.bazel
+++ b/lib/tests/tar/BUILD.bazel
@@ -224,6 +224,11 @@ copy_directory(
 
 tar(
     name = "dirs",
+    # Note, testonly should be propagated, proven by
+    # % bazel query --output=label_kind 'attr("testonly", 1,lib/tests/tar:all)'
+    # mtree_spec rule //lib/tests/tar:_dirs.mtree
+    # tar rule //lib/tests/tar:dirs
+    testonly = True,
     srcs = glob(["srcdir/**"]) + [
         "treeartifact",
     ],

--- a/lib/tests/tar/asserts.bzl
+++ b/lib/tests/tar/asserts.bzl
@@ -11,6 +11,7 @@ def assert_tar_listing(name, actual, expected):
     native.genrule(
         name = actual_listing,
         srcs = [actual],
+        testonly = True,
         outs = ["_{}.listing".format(name)],
         cmd = "$(BSDTAR_BIN) -tvf $(execpath {}) >$@".format(actual),
         toolchains = ["@bsd_tar_toolchains//:resolved_toolchain"],
@@ -18,6 +19,7 @@ def assert_tar_listing(name, actual, expected):
 
     write_file(
         name = expected_listing,
+        testonly = True,
         out = "_{}.expected".format(name),
         content = expected + [""],
         newline = "unix",


### PR DESCRIPTION
Not sure if it's worth the time to add an analysis_test for something this simple.