### PR TITLE
chore: make it possible to override run_binary#use_default_shell_env

### DIFF
--- a/lib/private/run_binary.bzl
+++ b/lib/private/run_binary.bzl
@@ -76,7 +76,7 @@ Possible fixes:
         mnemonic = ctx.attr.mnemonic if ctx.attr.mnemonic else None,
         progress_message = ctx.attr.progress_message if ctx.attr.progress_message else None,
         execution_requirements = ctx.attr.execution_requirements if ctx.attr.execution_requirements else None,
-        use_default_shell_env = False,
+        use_default_shell_env = ctx.attr.use_default_shell_env,
         env = dicts.add(ctx.configuration.default_shell_env, envs),
         input_manifests = tool_input_mfs,
     )
@@ -104,6 +104,7 @@ _run_binary = rule(
         "mnemonic": attr.string(),
         "progress_message": attr.string(),
         "execution_requirements": attr.string_dict(),
+        "use_default_shell_env": attr.bool(),
     }, **STAMP_ATTRS),
 )
 

--- a/lib/tests/run_binary_expansions/BUILD.bazel
+++ b/lib/tests/run_binary_expansions/BUILD.bazel
@@ -53,6 +53,9 @@ run_binary(
     },
     progress_message = "doing some work to make %{output}",
     tool = ":expansions_sh",
+    # May introduce non-determinism; use with care!
+    # See e.g. https://github.com/bazelbuild/bazel/issues/4912
+    use_default_shell_env = True,
 )
 
 diff_test(


### PR DESCRIPTION
Still not documented as public API. We think this leads to non-hermeticity and could cause cache misses, so it must be used with care.

Part of https://github.com/aspect-build/rules_js/issues/1303

---

### Type of change

- New feature or functionality (change which adds functionality)

### Test plan
Added a trivial usage.