### PR TITLE
fix: coreutils download path for darwin_amd64

### DIFF
--- a/lib/private/coreutils_toolchain.bzl
+++ b/lib/private/coreutils_toolchain.bzl
@@ -51,6 +51,7 @@ COREUTILS_VERSIONS = {
             "sha256": "sha256-9zGLFOMDjUDbraDY/hrE5zFJ0O+QYrvx2wHk3Gw3q/A=",
         },
         "darwin_amd64": {
+            # TODO: remove this version_override hack once 0.0.27 is releases and contains a darwin arm binary
             "version_override": "0.0.23",
             "filename": "coreutils-0.0.23-x86_64-apple-darwin.tar.gz",
             "sha256": "sha256-SswetVAuK/hMK1r9uBvNnKj5JpSgD0bzkbsHTxOabCo=",
@@ -177,7 +178,9 @@ def _coreutils_platform_repo_impl(rctx):
     is_windows = rctx.attr.platform.startswith("windows_")
     platform = rctx.attr.platform
     filename = COREUTILS_VERSIONS[rctx.attr.version][platform]["filename"]
-    version = COREUTILS_VERSIONS[rctx.attr.version][platform]["version_override"] or rctx.attr.version
+    version = rctx.attr.version
+    if "version_override" in COREUTILS_VERSIONS[rctx.attr.version][platform]:
+        version = COREUTILS_VERSIONS[rctx.attr.version][platform]["version_override"]
     url = "https://github.com/uutils/coreutils/releases/download/{}/{}".format(
         version,
         filename,

--- a/lib/private/coreutils_toolchain.bzl
+++ b/lib/private/coreutils_toolchain.bzl
@@ -51,6 +51,7 @@ COREUTILS_VERSIONS = {
             "sha256": "sha256-9zGLFOMDjUDbraDY/hrE5zFJ0O+QYrvx2wHk3Gw3q/A=",
         },
         "darwin_amd64": {
+            "version_override": "0.0.23",
             "filename": "coreutils-0.0.23-x86_64-apple-darwin.tar.gz",
             "sha256": "sha256-SswetVAuK/hMK1r9uBvNnKj5JpSgD0bzkbsHTxOabCo=",
         },
@@ -176,8 +177,9 @@ def _coreutils_platform_repo_impl(rctx):
     is_windows = rctx.attr.platform.startswith("windows_")
     platform = rctx.attr.platform
     filename = COREUTILS_VERSIONS[rctx.attr.version][platform]["filename"]
+    version = COREUTILS_VERSIONS[rctx.attr.version][platform]["version_override"] or rctx.attr.version
     url = "https://github.com/uutils/coreutils/releases/download/{}/{}".format(
-        rctx.attr.version,
+        version,
         filename,
     )
     rctx.download_and_extract(


### PR DESCRIPTION


---

### Changes are visible to end-users: no

### Test plan
- Manual testing; please provide instructions so we can reproduce:
Ran `bazel run //:format` locally to completion