### PR TITLE
fix: assert_contains does not print anything when content is different.

### DIFF
--- a/lib/testing.bzl
+++ b/lib/testing.bzl
@@ -20,8 +20,6 @@ def assert_contains(name, actual, expected, size = None, timeout = None, **kwarg
         timeout: the timeout attribute of the test target
         **kwargs: additional named arguments for the resulting sh_test
     """
-
-    test_sh = "_{}_test.sh".format(name)
     expected_file = "_{}_expected.txt".format(name)
 
     write_file(
@@ -30,23 +28,12 @@ def assert_contains(name, actual, expected, size = None, timeout = None, **kwarg
         content = [expected],
     )
 
-    write_file(
-        name = "_" + name,
-        out = test_sh,
-        content = [
-            "#!/usr/bin/env bash",
-            "set -o errexit",
-            "grep --fixed-strings -f $1 $2",
-        ],
-    )
-
-    native.sh_test(
+    diff_test(
         name = name,
-        srcs = [test_sh],
-        args = ["$(rootpath %s)" % expected_file, "$(rootpath %s)" % actual],
-        size = size,
+        file1 = expected_file,
+        file2 = actual,
         timeout = default_timeout(size, timeout),
-        data = [actual, expected_file],
+        size = size,
         **kwargs
     )
 


### PR DESCRIPTION
This fixes an issue where the test output is empty when there's difference.

```
FAIL: //examples/env_inheritance:check_digest (see /home/runner/.cache/bazel/_bazel_runner/ad636ec067a37408fd7596779f81b8e7/execroot/_main/bazel-out/k8-fastbuild/testlogs/examples/env_inheritance/check_digest/test.log)
INFO: From Testing //examples/env_inheritance:check_digest:
==================== Test output for //examples/env_inheritance:check_digest:
================================================================================
```

### Changes are visible to end-users: no

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases

