### PR TITLE
fix(tar): expose package_dir argument in mtree_mutate

### DIFF
--- a/docs/tar.md
+++ b/docs/tar.md
@@ -95,7 +95,7 @@ Rule that executes BSD `tar`. Most users should use the [`tar`](#tar) macro, rat
 ## mtree_mutate
 
 <pre>
-mtree_mutate(<a href="#mtree_mutate-name">name</a>, <a href="#mtree_mutate-mtree">mtree</a>, <a href="#mtree_mutate-strip_prefix">strip_prefix</a>, <a href="#mtree_mutate-mtime">mtime</a>, <a href="#mtree_mutate-owner">owner</a>, <a href="#mtree_mutate-ownername">ownername</a>, <a href="#mtree_mutate-awk_script">awk_script</a>, <a href="#mtree_mutate-kwargs">kwargs</a>)
+mtree_mutate(<a href="#mtree_mutate-name">name</a>, <a href="#mtree_mutate-mtree">mtree</a>, <a href="#mtree_mutate-strip_prefix">strip_prefix</a>, <a href="#mtree_mutate-package_dir">package_dir</a>, <a href="#mtree_mutate-mtime">mtime</a>, <a href="#mtree_mutate-owner">owner</a>, <a href="#mtree_mutate-ownername">ownername</a>, <a href="#mtree_mutate-awk_script">awk_script</a>, <a href="#mtree_mutate-kwargs">kwargs</a>)
 </pre>
 
 Modify metadata in an mtree file.
@@ -108,6 +108,7 @@ Modify metadata in an mtree file.
 | <a id="mtree_mutate-name"></a>name |  name of the target, output will be <code>[name].mtree</code>.   |  none |
 | <a id="mtree_mutate-mtree"></a>mtree |  input mtree file, typically created by <code>mtree_spec</code>.   |  none |
 | <a id="mtree_mutate-strip_prefix"></a>strip_prefix |  prefix to remove from all paths in the tar. Files and directories not under this prefix are dropped.   |  <code>None</code> |
+| <a id="mtree_mutate-package_dir"></a>package_dir |  directory prefix to add to all paths in the tar.   |  <code>None</code> |
 | <a id="mtree_mutate-mtime"></a>mtime |  new modification time for all entries.   |  <code>None</code> |
 | <a id="mtree_mutate-owner"></a>owner |  new uid for all entries.   |  <code>None</code> |
 | <a id="mtree_mutate-ownername"></a>ownername |  new uname for all entries.   |  <code>None</code> |

--- a/lib/tar.bzl
+++ b/lib/tar.bzl
@@ -130,6 +130,7 @@ def mtree_mutate(
         name,
         mtree,
         strip_prefix = None,
+        package_dir = None,
         mtime = None,
         owner = None,
         ownername = None,
@@ -141,6 +142,7 @@ def mtree_mutate(
         name: name of the target, output will be `[name].mtree`.
         mtree: input mtree file, typically created by `mtree_spec`.
         strip_prefix: prefix to remove from all paths in the tar. Files and directories not under this prefix are dropped.
+        package_dir: directory prefix to add to all paths in the tar.
         mtime: new modification time for all entries.
         owner: new uid for all entries.
         ownername: new uname for all entries.
@@ -150,6 +152,8 @@ def mtree_mutate(
     vars = []
     if strip_prefix:
         vars.append("-v strip_prefix='{}'".format(strip_prefix))
+    if package_dir:
+        vars.append("-v package_dir='{}'".format(package_dir))
     if mtime:
         vars.append("-v mtime='{}'".format(mtime))
     if owner:

--- a/lib/tests/tar/BUILD.bazel
+++ b/lib/tests/tar/BUILD.bazel
@@ -337,6 +337,7 @@ mtree_mutate(
     name = "modified1",
     mtree = "source-casync.mtree",
     strip_prefix = "xattr",
+    package_dir = "test",
 )
 
 diff_test(

--- a/lib/tests/tar/expected1.mtree
+++ b/lib/tests/tar/expected1.mtree
@@ -1,4 +1,4 @@
-xattr.go type=file mode=0664 size=984 uid=1000 gid=1000 uname=vbatts gname=vbatts time=1512774394.470900767 sha512256digest=a2700b603df30c3b0a91bdcf9045e64aea42f62647b0128ea154f51a0c48991e
-xattr_test.go type=file mode=0664 size=859 uid=1000 gid=1000 uname=vbatts gname=vbatts time=1512774394.470900767 sha512256digest=91294ea554801b75f6a9e33c268807c9620b531eb813ea24512dd4eeaf0592e4
-xattr_unsupported.go type=file mode=0664 size=509 uid=1000 gid=1000 uname=vbatts gname=vbatts time=1512774394.470900767 sha512256digest=81ced06a1cdf88c4936d10bbf8d46edc2d42dc26efeed3691ddbeeb469865f8a
-xattr_unsupported_test.go type=file mode=0664 size=877 uid=1000 gid=1000 uname=vbatts gname=vbatts time=1512774394.470900767 sha512256digest=46605a03a985c7a3a4ab1a488f81382db4865f77b90b6a2b32693af39a8e1fba
+test/xattr.go type=file mode=0664 size=984 uid=1000 gid=1000 uname=vbatts gname=vbatts time=1512774394.470900767 sha512256digest=a2700b603df30c3b0a91bdcf9045e64aea42f62647b0128ea154f51a0c48991e
+test/xattr_test.go type=file mode=0664 size=859 uid=1000 gid=1000 uname=vbatts gname=vbatts time=1512774394.470900767 sha512256digest=91294ea554801b75f6a9e33c268807c9620b531eb813ea24512dd4eeaf0592e4
+test/xattr_unsupported.go type=file mode=0664 size=509 uid=1000 gid=1000 uname=vbatts gname=vbatts time=1512774394.470900767 sha512256digest=81ced06a1cdf88c4936d10bbf8d46edc2d42dc26efeed3691ddbeeb469865f8a
+test/xattr_unsupported_test.go type=file mode=0664 size=877 uid=1000 gid=1000 uname=vbatts gname=vbatts time=1512774394.470900767 sha512256digest=46605a03a985c7a3a4ab1a488f81382db4865f77b90b6a2b32693af39a8e1fba


### PR DESCRIPTION
This was likely forgotten in #829 when making the parameters explicit during review.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes (stardoc)
- Breaking change (forces users to change their own code or config): no (genrule does not have a package_dir argument)
- Suggested release notes appear below: no (suggest to use commit message / PR title)

### Test plan

- New test cases added