### PR TITLE
ci: enforce PR titles are semantic

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,16 @@
+name: Verify PR title/description
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We want contributors to follow the instructions in the PR template, and use conventional commits to indicate the type of the PR.

Note, this uses the amannn upstream to check the title. We could use aspect-forks instead to check the description as well: https://github.com/aspect-forks/action-semantic-pull-request/blob/main/src/validatePrDescription.js


---

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:

will observe it running