### PR TITLE
fix: coreutils toolchain: Use statically linked linux amd64 variant

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -108,7 +108,7 @@ Registers coreutils toolchain and repositories
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="register_coreutils_toolchains-name"></a>name |  override the prefix for the generated toolchain repositories   |  <code>"coreutils"</code> |
-| <a id="register_coreutils_toolchains-version"></a>version |  the version of coreutils to execute (see https://github.com/uutils/coreutils/releases)   |  <code>"0.0.23"</code> |
+| <a id="register_coreutils_toolchains-version"></a>version |  the version of coreutils to execute (see https://github.com/uutils/coreutils/releases)   |  <code>"0.0.26"</code> |
 | <a id="register_coreutils_toolchains-register"></a>register |  whether to call through to native.register_toolchains. Should be True for WORKSPACE users, but false when used under bzlmod extension   |  <code>True</code> |
 
 

--- a/lib/private/coreutils_toolchain.bzl
+++ b/lib/private/coreutils_toolchain.bzl
@@ -34,33 +34,29 @@ COREUTILS_PLATFORMS = {
     ),
 }
 
-DEFAULT_COREUTILS_VERSION = "0.0.23"
+DEFAULT_COREUTILS_VERSION = "0.0.26"
 
 # https://github.com/uutils/coreutils/releases
 #
 # The integrity hashes can be automatically fetched for the coreutils releases by running
 # `tools/coreutils_mirror_release.sh`.
 COREUTILS_VERSIONS = {
-    "0.0.23": {
+    "0.0.26": {
         "darwin_arm64": {
-            "filename": "coreutils-0.0.23-aarch64-apple-darwin.tar.gz",
-            "sha256": "sha256-KP90sjKxtXDbLC+o5f4+gQnvP3Tr7O0RopME4g9QF5E=",
+            "filename": "coreutils-0.0.26-aarch64-apple-darwin.tar.gz",
+            "sha256": "sha256-/A6CNYWmvOwPW443pH+wO+VtzDFgussN1hRGuANnFOU="
         },
         "linux_arm64": {
-            "filename": "coreutils-0.0.23-aarch64-unknown-linux-gnu.tar.gz",
-            "sha256": "sha256-8wMVMgAgf8JQ2+2LdoewkyDo416VEsf9RlMJl4jiBjk=",
-        },
-        "darwin_amd64": {
-            "filename": "coreutils-0.0.23-x86_64-apple-darwin.tar.gz",
-            "sha256": "sha256-SswetVAuK/hMK1r9uBvNnKj5JpSgD0bzkbsHTxOabCo=",
+            "filename": "coreutils-0.0.26-aarch64-unknown-linux-musl.tar.gz",
+            "sha256": "sha256-9zGLFOMDjUDbraDY/hrE5zFJ0O+QYrvx2wHk3Gw3q/A="
         },
         "windows_amd64": {
-            "filename": "coreutils-0.0.23-x86_64-pc-windows-msvc.zip",
-            "sha256": "sha256-aglIj5JvFGLm2ABwRzWAsZRTTD3X444V3GxHM9pGJS4=",
+            "filename": "coreutils-0.0.26-x86_64-pc-windows-msvc.zip",
+            "sha256": "sha256-6qPkqxQZM4XBBBJ80t1uvzfZiz0gBeT/zoCdfqOO3uk="
         },
         "linux_amd64": {
-            "filename": "coreutils-0.0.23-x86_64-unknown-linux-gnu.tar.gz",
-            "sha256": "sha256-u7OMW43Y46aXRRIKULfKdfUW51WJn6G70s5Xxwb6/1g=",
+            "filename": "coreutils-0.0.26-x86_64-unknown-linux-musl.tar.gz",
+            "sha256": "sha256-QpGVp3wmHqpt5Brd/bdj7pyMQNftcihOtaRI8z2uhp0=",
         },
     },
 }

--- a/lib/private/coreutils_toolchain.bzl
+++ b/lib/private/coreutils_toolchain.bzl
@@ -50,6 +50,10 @@ COREUTILS_VERSIONS = {
             "filename": "coreutils-0.0.26-aarch64-unknown-linux-musl.tar.gz",
             "sha256": "sha256-9zGLFOMDjUDbraDY/hrE5zFJ0O+QYrvx2wHk3Gw3q/A="
         },
+        "darwin_amd64": {
+            "filename": "coreutils-0.0.23-x86_64-apple-darwin.tar.gz",
+            "sha256": "sha256-SswetVAuK/hMK1r9uBvNnKj5JpSgD0bzkbsHTxOabCo=",
+        },
         "windows_amd64": {
             "filename": "coreutils-0.0.26-x86_64-pc-windows-msvc.zip",
             "sha256": "sha256-6qPkqxQZM4XBBBJ80t1uvzfZiz0gBeT/zoCdfqOO3uk="

--- a/tools/coreutils_mirror_release.sh
+++ b/tools/coreutils_mirror_release.sh
@@ -11,7 +11,7 @@ JQ_FILTER='map({
             (.name | contains("i686") | not) and
             (
                 ( (.name | contains("windows")) and (.name | contains("gnu") | not) ) or
-                ( (.name | contains("windows") | not) and (.name | contains("gnu") ) and (.name | contains("gnueabihf") | not) ) or
+                ( .name | contains("musl") ) or
                 ( .name | contains("darwin") )
             )
         ))
@@ -27,7 +27,7 @@ JQ_FILTER='map({
                 sub("aarch64"; "arm64") |
                 gsub("\\d+.\\d+.\\d+-"; "") |
                 rtrimstr("-msvc") |
-                rtrimstr("-gnu") |
+                rtrimstr("-musl") |
                 split("-") |
                 reverse |
                 join("_"),


### PR DESCRIPTION
Uutils has a musl release artifact for linux amd64 and linux arm64. <strike>In the future, it should probably also be possible to add a aarch64 musl toolchain. At the moment, this is not an upstream release artifact.
I'm in the process of [fixing this upstream](https://github.com/uutils/coreutils/issues/5690).</strike>

### Type of change

- Bug fix (fixes #701)


### Test plan

- Covered by existing test cases
