### PR TITLE
perf: remove unnecessary calls to 'to_list'

### DIFF
--- a/lib/private/copy_directory_toolchain.bzl
+++ b/lib/private/copy_directory_toolchain.bzl
@@ -57,7 +57,7 @@ CopyToDirectoryInfo = provider(
 )
 
 def _copy_directory_toolchain_impl(ctx):
-    binary = ctx.attr.bin.files.to_list()[0]
+    binary = ctx.file.bin
 
     default_info = DefaultInfo(
         files = depset([binary]),

--- a/lib/private/copy_to_directory_toolchain.bzl
+++ b/lib/private/copy_to_directory_toolchain.bzl
@@ -57,7 +57,7 @@ CopyToDirectoryInfo = provider(
 )
 
 def _copy_to_directory_toolchain_impl(ctx):
-    binary = ctx.attr.bin.files.to_list()[0]
+    binary = ctx.file.bin
 
     default_info = DefaultInfo(
         files = depset([binary]),

--- a/lib/private/jq_toolchain.bzl
+++ b/lib/private/jq_toolchain.bzl
@@ -65,7 +65,7 @@ JqInfo = provider(
 )
 
 def _jq_toolchain_impl(ctx):
-    binary = ctx.attr.bin.files.to_list()[0]
+    binary = ctx.file.bin
 
     # Make the $(JQ_BIN) variable available in places like genrules.
     # See https://docs.bazel.build/versions/main/be/make-variables.html#custom_variables

--- a/lib/private/yq_toolchain.bzl
+++ b/lib/private/yq_toolchain.bzl
@@ -314,7 +314,7 @@ YqInfo = provider(
 )
 
 def _yq_toolchain_impl(ctx):
-    binary = ctx.attr.bin.files.to_list()[0]
+    binary = ctx.file.bin
 
     # Make the $(YQ_BIN) variable available in places like genrules.
     # See https://docs.bazel.build/versions/main/be/make-variables.html#custom_variables


### PR DESCRIPTION
Removes the unnecessary calls to `to_list` to retrieve the single file, when the attr is marked as `allow_single_file`, the file object can be obtained via `ctx.file` without the need to flatten the `files` depset.

---

### Type of change

- Bug fix (change which fixes an issue)
- Performance (a code change that improves performance)

**For changes visible to end-users**

- Suggested release notes are provided below:

Access toolchain `bin` via `ctx.file` to remove the need to flatten the files depset.

### Test plan

- Covered by existing test cases