### PR TITLE
feat: allow write_source_file(s) to write source files to bazel packages outside of the target's package

### DIFF
--- a/docs/write_source_files.md
+++ b/docs/write_source_files.md
@@ -8,7 +8,7 @@ Public API for write_source_files
 
 <pre>
 write_source_file(<a href="#write_source_file-name">name</a>, <a href="#write_source_file-in_file">in_file</a>, <a href="#write_source_file-out_file">out_file</a>, <a href="#write_source_file-executable">executable</a>, <a href="#write_source_file-additional_update_targets">additional_update_targets</a>,
-                  <a href="#write_source_file-suggested_update_target">suggested_update_target</a>, <a href="#write_source_file-diff_test">diff_test</a>, <a href="#write_source_file-kwargs">kwargs</a>)
+                  <a href="#write_source_file-suggested_update_target">suggested_update_target</a>, <a href="#write_source_file-diff_test">diff_test</a>, <a href="#write_source_file-check_that_out_file_exists">check_that_out_file_exists</a>, <a href="#write_source_file-kwargs">kwargs</a>)
 </pre>
 
 Write a file or directory to the source tree.
@@ -25,11 +25,12 @@ To disable the exists check and up-to-date test set `diff_test` to `False`.
 | :------------- | :------------- | :------------- |
 | <a id="write_source_file-name"></a>name |  Name of the runnable target that creates or updates the source tree file or directory.   |  none |
 | <a id="write_source_file-in_file"></a>in_file |  File or directory to use as the desired content to write to <code>out_file</code>.<br><br>This is typically a file or directory output of another target. If <code>in_file</code> is a directory then entire directory contents are copied.   |  <code>None</code> |
-| <a id="write_source_file-out_file"></a>out_file |  The file or directory to write to in the source tree. Must be within the same containing Bazel package as this target.   |  <code>None</code> |
+| <a id="write_source_file-out_file"></a>out_file |  The file or directory to write to in the source tree.<br><br>The output file or directory must be within the same containing Bazel package as this target if <code>check_that_out_file_exists</code> is <code>True</code>. See <code>check_that_out_file_exists</code> docstring for more info.   |  <code>None</code> |
 | <a id="write_source_file-executable"></a>executable |  Whether source tree file or files within the source tree directory written should be made executable.   |  <code>False</code> |
 | <a id="write_source_file-additional_update_targets"></a>additional_update_targets |  List of other <code>write_source_files</code> or <code>write_source_file</code> targets to call in the same run.   |  <code>[]</code> |
 | <a id="write_source_file-suggested_update_target"></a>suggested_update_target |  Label of the <code>write_source_files</code> or <code>write_source_file</code> target to suggest running when files are out of date.   |  <code>None</code> |
 | <a id="write_source_file-diff_test"></a>diff_test |  Test that the source tree file or directory exist and is up to date.   |  <code>True</code> |
+| <a id="write_source_file-check_that_out_file_exists"></a>check_that_out_file_exists |  Test that the output file exists and print a helpful error message if it doesn't.<br><br>If <code>True</code>, the output file or directory must be in the same containing Bazel package as the target since the underlying mechanism for this check is limited to files in the same Bazel package.   |  <code>True</code> |
 | <a id="write_source_file-kwargs"></a>kwargs |  Other common named parameters such as <code>tags</code> or <code>visibility</code>   |  none |
 
 **RETURNS**
@@ -43,7 +44,7 @@ Name of the generated test target if requested, otherwise None.
 
 <pre>
 write_source_files(<a href="#write_source_files-name">name</a>, <a href="#write_source_files-files">files</a>, <a href="#write_source_files-executable">executable</a>, <a href="#write_source_files-additional_update_targets">additional_update_targets</a>, <a href="#write_source_files-suggested_update_target">suggested_update_target</a>,
-                   <a href="#write_source_files-diff_test">diff_test</a>, <a href="#write_source_files-kwargs">kwargs</a>)
+                   <a href="#write_source_files-diff_test">diff_test</a>, <a href="#write_source_files-check_that_out_file_exists">check_that_out_file_exists</a>, <a href="#write_source_files-kwargs">kwargs</a>)
 </pre>
 
 Write one or more files and/or directories to the source tree.
