### PR TITLE
Update paths.bzl

### DIFF
--- a/lib/paths.bzl
+++ b/lib/paths.bzl
@@ -21,6 +21,6 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   source "$0.runfiles/$f" 2>/dev/null || \
   source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
   source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+  { echo>&2 "ERROR: runfiles.bash initializer cannot find $f. An executable rule may have forgotten to expose it in the runfiles, or the binary may require RUNFILES_DIR to be set."; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v3 ---
 """


### PR DESCRIPTION
Add a more helpful error when runfiles.bash can't be found.

FYI @fmeum  - this is the symbol we load in aspect rules rather than copy-paste from the bazel sources into every script :)