### PR TITLE
bug: write_source_files diff_test fails on same-named directory

### DIFF
--- a/lib/tests/write_source_files/BUILD.bazel
+++ b/lib/tests/write_source_files/BUILD.bazel
@@ -220,3 +220,9 @@ write_source_file_test(
     in_file = ":a-desired",
     out_file = "//lib/tests:a.js",
 )
+
+# Copy directory to directory with the same name
+write_source_files(
+    name = "e_dir-desired_test",
+    files = {"e_dir-desired": ":e_dir-desired"},
+)

--- a/lib/tests/write_source_files/e_dir-desired/e-contained.js
+++ b/lib/tests/write_source_files/e_dir-desired/e-contained.js
@@ -1,0 +1,1 @@
+console.log("e*");


### PR DESCRIPTION
Bug report in the form of a failing test.

If you use `write_source_files` to copy a directory in the output tree to a directory in the source tree with the same name, the generated `diff_test` always fails. The error is "diff_test comparing the same file".

```
$ bazel test //lib/tests/write_source_files:e_dir-desired_test_test
ERROR: /Users/john/figma/bazel-lib/lib/tests/write_source_files/BUILD.bazel:225:19: in _diff_test rule //lib/tests/write_source_files:e_dir-desired_test_test:
Traceback (most recent call last):
	File "/Users/john/figma/bazel-lib/lib/private/diff_test.bzl", line 56, column 13, in _diff_test_impl
		fail(msg)
Error in fail: diff_test comparing the same file <generated file lib/tests/write_source_files/e_dir-desired>
ERROR: /Users/john/figma/bazel-lib/lib/tests/write_source_files/BUILD.bazel:225:19: Analysis of target '//lib/tests/write_source_files:e_dir-desired_test_test' failed
```