@@ -136,11 +137,12 @@ NOTE: If you run formatters or linters on your codebase, it is advised that you 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="write_source_files-name"></a>name |  Name of the runnable target that creates or updates the source tree files and/or directories.   |  none |
-| <a id="write_source_files-files"></a>files |  A dict where the keys are files or directories in the source tree to write to and the values are labels pointing to the desired content, typically file or directory outputs of other targets.<br><br>Destination files and directories must be within the same containing Bazel package as this target.   |  <code>{}</code> |
+| <a id="write_source_files-files"></a>files |  A dict where the keys are files or directories in the source tree to write to and the values are labels pointing to the desired content, typically file or directory outputs of other targets.<br><br>Destination files and directories must be within the same containing Bazel package as this target if <code>check_that_out_file_exists</code> is True. See <code>check_that_out_file_exists</code> docstring for more info.   |  <code>{}</code> |
 | <a id="write_source_files-executable"></a>executable |  Whether source tree files written should be made executable.<br><br>This applies to all source tree files written by this target. This attribute is not propagated to <code>additional_update_targets</code>.<br><br>To set different executable permissions on different source tree files use multiple <code>write_source_files</code> targets.   |  <code>False</code> |
 | <a id="write_source_files-additional_update_targets"></a>additional_update_targets |  List of other <code>write_source_files</code> or <code>write_source_file</code> targets to call in the same run.   |  <code>[]</code> |
 | <a id="write_source_files-suggested_update_target"></a>suggested_update_target |  Label of the <code>write_source_files</code> or <code>write_source_file</code> target to suggest running when files are out of date.   |  <code>None</code> |
 | <a id="write_source_files-diff_test"></a>diff_test |  Test that the source tree files and/or directories exist and are up to date.   |  <code>True</code> |
+| <a id="write_source_files-check_that_out_file_exists"></a>check_that_out_file_exists |  Test that each output file exists and print a helpful error message if it doesn't.<br><br>If <code>True</code>, destination files and directories must be in the same containing Bazel package as the target since the underlying mechanism for this check is limited to files in the same Bazel package.   |  <code>True</code> |
 | <a id="write_source_files-kwargs"></a>kwargs |  Other common named parameters such as <code>tags</code> or <code>visibility</code>   |  none |
 
 

--- a/lib/tests/BUILD.bazel
+++ b/lib/tests/BUILD.bazel
@@ -13,6 +13,8 @@ load(":paths_test.bzl", "paths_test_suite")
 load(":strings_tests.bzl", "strings_test_suite")
 load(":utils_test.bzl", "utils_test_suite")
 
+exports_files(["a.js"])
+
 config_setting(
     name = "allow_unresolved_symlinks",
     values = {bazel_features.flags.allow_unresolved_symlinks: "true"},

--- a/lib/tests/a.js
+++ b/lib/tests/a.js
@@ -1,0 +1,1 @@
+console.log("a");

--- a/lib/tests/write_source_files/BUILD.bazel
+++ b/lib/tests/write_source_files/BUILD.bazel
@@ -204,3 +204,19 @@ write_source_files(
         "skylib_LICENSE": "@bazel_skylib//:LICENSE",
     },
 )
+
+# Test that we can write to a sub package
+write_source_file_test(
+    name = "a_subpkg_test",
+    check_that_out_file_exists = False,
+    in_file = ":a-desired",
+    out_file = "//lib/tests/write_source_files/subpkg:a.js",
+)
+
+# Test that we can write to a parent package
+write_source_file_test(
+    name = "a_parentpkg_test",
+    check_that_out_file_exists = False,
+    in_file = ":a-desired",
+    out_file = "//lib/tests:a.js",
+)

