### PR TITLE
chore: test against bazel 7.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,9 +42,9 @@ jobs:
       - id: bazel_6
         run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
       - id: bazel_7
-        run: echo "bazelversion=7.0.0-pre.20230530.3" >> $GITHUB_OUTPUT
+        run: echo "bazelversion=7.0.0" >> $GITHUB_OUTPUT
     outputs:
-      # Will look like '["<version from .bazelversion>", "7.0.0-pre.*"]'
+      # Will look like '["<version from .bazelversion>", "7.0.0"]'
       bazelversions: ${{ toJSON(steps.*.outputs.bazelversion) }}
 
   matrix-prep-os:
@@ -97,13 +97,13 @@ jobs:
           - config: rbe
             os: macos-latest
           # Don't test MacOS with Bazel 7 to minimize MacOS minutes (billed at 10X)
-          - bazelversion: 7.0.0-pre.20230530.3
+          - bazelversion: 7.0.0
             os: macos-latest
           # Don't test Windows with RBE to minimize Windows minutes (billed at 2X)
           - config: rbe
             os: windows-latest
           # Don't test Windows with Bazel 7 to minimize Windows minutes (billed at 2X)
-          - bazelversion: 7.0.0-pre.20230530.3
+          - bazelversion: 7.0.0
             os: windows-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -117,8 +117,8 @@ jobs:
           path: |
             ~/.cache/bazel
             ~/.cache/bazel-repo
-          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
-          restore-keys: bazel-cache-
+          key: bazel-cache-${{ matrix.os }}-${{ matrix.bazelversion }}-${{ matrix.folder }}-${{ matrix.bzlmodEnabled }}-${{ matrix.config }}-${{ hashFiles('.bazelrc', '.bazelversion', '.bazeliskrc', '**/BUILD', '**/BUILD.bazel', '**/*.bzl', 'WORKSPACE', 'WORKSPACE.bazel', 'WORKSPACE.bzlmod', 'MODULE.bazel', 'MODULE.bazel.lock') }}
+          restore-keys: bazel-cache-${{ matrix.os }}-${{ matrix.bazelversion }}-${{ matrix.folder }}-${{ matrix.bzlmodEnabled }}-${{ matrix.config }}-
 
       - name: Configure Bazel version
         if: ${{ matrix.os != 'windows-latest' }}
@@ -175,7 +175,6 @@ jobs:
           bazel --bazelrc=${{ github.workspace }}/.aspect/bazelrc/ci.bazelrc \
             --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc \
             --bazelrc=${{ github.workspace }}/.aspect/bazelrc/bazel${BAZEL_VERSION::1}.bazelrc \
-            --bazelrc=.bazelrc \
             test --config=${{ matrix.config }} //... \
             ${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }}
         env:
