### PR TITLE
chore: bump to e2-medium k8s nodes

### DIFF
--- a/.aspect/workflows/terraform/workflows.tf
+++ b/.aspect/workflows/terraform/workflows.tf
@@ -28,7 +28,7 @@ module "aspect_workflows" {
     # Kubernetes cluster on this deploymemt is tuned for cost. A high-performance deployment should
     # use a minimum of e2-standard-2 and multiple nodes so that the cache can be sharded.
     node_count   = 1
-    machine_type = "e2-small"
+    machine_type = "e2-medium"
   }
 
   # Delivery properties


### PR DESCRIPTION
e2-small was pushing it for the number of services running on the node