### PR TITLE
fix: srcs is not mandatory

### DIFF
--- a/docs/tar.md
+++ b/docs/tar.md
@@ -68,7 +68,7 @@ Create an mtree specification to map a directory hierarchy. See https://man.free
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="mtree_spec-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="mtree_spec-out"></a>out |  Resulting specification file to write   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  |
-| <a id="mtree_spec-srcs"></a>srcs |  Files that are placed into the tar   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+| <a id="mtree_spec-srcs"></a>srcs |  Files that are placed into the tar   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 
 
 <a id="tar_rule"></a>
@@ -92,7 +92,7 @@ Rule that executes BSD `tar`. Most users should use the [`tar`](#tar) macro, rat
 | <a id="tar_rule-mode"></a>mode |  A mode indicator from the following list, copied from the tar manpage:<br><br>       - create: Create a new archive containing the specified items.        - append: Like <code>create</code>, but new entries are appended to the archive.             Note that this only works on uncompressed archives stored in regular files.             The -f option is required.        - list: List  archive contents to stdout.        - update: Like <code>append</code>, but new entries are added only if they have a             modification date newer than the corresponding entry in the archive. 	       Note that this only works on uncompressed archives stored in 	       regular files. The -f option	is required.        - extract: Extract to disk from the archive. If a file with the same name 	       appears more than once in the archive, each copy	 will  be  extracted,            with  later  copies  overwriting  (replacing) earlier copies.   | String | optional | <code>"create"</code> |
 | <a id="tar_rule-mtree"></a>mtree |  An mtree specification file   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="tar_rule-out"></a>out |  Resulting tar file to write. If absent, <code>[name].tar</code> is written.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  |
-| <a id="tar_rule-srcs"></a>srcs |  Files, directories, or other targets whose default outputs are placed into the tar.<br><br>        If any of the srcs are binaries with runfiles, those are copied into the resulting tar as well.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+| <a id="tar_rule-srcs"></a>srcs |  Files, directories, or other targets whose default outputs are placed into the tar.<br><br>        If any of the srcs are binaries with runfiles, those are copied into the resulting tar as well.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 
 
 <a id="tar"></a>

--- a/lib/private/tar.bzl
+++ b/lib/private/tar.bzl
@@ -50,7 +50,6 @@ _tar_attrs = {
 
         If any of the srcs are binaries with runfiles, those are copied into the resulting tar as well.
         """,
-        mandatory = True,
         allow_files = True,
     ),
     "mode": attr.string(
@@ -88,7 +87,7 @@ _tar_attrs = {
 }
 
 _mtree_attrs = {
-    "srcs": attr.label_list(doc = "Files that are placed into the tar", mandatory = True, allow_files = True),
+    "srcs": attr.label_list(doc = "Files that are placed into the tar", allow_files = True),
     "out": attr.output(doc = "Resulting specification file to write"),
 }
 

--- a/lib/tests/tar/BUILD.bazel
+++ b/lib/tests/tar/BUILD.bazel
@@ -328,3 +328,17 @@ assert_tar_listing(
         "-rwxr-xr-x  0 0      0       11358 Jan  1  2023 a",
     ],
 )
+
+# Case 11: Can create tar without srcs
+tar(
+    name = "create_tmp",
+    mtree = ["./tmp time=1501783453.0 mode=1777 gid=0 uid=0 type=dir"],
+)
+
+assert_tar_listing(
+    name = "test_create_create_tmp",
+    actual = "create_tmp",
+    expected = [
+        "drwxrwxrwt  0 0      0           0 Aug  3  2017 ./tmp/",
+    ],
+)


### PR DESCRIPTION
### Type of change

- New feature or functionality (change which adds functionality)

### Test plan

- New test cases added

#785 fixed the weird issue when no srcs were passed but didn't actually made the srcs optional.