### PR TITLE
presets: remove eternal test_timeout_filtering

### DIFF
--- a/.aspect/bazelrc/ci.bazelrc
+++ b/.aspect/bazelrc/ci.bazelrc
@@ -1,10 +1,3 @@
-# We recommend enforcing a policy that keeps your CI from being slowed down
-# by individual test targets that should be optimized
-# or split up into multiple test targets with sharding or manually.
-# Set this flag to exclude targets that have their timeout set to eternal (>15m) from running on CI.
-# Docs: https://bazel.build/docs/user-manual#test-timeout-filters
-test --test_timeout_filters=-eternal
-
 # Set this flag to enable re-tries of failed tests on CI.
 # When any test target fails, try one or more times. This applies regardless of whether the "flaky"
 # tag appears on the target definition.

--- a/lib/tests/bazelrc_presets/all/ci.bazelrc
+++ b/lib/tests/bazelrc_presets/all/ci.bazelrc
@@ -1,10 +1,3 @@
-# We recommend enforcing a policy that keeps your CI from being slowed down
-# by individual test targets that should be optimized
-# or split up into multiple test targets with sharding or manually.
-# Set this flag to exclude targets that have their timeout set to eternal (>15m) from running on CI.
-# Docs: https://bazel.build/docs/user-manual#test-timeout-filters
-test --test_timeout_filters=-eternal
-
 # Set this flag to enable re-tries of failed tests on CI.
 # When any test target fails, try one or more times. This applies regardless of whether the "flaky"
 # tag appears on the target definition.


### PR DESCRIPTION
In practice we've disabled this setting at some clients, because there's not a surrounding workflow to find these targets are being silently dropped from CI, nor run them on another schedule.

We can re-introduce something better when we add Test Selection to Aspect Workflows.

---

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

**For changes visible to end-users**

- Suggested release notes are provided below:

We no longer recommend filtering test targets by timeout on CI for all cases. Some organizations may still want to restore this setting locally as a matter of policy, but you need to do *something* with the filtered test targets to keep them green.

