### PR TITLE
fix: allow copy_to_directory to have an empty srcs list

### DIFF
--- a/lib/private/copy_to_directory.bzl
+++ b/lib/private/copy_to_directory.bzl
@@ -461,9 +461,6 @@ def copy_to_directory_bin_action(
         })
         file_inputs.append(f.file)
 
-    if not file_inputs:
-        fail("No files to copy")
-
     config = {
         "allow_overwrites": allow_overwrites,
         "dst": dst.path,

--- a/lib/tests/copy_to_directory/BUILD.bazel
+++ b/lib/tests/copy_to_directory/BUILD.bazel
@@ -449,3 +449,22 @@ diff_test(
     file1 = "case_21",
     file2 = ":expected_21",
 )
+
+# Case 22: empty sources creates an empty directory output
+copy_to_directory(
+    name = "case_22",
+    srcs = [],
+)
+
+copy_to_directory(
+    name = "expected_22",
+    srcs = ["dir_expected_22"],
+    exclude_srcs_patterns = ["**/filter_me_out"],
+)
+
+diff_test(
+    name = "case_22_test",
+    file1 = "case_22",
+    file2 = ":expected_22",
+    tags = ["local"],  # seems that the Bazel sandbox has trouble with empty directories
+)


### PR DESCRIPTION
Requested by a Bazel support customer where a copy_to_directory target in their repo had no srcs. 

Remove an explicit fail check on empty srcs since outputting an empty directory is valid in Bazel and a valid use case for `copy_to_directory` rule.

---

### Test plan

- New test cases added
