### PR TITLE
chore: add bazel test support to javascript --config=debug preset

### DIFF
--- a/.aspect/bazelrc/javascript.bazelrc
+++ b/.aspect/bazelrc/javascript.bazelrc
@@ -8,3 +8,4 @@
 # details.
 # Docs: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options
 run:debug -- --node_options=--inspect-brk
+test:debug --test_env=NODE_OPTIONS=--inspect-brk

--- a/lib/tests/bazelrc_presets/all/javascript.bazelrc
+++ b/lib/tests/bazelrc_presets/all/javascript.bazelrc
@@ -8,3 +8,4 @@
 # details.
 # Docs: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options
 run:debug -- --node_options=--inspect-brk
+test:debug --test_env=NODE_OPTIONS=--inspect-brk

--- a/lib/tests/bazelrc_presets/subset/javascript.bazelrc
+++ b/lib/tests/bazelrc_presets/subset/javascript.bazelrc
@@ -8,3 +8,4 @@
 # details.
 # Docs: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options
 run:debug -- --node_options=--inspect-brk
+test:debug --test_env=NODE_OPTIONS=--inspect-brk


### PR DESCRIPTION
@jfirebaugh pointed out that we are missing this.

Tested downstream in rules_js:

```
bazel test //examples/js_binary:test_test --config=debug
WARNING: Streamed test output requested. All tests will be run locally, without sharding, one at a time
INFO: Analyzed target //examples/js_binary:test_test (0 packages loaded, 0 targets configured).
Debugger listening on ws://127.0.0.1:9229/385833a3-8f5e-437e-804d-a888a56bf7dd
For help, see: https://nodejs.org/en/docs/inspector
[1 / 2] Testing //examples/js_binary:test_test; 4s darwin-sandbox
```