### PR TITLE
refactor: remove --enable-runfiles from javascript recommended bazelrc settings

### DIFF
--- a/.aspect/bazelrc/javascript.bazelrc
+++ b/.aspect/bazelrc/javascript.bazelrc
@@ -8,21 +8,3 @@
 # details.
 # Docs: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options
 run:debug -- --node_options=--inspect-brk
-
-# Enable runfiles on all platforms. Runfiles are on by default on Linux and MacOS but off on
-# Windows.
-#
-# In general, rules_js and derivate rule sets assume that runfiles are enabled and do not support no
-# runfiles case because it does not scale to teach all Node.js tools to use the runfiles manifest.
-#
-# If you are developing on Windows, you must either run bazel with administrator privileges or
-# enable developer mode. If you do not you may hit this error on Windows:
-#
-#   Bazel needs to create symlinks to build the runfiles tree.
-#   Creating symlinks on Windows requires one of the following:
-#       1. Bazel is run with administrator privileges.
-#       2. The system version is Windows 10 Creators Update (1703) or later
-#          and developer mode is enabled.
-#
-# Docs: https://bazel.build/reference/command-line-reference#flag--enable_runfiles
-build --enable_runfiles

--- a/lib/tests/bazelrc_presets/all/javascript.bazelrc
+++ b/lib/tests/bazelrc_presets/all/javascript.bazelrc
@@ -8,21 +8,3 @@
 # details.
 # Docs: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options
 run:debug -- --node_options=--inspect-brk
-
-# Enable runfiles on all platforms. Runfiles are on by default on Linux and MacOS but off on
-# Windows.
-#
-# In general, rules_js and derivate rule sets assume that runfiles are enabled and do not support no
-# runfiles case because it does not scale to teach all Node.js tools to use the runfiles manifest.
-#
-# If you are developing on Windows, you must either run bazel with administrator privileges or
-# enable developer mode. If you do not you may hit this error on Windows:
-#
-#   Bazel needs to create symlinks to build the runfiles tree.
-#   Creating symlinks on Windows requires one of the following:
-#       1. Bazel is run with administrator privileges.
-#       2. The system version is Windows 10 Creators Update (1703) or later
-#          and developer mode is enabled.
-#
-# Docs: https://bazel.build/reference/command-line-reference#flag--enable_runfiles
-build --enable_runfiles

--- a/lib/tests/bazelrc_presets/subset/javascript.bazelrc
+++ b/lib/tests/bazelrc_presets/subset/javascript.bazelrc
@@ -8,21 +8,3 @@
 # details.
 # Docs: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options
 run:debug -- --node_options=--inspect-brk
-
-# Enable runfiles on all platforms. Runfiles are on by default on Linux and MacOS but off on
-# Windows.
-#
-# In general, rules_js and derivate rule sets assume that runfiles are enabled and do not support no
-# runfiles case because it does not scale to teach all Node.js tools to use the runfiles manifest.
-#
-# If you are developing on Windows, you must either run bazel with administrator privileges or
-# enable developer mode. If you do not you may hit this error on Windows:
-#
-#   Bazel needs to create symlinks to build the runfiles tree.
-#   Creating symlinks on Windows requires one of the following:
-#       1. Bazel is run with administrator privileges.
-#       2. The system version is Windows 10 Creators Update (1703) or later
-#          and developer mode is enabled.
-#
-# Docs: https://bazel.build/reference/command-line-reference#flag--enable_runfiles
-build --enable_runfiles


### PR DESCRIPTION
With https://github.com/aspect-build/rules_js/pull/1428, rules_js no longer requires runfiles.

---

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

### Test plan

- Covered by existing test cases
