### PR TITLE
chore: fix failing test on arm64 machines

### DIFF
--- a/lib/tests/run_binary_expansions/expansions.sh
+++ b/lib/tests/run_binary_expansions/expansions.sh
@@ -7,5 +7,6 @@ rm -f $outfile
 for each in $@; do
   sanitized=${each/darwin/PLATFORM}
   sanitized=${sanitized/k8/PLATFORM}
+  sanitized=${sanitized/_arm64/}
   echo $sanitized >>$outfile
 done


### PR DESCRIPTION
This test is failing locally on an M3 mac. Likely would fail on a linux arm64 as well.

```
==================== Test output for //lib/tests/run_binary_expansions:expansions_golden_test:
1,2c1,2
< bazel-out/PLATFORM_arm64-opt/bin/lib/tests/run_binary_expansions/expansions_out
< bazel-out/PLATFORM_arm64-opt/bin/lib/tests/run_binary_expansions
---
> bazel-out/PLATFORM-opt/bin/lib/tests/run_binary_expansions/expansions_out
> bazel-out/PLATFORM-opt/bin/lib/tests/run_binary_expansions
5,6c5,6
< bazel-out/PLATFORM_arm64-opt/bin/lib/tests/run_binary_expansions/src_1
< bazel-out/PLATFORM_arm64-opt/bin/lib/tests/run_binary_expansions/src_1
---
> bazel-out/PLATFORM-opt/bin/lib/tests/run_binary_expansions/src_1
> bazel-out/PLATFORM-opt/bin/lib/tests/run_binary_expansions/src_1
9,10c9,10
< bazel-out/PLATFORM_arm64-opt/bin/lib/tests/run_binary_expansions/src_1
< bazel-out/PLATFORM_arm64-opt/bin/lib/tests/run_binary_expansions/src_1
---
> bazel-out/PLATFORM-opt/bin/lib/tests/run_binary_expansions/src_1
> bazel-out/PLATFORM-opt/bin/lib/tests/run_binary_expansions/src_1
12,14c12,14
< bazel-out/PLATFORM_arm64-opt/bin
< bazel-out/PLATFORM_arm64-opt/bin
< PLATFORM_arm64
---
> bazel-out/PLATFORM-opt/bin
> bazel-out/PLATFORM-opt/bin
> PLATFORM
FAIL: files "lib/tests/run_binary_expansions/expansions_out" and "lib/tests/run_binary_expansions/expansions_golden" differ. 
================================================================================
```

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Covered by existing test cases
