### PR TITLE
fix: Directory hidden files in write_source_file.

### DIFF
--- a/lib/private/write_source_file.bzl
+++ b/lib/private/write_source_file.bzl
@@ -209,7 +209,7 @@ fi"""]
             executable_dir = "find \"$out\" -type f | xargs chmod -x"
         else:
             # Remove execute/search bit recursively from files bit not directories: https://superuser.com/a/434418
-            executable_dir = "chmod -R -x+X \"$out\"/{{*,.[!.]*}}"
+            executable_dir = "chmod -R -x+X \"$out\""
 
     for in_path, out_path in paths:
         contents.append("""
@@ -233,8 +233,8 @@ else
     chmod -R ug+w "$out" > /dev/null 2>&1 || true
     rm -Rf "$out"/{{*,.[!.]*}}
     mkdir -p "$out"
-    cp -fRL "$in"/{{*,.[!.]*}} "$out"
-    chmod -R ug+w "$out"/{{*,.[!.]*}}
+    cp -fRL "$in"/ "$out"
+    chmod -R ug+w "$out"
     {executable_dir}
 fi
 """.format(

--- a/lib/private/write_source_file.bzl
+++ b/lib/private/write_source_file.bzl
@@ -201,7 +201,7 @@ fi"""]
 
     if ctx.attr.executable:
         executable_file = "chmod +x \"$out\""
-        executable_dir = "chmod -R +x \"$out\"/{{*,.[!.]*}}"
+        executable_dir = "chmod -R +x \"$out\""
     else:
         executable_file = "chmod -x \"$out\""
         if is_macos:

--- a/lib/private/write_source_file.bzl
+++ b/lib/private/write_source_file.bzl
@@ -233,7 +233,7 @@ else
     chmod -R ug+w "$out" > /dev/null 2>&1 || true
     rm -Rf "$out"/{{*,.[!.]*}}
     mkdir -p "$out"
-    cp -fRL "$in"/ "$out"
+    cp -fRL "$in"/. "$out"
     chmod -R ug+w "$out"
     {executable_dir}
 fi

--- a/lib/private/write_source_file.bzl
+++ b/lib/private/write_source_file.bzl
@@ -201,7 +201,7 @@ fi"""]
 
     if ctx.attr.executable:
         executable_file = "chmod +x \"$out\""
-        executable_dir = "chmod -R +x \"$out\"/*"
+        executable_dir = "chmod -R +x \"$out\"/{{*,.[!.]*}}"
     else:
         executable_file = "chmod -x \"$out\""
         if is_macos:
@@ -209,7 +209,7 @@ fi"""]
             executable_dir = "find \"$out\" -type f | xargs chmod -x"
         else:
             # Remove execute/search bit recursively from files bit not directories: https://superuser.com/a/434418
-            executable_dir = "chmod -R -x+X \"$out\"/*"
+            executable_dir = "chmod -R -x+X \"$out\"/{{*,.[!.]*}}"
 
     for in_path, out_path in paths:
         contents.append("""
@@ -231,10 +231,10 @@ else
     echo "Copying directory $in to $out in $PWD"
     # in case `cp` from previous command was terminated midway which can result in read-only files/dirs
     chmod -R ug+w "$out" > /dev/null 2>&1 || true
-    rm -Rf "$out"/*
+    rm -Rf "$out"/{{*,.[!.]*}}
     mkdir -p "$out"
-    cp -fRL "$in"/* "$out"
-    chmod -R ug+w "$out"/*
+    cp -fRL "$in"/{{*,.[!.]*}} "$out"
+    chmod -R ug+w "$out"/{{*,.[!.]*}}
     {executable_dir}
 fi
 """.format(

--- a/lib/tests/write_source_files/BUILD.bazel
+++ b/lib/tests/write_source_files/BUILD.bazel
@@ -101,6 +101,19 @@ output_files(
     target = ":g_h-desired",
 )
 
+genrule(
+    name = "hidden-contained",
+    outs = [".hidden"],
+    cmd = "echo 'hidden file test' > $@",
+)
+
+copy_to_directory(
+    name = "hidden_dir-desired",
+    srcs = [
+        ":hidden-contained",
+    ],
+)
+
 write_source_file_test(
     name = "a_test",
     in_file = ":a-desired",
@@ -135,6 +148,12 @@ write_source_file_test(
     name = "g_test",
     in_file = ":g-desired",
     out_file = "g.js",
+)
+
+write_source_file(
+    name = "hidden_dir_test",
+    in_file = ":hidden_dir-desired",
+    out_file = "hidden_dir",
 )
 
 write_source_files(

--- a/lib/tests/write_source_files/hidden_dir/.hidden
+++ b/lib/tests/write_source_files/hidden_dir/.hidden
@@ -1,0 +1,1 @@
+hidden file test


### PR DESCRIPTION
Copy and manage hidden files starting with "." in write_source_files.

Previously these files were not supported if they were in the top level of the directory to copy.

Refs: #667 

<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

<!-- Delete any which do not apply -->

- Manual testing: Used this lib version to copy a directory of generated files that included hidden files.
