### PR TITLE
jq: add data file and location expansion support

### DIFF
--- a/docs/jq.md
+++ b/docs/jq.md
@@ -7,7 +7,7 @@ Public API for jq
 ## jq
 
 <pre>
-jq(<a href="#jq-name">name</a>, <a href="#jq-srcs">srcs</a>, <a href="#jq-filter">filter</a>, <a href="#jq-filter_file">filter_file</a>, <a href="#jq-args">args</a>, <a href="#jq-out">out</a>, <a href="#jq-kwargs">kwargs</a>)
+jq(<a href="#jq-name">name</a>, <a href="#jq-srcs">srcs</a>, <a href="#jq-filter">filter</a>, <a href="#jq-filter_file">filter_file</a>, <a href="#jq-args">args</a>, <a href="#jq-out">out</a>, <a href="#jq-data">data</a>, <a href="#jq-expand_args">expand_args</a>, <a href="#jq-kwargs">kwargs</a>)
 </pre>
 
 Invoke jq with a filter on a set of json input files.
@@ -127,6 +127,8 @@ genrule(
 | <a id="jq-filter_file"></a>filter_file |  File containing filter expression (alternative to <code>filter</code>)   |  <code>None</code> |
 | <a id="jq-args"></a>args |  Additional args to pass to jq   |  <code>[]</code> |
 | <a id="jq-out"></a>out |  Name of the output json file; defaults to the rule name plus ".json"   |  <code>None</code> |
+| <a id="jq-data"></a>data |  List of additional files. May be empty.   |  <code>[]</code> |
+| <a id="jq-expand_args"></a>expand_args |  Run bazel's location-expansion on the args.   |  <code>False</code> |
 | <a id="jq-kwargs"></a>kwargs |  Other common named parameters such as <code>tags</code> or <code>visibility</code>   |  none |
 
 

--- a/lib/jq.bzl
+++ b/lib/jq.bzl
@@ -8,7 +8,7 @@ _jq_rule = rule(
     toolchains = ["@aspect_bazel_lib//lib:jq_toolchain_type"],
 )
 
-def jq(name, srcs, filter = None, filter_file = None, args = [], out = None, **kwargs):
+def jq(name, srcs, filter = None, filter_file = None, args = [], out = None, data = [], expand_args = False, **kwargs):
     """Invoke jq with a filter on a set of json input files.
 
     For jq documentation, see https://stedolan.github.io/jq/.
@@ -117,6 +117,7 @@ def jq(name, srcs, filter = None, filter_file = None, args = [], out = None, **k
     Args:
         name: Name of the rule
         srcs: List of input files. May be empty.
+        data: List of additional files. May be empty.
         filter: Filter expression (https://stedolan.github.io/jq/manual/#Basicfilters).
             Subject to stamp variable replacements, see [Stamping](./stamping.md).
             When stamping is enabled, a variable named "STAMP" will be available in the filter.
@@ -125,6 +126,7 @@ def jq(name, srcs, filter = None, filter_file = None, args = [], out = None, **k
 
         filter_file: File containing filter expression (alternative to `filter`)
         args: Additional args to pass to jq
+        expand_args: Run bazel's location-expansion on the args.
         out: Name of the output json file; defaults to the rule name plus ".json"
         **kwargs: Other common named parameters such as `tags` or `visibility`
     """
@@ -139,5 +141,7 @@ def jq(name, srcs, filter = None, filter_file = None, args = [], out = None, **k
         filter_file = filter_file,
         args = args,
         out = out,
+        expand_args = expand_args,
+        data = data,
         **kwargs
     )

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -159,7 +159,10 @@ bzl_library(
     name = "jq",
     srcs = ["jq.bzl"],
     visibility = ["//lib:__subpackages__"],
-    deps = ["//lib:stamping"],
+    deps = [
+        ":expand_locations",
+        "//lib:stamping",
+    ],
 )
 
 bzl_library(

--- a/lib/tests/jq/BUILD.bazel
+++ b/lib/tests/jq/BUILD.bazel
@@ -79,6 +79,26 @@ diff_test(
     file2 = "null.json",
 )
 
+# Data files are passed in correctly
+jq(
+    name = "case_data_input_flag",
+    srcs = [],
+    args = [
+        "--slurpfile",
+        "a",
+        "$(location a_pretty.json)",
+    ],
+    data = ["a_pretty.json"],
+    expand_args = True,
+    filter = "$a[0]",
+)
+
+diff_test(
+    name = "case_data_input_flag_test",
+    file1 = ":case_data_input_flag",
+    file2 = "a_pretty.json",
+)
+
 # Load filter from file
 jq(
     name = "case_filter_file",


### PR DESCRIPTION
This teaches the jq rule about a `data` attribute and adds conditional support to do bazel location expansion. The expansion is disabled by default because it likely would cause compat concerns (since jq can take arbitrary text as input args).

### Type of change

- New feature or functionality (change which adds functionality)

**For changes visible to end-users**

- Relevant documentation has been updated
- Suggested release notes are provided below:

jq now supports data dependencies and optional location expansion on the args attr

### Test plan

- New test cases added