### PR TITLE
clean rm of copied dirs and files

### DIFF
--- a/lib/private/write_source_file.bzl
+++ b/lib/private/write_source_file.bzl
@@ -219,6 +219,8 @@ out={out_path}
 mkdir -p "$(dirname "$out")"
 if [[ -f "$in" ]]; then
     echo "Copying file $in to $out in $PWD"
+    # in case `cp` from previous command was terminated midway which can result in read-only files/dirs
+    chmod -R ug+w "$out" > /dev/null 2>&1 || true
     rm -Rf "$out"
     cp -f "$in" "$out"
     # cp should make the file writable but call chmod anyway as a defense in depth
@@ -227,6 +229,8 @@ if [[ -f "$in" ]]; then
     {executable_file}
 else
     echo "Copying directory $in to $out in $PWD"
+    # in case `cp` from previous command was terminated midway which can result in read-only files/dirs
+    chmod -R ug+w "$out" > /dev/null 2>&1 || true
     rm -Rf "$out"/*
     mkdir -p "$out"
     cp -fRL "$in"/* "$out"


### PR DESCRIPTION
We hit an issue recently where the `write_source_file` halted during the `cp` part of a `bazel run <write_source_file_target>` command, this can leave dirs/files copied to the workspace to be read-only, and a subsequent `bazel run <write_source_file_target>` will fail with permission-denied. This is our workaround to this.

Simpler case in point:
```
$ mkdir bar
$ touch bar/baz
$ chmod -w bar
$ rm -r bar
rm: bar/baz: Permission denied
```

### Test plan

Test locally by:
1. running a bazel run command
2. while it's in the `cp` phase, terminate it before the command completes
3. verify that subdirs in the destination folder are read-only (`dr-xr-xr-x`)
4. subsequent bazel run command fail with `Permission denied`
5. Repeat 1-4, but with this patch, subsequent bazel run command always succeeds.