--- a/lib/tests/write_source_files/subpkg/BUILD.bazel
+++ b/lib/tests/write_source_files/subpkg/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["a.js"])

--- a/lib/tests/write_source_files/subpkg/a.js
+++ b/lib/tests/write_source_files/subpkg/a.js
@@ -1,0 +1,1 @@
+console.log("a");

--- a/lib/tests/write_source_files/write_source_file_test.bzl
+++ b/lib/tests/write_source_files/write_source_file_test.bzl
@@ -172,7 +172,7 @@ _write_source_file_test = rule(
     test = True,
 )
 
-def write_source_file_test(name, in_file, out_file):
+def write_source_file_test(name, in_file, out_file, check_that_out_file_exists = True):
     """Stamp a write_source_files executable and a test to run against it"""
 
     _write_source_file(
@@ -180,6 +180,7 @@ def write_source_file_test(name, in_file, out_file):
         in_file = in_file,
         out_file = out_file,
         diff_test = False,
+        check_that_out_file_exists = check_that_out_file_exists,
     )
 
     # Note that for testing we update the source files in the sandbox,

--- a/lib/write_source_files.bzl
+++ b/lib/write_source_files.bzl
@@ -12,6 +12,7 @@ def write_source_files(
         additional_update_targets = [],
         suggested_update_target = None,
         diff_test = True,
+        check_that_out_file_exists = True,
         **kwargs):
     """Write one or more files and/or directories to the source tree.
 
@@ -102,7 +103,8 @@ def write_source_files(
         files: A dict where the keys are files or directories in the source tree to write to and the values are labels
             pointing to the desired content, typically file or directory outputs of other targets.
 
-            Destination files and directories must be within the same containing Bazel package as this target.
+            Destination files and directories must be within the same containing Bazel package as this target if
+            `check_that_out_file_exists` is True. See `check_that_out_file_exists` docstring for more info.
 
         executable: Whether source tree files written should be made executable.
 
@@ -115,6 +117,11 @@ def write_source_files(
         suggested_update_target: Label of the `write_source_files` or `write_source_file` target to suggest running when files are out of date.
 
         diff_test: Test that the source tree files and/or directories exist and are up to date.
+
+        check_that_out_file_exists: Test that each output file exists and print a helpful error message if it doesn't.
+
+            If `True`, destination files and directories must be in the same containing Bazel package as the target since the underlying
+            mechanism for this check is limited to files in the same Bazel package.
 
         **kwargs: Other common named parameters such as `tags` or `visibility`
     """
@@ -143,6 +150,7 @@ def write_source_files(
             additional_update_targets = additional_update_targets if single_update_target else [],
             suggested_update_target = this_suggested_update_target,
             diff_test = diff_test,
+            check_that_out_file_exists = check_that_out_file_exists,
             **kwargs
         )
 
@@ -162,7 +170,6 @@ def write_source_files(
             name = name,
             additional_update_targets = update_targets + additional_update_targets,
             suggested_update_target = suggested_update_target,
-            diff_test = False,
             **kwargs
         )
 


### PR DESCRIPTION
We've received requests for this feature a few times now with the latest one being here https://bazelbuild.slack.com/archives/C04281DTLH0/p1704883631739649.

The glob trick to check that the out file exists must be disabled by setting `check_that_out_file(s)_exists` to `False` when writing to a different Bazel package. The trick doesn't work unless the out file is in the same Bazel package (glob's don't traverse into sub packages and can't look into sibling or parent packages).

### Type of change

- New feature or functionality (change which adds functionality)

**For changes visible to end-users**

- Suggested release notes are provided below:

write_source_files(s) can now write source files to Bazel packages outside of the target's package when you set `check_that_out_file(s)_exists` to False.

### Test plan

- New test cases added
