### PR TITLE
Update tar.bzl

### DIFF
--- a/docs/tar.md
+++ b/docs/tar.md
@@ -105,8 +105,7 @@ tar(<a href="#tar-name">name</a>, <a href="#tar-mtree">mtree</a>, <a href="#tar-
 
 Wrapper macro around [`tar_rule`](#tar_rule).
 
-Options for mtree
------------------
+### Options for mtree
 
 mtree provides the "specification" or manifest of a tar file.
 See https://man.freebsd.org/cgi/man.cgi?mtree(8)

--- a/lib/tar.bzl
+++ b/lib/tar.bzl
@@ -67,8 +67,7 @@ tar_lib = _tar_lib
 def tar(name, mtree = "auto", **kwargs):
     """Wrapper macro around [`tar_rule`](#tar_rule).
 
-    Options for mtree
-    -----------------
+    ### Options for mtree
 
     mtree provides the "specification" or manifest of a tar file.
     See https://man.freebsd.org/cgi/man.cgi?mtree(8)


### PR DESCRIPTION
Fix header so it's not presented at the same level as the parent (the `tar` macro)

This PR will be red because it needs a docs change - can't wait for a Marvin suggested fix I can just accept :)