@@ -191,7 +190,6 @@ jobs:
           bazel --bazelrc=${{ github.workspace }}/.aspect/bazelrc/ci.bazelrc `
             --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc `
             --bazelrc=${{ github.workspace }}/.aspect/bazelrc/bazel$BAZEL_MAJOR_VERSION.bazelrc `
-            --bazelrc=.bazelrc `
             test --config=${{ matrix.config }} //... `
             ${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,17 @@ jobs:
           path: |
             ~/.cache/bazel
             ~/.cache/bazel-repo
-          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
-          restore-keys: bazel-cache-
+          key: bazel-cache-release-${{ hashFiles('.bazelrc', '.bazelversion', '.bazeliskrc', '**/BUILD', '**/BUILD.bazel', '**/*.bzl', 'WORKSPACE', 'WORKSPACE.bazel', 'WORKSPACE.bzlmod', 'MODULE.bazel', 'MODULE.bazel.lock') }}
+          restore-keys: bazel-cache-release-
       - name: bazel test //... (release)
         env:
           # Bazelisk will download bazel to here
           XDG_CACHE_HOME: ~/.cache/bazel-repo
-        run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
+        run: |
+          bazel --bazelrc=.aspect/bazelrc/ci.bazelrc \
+            --bazelrc=.github/workflows/ci.bazelrc \
+            --bazelrc=.aspect/bazelrc/bazel6.bazelrc \
+            test --config=local //...
       - name: Build release artifacts
         run: |
           if [ -n "$(git status --porcelain)" ]; then
@@ -34,7 +38,10 @@ jobs:
             exit 1
           fi
           rm -rf /tmp/aspect/release
-          bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc run //tools/release -- /tmp/aspect/release
+          bazel --bazelrc=.aspect/bazelrc/ci.bazelrc \
+            --bazelrc=.github/workflows/ci.bazelrc \
+            --bazelrc=.aspect/bazelrc/bazel6.bazelrc \
+            run --config=local //tools/release -- /tmp/aspect/release
       - name: Prepare workspace snippet
         run: .github/workflows/release_prep.sh ${{ env.GITHUB_REF_NAME }} > release_notes.txt
       - name: Release

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,6 +9,9 @@ load("//lib:testing.bzl", "assert_contains")
 load("//lib:write_source_files.bzl", "write_source_files")
 load("//lib:yq.bzl", "yq")
 
+# buildifier: disable=bzl-visibility
+load("//lib/private:utils.bzl", "utils")
+
 # gazelle:prefix github.com/aspect-build/bazel-lib
 
 gazelle_binary(
@@ -76,7 +79,7 @@ bzl_library(
     deps = [
         "@bazel_tools//tools/build_defs/repo:http.bzl",
         "@bazel_tools//tools/build_defs/repo:utils.bzl",
-    ],
+    ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if utils.is_bazel_7_or_greater() else []),
 )
 
 # write_source_files() to a git ignored subdirectory of the root

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -77,3 +77,4 @@ use_repo(
 
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.3.3", dev_dependency = True)
+bazel_dep(name = "bazel_features", version = "0.1.0", dev_dependency = True)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,6 +10,10 @@ load(":internal_deps.bzl", "bazel_lib_internal_deps")
 # Fetch deps needed only locally for development
 bazel_lib_internal_deps()
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -67,6 +67,13 @@ def bazel_lib_internal_deps():
         url = "https://github.com/aspect-build/rules_lint/releases/download/v0.6.1/rules_lint-v0.6.1.tar.gz",
     )
 
+    http_archive(
+        name = "bazel_features",
+        sha256 = "f3082bfcdca73dc77dcd68faace806135a2e08c230b02b1d9fbdbd7db9d9c450",
+        strip_prefix = "bazel_features-0.1.0",
+        url = "https://github.com/bazel-contrib/bazel_features/releases/download/v0.1.0/bazel_features-v0.1.0.tar.gz",
+    )
+
     # Register toolchains for tests
     register_jq_toolchains()
     register_yq_toolchains()

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//lib/private:utils.bzl", "utils")
 
 exports_files(
     [
@@ -215,7 +216,7 @@ bzl_library(
     deps = [
         "@bazel_tools//tools/build_defs/repo:http.bzl",
         "@bazel_tools//tools/build_defs/repo:utils.bzl",
-    ],
+    ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if utils.is_bazel_7_or_greater() else []),
 )
 
 # keep

--- a/lib/private/utils.bzl
+++ b/lib/private/utils.bzl
@@ -205,6 +205,38 @@ def _is_bazel_6_or_greater():
     # native.bazel_version only works in repository rules.
     return "apple_binary" not in dir(native)
 
+def _is_bazel_7_or_greater():
+    """Detects if the Bazel version being used is greater than or equal to 7 (including Bazel 7 pre-releases and RCs).
+
+    Unlike the undocumented `native.bazel_version`, which only works in WORKSPACE and repository rules, this function can
+    be used in rules and BUILD files.
+
+    An alternate approach to make the Bazel version available in BUILD files and rules would be to
+    use the [host_repo](https://github.com/aspect-build/bazel-lib/blob/main/docs/host_repo.md) repository rule
+    which contains the bazel_version in the exported `host` struct:
+
+    WORKSPACE:
+    ```
+    load("@aspect_bazel_lib//lib:host_repo.bzl", "host_repo")
+    host_repo(name = "aspect_bazel_lib_host")
+    ```
+
+    BUILD.bazel:
+    ```
+    load("@aspect_bazel_lib_host//:defs.bzl", "host")
+    print(host.bazel_version)
+    ```
+
+    That approach, however, incurs a cost in the user's WORKSPACE.
+
+    Returns:
+        True if the Bazel version being used is greater than or equal to 7 (including pre-releases and RCs)
+    """
+
+    # Hacky way to check if the we're using at least Bazel 7. Would be nice if there was a ctx.bazel_version instead.
+    # native.bazel_version only works in repository rules.
+    return "apple_binary" not in dir(native) and "cc_host_toolchain_alias" not in dir(native)
+
 def is_bzlmod_enabled():
     """Detect the value of the --enable_bzlmod flag"""
     return str(Label("@//:BUILD.bazel")).startswith("@@")
@@ -343,6 +375,7 @@ utils = struct(
     file_exists = _file_exists,
     glob_directories = _glob_directories,
     is_bazel_6_or_greater = _is_bazel_6_or_greater,
+    is_bazel_7_or_greater = _is_bazel_7_or_greater,
     is_bzlmod_enabled = is_bzlmod_enabled,
     is_external_label = _is_external_label,
     maybe_http_archive = _maybe_http_archive,

--- a/lib/tests/BUILD.bazel
+++ b/lib/tests/BUILD.bazel
@@ -1,5 +1,6 @@
 "tests for libs"
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//lib:expand_template.bzl", "expand_template")
@@ -13,8 +14,8 @@ load(":strings_tests.bzl", "strings_test_suite")
 load(":utils_test.bzl", "utils_test_suite")
 
 config_setting(
-    name = "experimental_allow_unresolved_symlinks",
-    values = {"experimental_allow_unresolved_symlinks": "true"},
+    name = "allow_unresolved_symlinks",
+    values = {bazel_features.flags.allow_unresolved_symlinks: "true"},
     visibility = ["//visibility:public"],
 )
 

--- a/lib/tests/copy_to_directory_bin_action/BUILD.bazel
+++ b/lib/tests/copy_to_directory_bin_action/BUILD.bazel
@@ -54,7 +54,7 @@ pkg(
         "//conditions:default": [],
     }),
     use_declare_symlink = select({
-        "//lib/tests:experimental_allow_unresolved_symlinks": True,
+        "//lib/tests:allow_unresolved_symlinks": True,
         "//conditions:default": False,
     }),
 )


### PR DESCRIPTION
Bazel 7 final it out now. We can flip to testing Bazel 7 as primary & Bazel 6.4.0 as secondary in a follow-up PR.