### PR TITLE
chore: add --check_direct_dependencies to .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,16 +10,21 @@ import %workspace%/.aspect/bazelrc/performance.bazelrc
 
 # For testing our --stamp behavior.
 # Normally users would use a --workspace_status_command with a script that calls `git describe`.
-build --embed_label=v1.2.3
+common --embed_label=v1.2.3
 
 # Mock versioning command to test the --stamp behavior
-build --workspace_status_command="echo BUILD_SCM_VERSION 1.2.3"
+common --workspace_status_command="echo BUILD_SCM_VERSION 1.2.3"
 
 # For releasing, use --workspace_status_command and stamp
 # before adding more flags to the release config make sure it does not
 # affect the hashes of /tools. See tools/release.bzl for opt transition
 # add appropriate commandline transition there to match the configuration.
 common:release -c opt
+
+# Don’t want to push a rules author to update their deps if not needed.
+# https://bazel.build/reference/command-line-reference#flag--check_direct_dependencies
+# https://bazelbuild.slack.com/archives/C014RARENH0/p1691158021917459?thread_ts=1691156601.420349&cid=C014RARENH0
+common --check_direct_dependencies=off
 
 # Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
 # This file should appear in `.gitignore` so that settings are not shared with team members. This


### PR DESCRIPTION
Setting this flag in our the rule sets we maintain. Don’t want to push a rules author to update their deps if not needed.

https://bazel.build/reference/command-line-reference#flag--check_direct_dependencies

https://bazelbuild.slack.com/archives/C014RARENH0/p1691158021917459?thread_ts=1691156601.420349&cid=C014RARENH0