### PR TITLE
fix: register @zstd_toolchains//:all

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -35,6 +35,7 @@ register_toolchains(
     "@expand_template_toolchains//:all",
     "@bats_toolchains//:all",
     "@bsd_tar_toolchains//:all",
+    "@zstd_toolchains//:all",
 )
 
 host = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "host", dev_dependency = True)


### PR DESCRIPTION
I don't know why Bazel did not complain that the toolchain wasn't registered. 

### Changes are visible to end-users: yes/no

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases
