### PR TITLE
feat: add is_bazel_7_or_greater utility function to public API

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,11 +6,9 @@ load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 load("//lib:diff_test.bzl", "diff_test")
 load("//lib:testing.bzl", "assert_contains")
+load("//lib:utils.bzl", "is_bazel_7_or_greater")
 load("//lib:write_source_files.bzl", "write_source_files")
 load("//lib:yq.bzl", "yq")
-
-# buildifier: disable=bzl-visibility
-load("//lib/private:utils.bzl", "utils")
 
 # gazelle:prefix github.com/aspect-build/bazel-lib
 
@@ -79,7 +77,7 @@ bzl_library(
     deps = [
         "@bazel_tools//tools/build_defs/repo:http.bzl",
         "@bazel_tools//tools/build_defs/repo:utils.bzl",
-    ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if utils.is_bazel_7_or_greater() else []),
+    ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if is_bazel_7_or_greater() else []),
 )
 
 # write_source_files() to a git ignored subdirectory of the root

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -158,6 +158,44 @@ That approach, however, incurs a cost in the user's WORKSPACE.
 True if the Bazel version being used is greater than or equal to 6 (including pre-releases and RCs)
 
 
+<a id="is_bazel_7_or_greater"></a>
+
+## is_bazel_7_or_greater
+
+<pre>
+is_bazel_7_or_greater()
+</pre>
+
+Detects if the Bazel version being used is greater than or equal to 7 (including Bazel 7 pre-releases and RCs).
+
+Unlike the undocumented `native.bazel_version`, which only works in WORKSPACE and repository rules, this function can
+be used in rules and BUILD files.
+
+An alternate approach to make the Bazel version available in BUILD files and rules would be to
+use the [host_repo](https://github.com/aspect-build/bazel-lib/blob/main/docs/host_repo.md) repository rule
+which contains the bazel_version in the exported `host` struct:
+
+WORKSPACE:
+```
+load("@aspect_bazel_lib//lib:host_repo.bzl", "host_repo")
+host_repo(name = "aspect_bazel_lib_host")
+```
+
+BUILD.bazel:
+```
+load("@aspect_bazel_lib_host//:defs.bzl", "host")
+print(host.bazel_version)
+```
+
+That approach, however, incurs a cost in the user's WORKSPACE.
+
+
+
+**RETURNS**
+
+True if the Bazel version being used is greater than or equal to 7 (including pre-releases and RCs)
+
+
 <a id="is_bzlmod_enabled"></a>
 
 ## is_bzlmod_enabled

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//lib/private:utils.bzl", "utils")
+load("//lib:utils.bzl", "is_bazel_7_or_greater")
 
 exports_files(
     [
@@ -216,7 +216,7 @@ bzl_library(
     deps = [
         "@bazel_tools//tools/build_defs/repo:http.bzl",
         "@bazel_tools//tools/build_defs/repo:utils.bzl",
-    ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if utils.is_bazel_7_or_greater() else []),
+    ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if is_bazel_7_or_greater() else []),
 )
 
 # keep

--- a/lib/utils.bzl
+++ b/lib/utils.bzl
@@ -6,6 +6,7 @@ default_timeout = utils.default_timeout
 file_exists = utils.file_exists
 glob_directories = utils.glob_directories
 is_bazel_6_or_greater = utils.is_bazel_6_or_greater
+is_bazel_7_or_greater = utils.is_bazel_7_or_greater
 is_bzlmod_enabled = utils.is_bzlmod_enabled
 is_external_label = utils.is_external_label
 maybe_http_archive = utils.maybe_http_archive


### PR DESCRIPTION
In the future we should make detection of the Bazel version part of the public API of bazel_features and use that. 

Currently, however, the [bazel version comparison functions in bazel_features](https://github.com/bazel-contrib/bazel_features/blob/main/private/util.bzl) are private API so a change needs to be made there to make the public API. Also adding a new non-dev dep on bazel_features here would be breaking for WORKSPACE users which is undesirable atm.

---

### Type of change

- New feature or functionality (change which adds functionality)

### Test plan

- Covered by existing test cases
