### PR TITLE
feat: add platform_transition_test

### DIFF
--- a/docs/transitions.md
+++ b/docs/transitions.md
@@ -43,3 +43,24 @@ Transitions the srcs to use the provided platform. The filegroup will contain ar
 | <a id="platform_transition_filegroup-target_platform"></a>target_platform |  The target platform to transition the srcs.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
 
+<a id="platform_transition_test"></a>
+
+## platform_transition_test
+
+<pre>
+platform_transition_test(<a href="#platform_transition_test-name">name</a>, <a href="#platform_transition_test-basename">basename</a>, <a href="#platform_transition_test-binary">binary</a>, <a href="#platform_transition_test-target_platform">target_platform</a>)
+</pre>
+
+Transitions the test to use the provided platform.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="platform_transition_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="platform_transition_test-basename"></a>basename |  -   | String | optional | <code>""</code> |
+| <a id="platform_transition_test-binary"></a>binary |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="platform_transition_test-target_platform"></a>target_platform |  The target platform to transition the binary.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+
+

--- a/lib/tests/transitions/BUILD.bazel
+++ b/lib/tests/transitions/BUILD.bazel
@@ -1,7 +1,12 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//lib:diff_test.bzl", "diff_test")
-load("//lib:transitions.bzl", "platform_transition_binary", "platform_transition_filegroup")
+load(
+    "//lib:transitions.bzl",
+    "platform_transition_binary",
+    "platform_transition_filegroup",
+    "platform_transition_test",
+)
 
 platform(
     name = "armv7_linux",
@@ -109,6 +114,11 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
+go_test(
+    name = "test_transition_test",
+    srcs = ["simple_test.go"],
+)
+
 platform_transition_binary(
     name = "transitioned_go_binary_x86_64",
     binary = ":test_transition_binary",
@@ -118,6 +128,18 @@ platform_transition_binary(
 platform_transition_binary(
     name = "transitioned_go_binary_arm64",
     binary = ":test_transition_binary",
+    target_platform = "arm64_linux",
+)
+
+platform_transition_test(
+    name = "transitioned_go_test_x86_64",
+    binary = ":test_transition_test",
+    target_platform = "x86_64_linux",
+)
+
+platform_transition_test(
+    name = "transitioned_go_test_arm64",
+    binary = ":test_transition_test",
     target_platform = "arm64_linux",
 )
 
@@ -139,6 +161,26 @@ sh_test(
         "aarch64",
     ],
     data = [":transitioned_go_binary_arm64"],
+)
+
+sh_test(
+    name = "test_go_test_is_x86_64",
+    srcs = ["test_file_type_contains.sh"],
+    args = [
+        "$(rootpath :transitioned_go_test_x86_64)",
+        "x86-64",
+    ],
+    data = [":transitioned_go_test_x86_64"],
+)
+
+sh_test(
+    name = "test_go_test_is_arm64",
+    srcs = ["test_file_type_contains.sh"],
+    args = [
+        "$(rootpath :transitioned_go_test_arm64)",
+        "aarch64",
+    ],
+    data = [":transitioned_go_test_arm64"],
 )
 
 go_library(

--- a/lib/tests/transitions/BUILD.bazel
+++ b/lib/tests/transitions/BUILD.bazel
@@ -134,12 +134,20 @@ platform_transition_binary(
 platform_transition_test(
     name = "transitioned_go_test_x86_64",
     binary = ":test_transition_test",
+    # only run this test on x86_64 platforms
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+    ],
     target_platform = "x86_64_linux",
 )
 
 platform_transition_test(
     name = "transitioned_go_test_arm64",
     binary = ":test_transition_test",
+    # only run this test on arm64 platforms
+    target_compatible_with = [
+        "@platforms//cpu:arm64",
+    ],
     target_platform = "arm64_linux",
 )
 

--- a/lib/tests/transitions/simple_test.go
+++ b/lib/tests/transitions/simple_test.go
@@ -1,0 +1,10 @@
+package simple_test
+
+import "testing"
+
+func TestAdd(t *testing.T) {
+	result := 1 + 2
+	if result != 3 {
+		t.Errorf("got %q, wanted %q", result, 3)
+	}
+}

--- a/lib/transitions.bzl
+++ b/lib/transitions.bzl
@@ -87,19 +87,28 @@ def _platform_transition_binary_impl(ctx):
 
     return result
 
+_platform_transition_attrs = {
+    "basename": attr.string(),
+    "binary": attr.label(allow_files = True, cfg = _transition_platform),
+    "target_platform": attr.label(
+        doc = "The target platform to transition the binary.",
+        mandatory = True,
+    ),
+    "_allowlist_function_transition": attr.label(
+        default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+    ),
+}
+
 platform_transition_binary = rule(
     implementation = _platform_transition_binary_impl,
-    attrs = {
-        "basename": attr.string(),
-        "binary": attr.label(allow_files = True, cfg = _transition_platform),
-        "target_platform": attr.label(
-            doc = "The target platform to transition the binary.",
-            mandatory = True,
-        ),
-        "_allowlist_function_transition": attr.label(
-            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-        ),
-    },
+    attrs = _platform_transition_attrs,
     executable = True,
     doc = "Transitions the binary to use the provided platform.",
+)
+
+platform_transition_test = rule(
+    implementation = _platform_transition_binary_impl,
+    attrs = _platform_transition_attrs,
+    test = True,
+    doc = "Transitions the test to use the provided platform.",
 )


### PR DESCRIPTION
### Type of change

New feature or functionality (change which adds functionality)

Adding a test equiv. for `platform_transition_binary`. We find this very useful when we need to run tests targeting multiple platforms.

### Test plan

New test cases added
