### PR TITLE
perf: use darwin's clonefile syscall

### DIFF
--- a/tools/common/BUILD.bazel
+++ b/tools/common/BUILD.bazel
@@ -3,9 +3,20 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "common",
     srcs = [
+        "clonefile_darwin.go",
+        "clonefile_stub.go",
         "copy.go",
         "file.go",
     ],
     importpath = "github.com/aspect-build/bazel-lib/tools/common",
     visibility = ["//visibility:public"],
+    deps = select({
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "@org_golang_x_sys//unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:ios": [
+            "@org_golang_x_sys//unix:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/tools/common/clonefile_darwin.go
+++ b/tools/common/clonefile_darwin.go
@@ -9,13 +9,14 @@ import (
 
 // https://keith.github.io/xcode-man-pages/clonefile.2.html
 func cloneFile(src, dst string) (supported bool, err error) {
+	supported = true
 	if err = unix.Clonefile(src, dst, 0); err != nil {
-		return true, &os.LinkError{
+		err = &os.LinkError{
 			Op:  "clonefile",
 			Old: src,
 			New: dst,
 			Err: err,
 		}
 	}
-	return true, nil
+	return
 }

--- a/tools/common/clonefile_darwin.go
+++ b/tools/common/clonefile_darwin.go
@@ -1,0 +1,21 @@
+//go:build darwin
+
+package common
+
+import (
+	"golang.org/x/sys/unix"
+	"os"
+)
+
+// https://keith.github.io/xcode-man-pages/clonefile.2.html
+func cloneFile(src, dst string) (supported bool, err error) {
+	if err = unix.Clonefile(src, dst, 0); err != nil {
+		return true, &os.LinkError{
+			Op:  "clonefile",
+			Old: src,
+			New: dst,
+			Err: err,
+		}
+	}
+	return true, nil
+}

--- a/tools/common/clonefile_stub.go
+++ b/tools/common/clonefile_stub.go
@@ -3,5 +3,7 @@
 package common
 
 func cloneFile(src, dst string) (supported bool, err error) {
-	return false, nil
+	supported = false
+	err = nil
+	return
 }

--- a/tools/common/clonefile_stub.go
+++ b/tools/common/clonefile_stub.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package common
+
+func cloneFile(src, dst string) (supported bool, err error) {
+	return false, nil
+}

--- a/tools/common/copy.go
+++ b/tools/common/copy.go
@@ -30,32 +30,54 @@ func Copy(opts CopyOpts) {
 	if !opts.info.Mode().IsRegular() {
 		log.Fatalf("%s is not a regular file", opts.src)
 	}
+
+	opModifier := ""
+	const fallback = " (fallback)"
+
 	if opts.hardlink {
 		// hardlink this file
 		if opts.verbose {
-			fmt.Printf("hardlink %v => %v\n", opts.src, opts.dst)
+			fmt.Printf("hardlink%s %v => %v\n", opModifier, opts.src, opts.dst)
 		}
 		err := os.Link(opts.src, opts.dst)
 		if err != nil {
-			// fallback to copy
 			if opts.verbose {
 				fmt.Printf("hardlink failed: %v\n", err)
-				fmt.Printf("copy (fallback) %v => %v\n", opts.src, opts.dst)
+				opModifier = fallback
 			}
-			err = CopyFile(opts.src, opts.dst)
-			if err != nil {
-				log.Fatal(err)
-			}
+			// fallback to clonefile or copy
+		} else {
+			return
 		}
-	} else {
-		// copy this file
+	}
+
+	// clone this file
+	if opts.verbose {
+		fmt.Printf("clonefile%s %v => %v\n", opModifier, opts.src, opts.dst)
+	}
+	switch supported, err := cloneFile(opts.src, opts.dst); {
+	case !supported:
 		if opts.verbose {
-			fmt.Printf("copy %v => %v\n", opts.src, opts.dst)
+			fmt.Print("clonefile skipped: not supported by platform\n")
 		}
-		err := CopyFile(opts.src, opts.dst)
-		if err != nil {
-			log.Fatal(err)
+		// fallback to copy
+	case supported && err == nil:
+		return
+	case supported && err != nil:
+		if opts.verbose {
+			fmt.Printf("clonefile failed: %v\n", err)
+			opModifier = fallback
 		}
+		// fallback to copy
+	}
+
+	// copy this file
+	if opts.verbose {
+		fmt.Printf("copy%s %v => %v\n", opModifier, opts.src, opts.dst)
+	}
+	err := CopyFile(opts.src, opts.dst)
+	if err != nil {
+		log.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This can save time and disk-space when copying files around on the same device. File clones (aka reflinks) share backing disk blocks; they differ from hardlinks in that inodes are not shared and the contents are copy-on-write.

The Go standard library (as of v1.22) will arrange to do a similar thing for file copies on Linux (see: https://cs.opensource.google/go/go/+/refs/tags/go1.22.6:src/os/zero_copy_linux.go;l=53). Unfortunately, Mac OS' more limited API is less amenable to that form of transparent wrapping.

---

### Changes are visible to end-users: no

### Test plan

Manually confirmed that cloned files differ in inode but share backing blocks with a custom script ([gist](https://gist.github.com/plobsing/dc4456e1b461563a3a9e0e93673834b9)).

#### Before

```
❯ bazel test lib/tests/copy_to_directory:all
[...]
hardlink bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/b/b2 => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/b/b2
copy lib/tests/copy_to_directory/f/f2/f2 => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/f/f2/f2
hardlink bazel-out/darwin_arm64-fastbuild/bin/external/external_test_repo/test_a/test_a => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/test_a/test_a
hardlink bazel-out/darwin_arm64-fastbuild/bin/external/external_test_repo/test_a/test_a2 => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/test_a/test_a2
hardlink bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/a/a2 => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/a/a2
hardlink bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/a/a => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/a/a
copy lib/tests/copy_to_directory/e/e1 => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/e/e1
copy lib/tests/copy_to_directory/c => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/c
copy external/external_test_repo/test_c => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/test_c
copy external/external_test_repo/test_d => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/test_d
copy lib/tests/copy_to_directory/d => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/d
copy lib/tests/copy_to_directory/f/f2/f1 => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/f/f2/f1
copy lib/tests/copy_to_directory/e/e2 => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/e/e2
hardlink bazel-out/darwin_arm64-fastbuild/bin/external/external_test_repo/test_b/test_b2 => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/test_b/test_b2
hardlink bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/b/b => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/b/b
hardlink bazel-out/darwin_arm64-fastbuild/bin/external/external_test_repo/test_b/test_b => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/test_b/test_b
[...]
❯ log2phys lib/tests/copy_to_directory/f/f2/f2 bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/f/f2/f2
==== lib/tests/copy_to_directory/f/f2/f2 ====
st_dev:              16777232    st_ino:            940040459
logaddr:                    0    flags: 00000000    len:                    6    physaddr:         329977204736

==== bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/f/f2/f2 ====
st_dev:              16777232    st_ino:            940386312
logaddr:                    0    flags: 00000000    len:                    6    physaddr:         418410364928
```

#### After

```
❯ bazel test lib/tests/copy_to_directory:all                                                                                                
[...]
hardlink bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/a/a => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/a/a
hardlink bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/b/b2 => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/b/b2
clonefile lib/tests/copy_to_directory/f/f2/f2 => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/f/f2/f2
hardlink bazel-out/darwin_arm64-fastbuild/bin/external/external_test_repo/test_a/test_a2 => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/test_a/test_a2
clonefile lib/tests/copy_to_directory/e/e1 => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/e/e1
hardlink bazel-out/darwin_arm64-fastbuild/bin/external/external_test_repo/test_b/test_b => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/test_b/test_b
hardlink bazel-out/darwin_arm64-fastbuild/bin/external/external_test_repo/test_b/test_b2 => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/test_b/test_b2
clonefile external/external_test_repo/test_c => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/test_c
hardlink bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/b/b => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/b/b
clonefile external/external_test_repo/test_d => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/test_d
hardlink bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/a/a2 => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/a/a2
hardlink bazel-out/darwin_arm64-fastbuild/bin/external/external_test_repo/test_a/test_a => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/test_a/test_a
clonefile lib/tests/copy_to_directory/e/e2 => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/e/e2
clonefile lib/tests/copy_to_directory/c => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/c
clonefile lib/tests/copy_to_directory/f/f2/f1 => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/f/f2/f1
clonefile lib/tests/copy_to_directory/d => bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/d
[...]
❯ log2phys lib/tests/copy_to_directory/f/f2/f2 bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/f/f2/f2
==== lib/tests/copy_to_directory/f/f2/f2 ====
st_dev:              16777232    st_ino:            940040459
logaddr:                    0    flags: 00000000    len:                    6    physaddr:         329977204736

==== bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/f/f2/f2 ====
st_dev:              16777232    st_ino:            940389079
logaddr:                    0    flags: 00000000    len:                    6    physaddr:         329977204736

```

Note: source and cloned file differ in inode but contents share a location on disk. This relationship can be broken by making edits to the source file (exercising transparent copy-on-write).

```
❯ echo quux >> lib/tests/copy_to_directory/f/f2/f2
❯ log2phys lib/tests/copy_to_directory/f/f2/f2 bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/f/f2/f2
==== lib/tests/copy_to_directory/f/f2/f2 ====
st_dev:              16777232    st_ino:            940040459
logaddr:                    0    flags: 00000000    len:                   11    physaddr:         418404380672

==== bazel-out/darwin_arm64-fastbuild/bin/lib/tests/copy_to_directory/case_3/lib/tests/copy_to_directory/f/f2/f2 ====
st_dev:              16777232    st_ino:            940389079
logaddr:                    0    flags: 00000000    len:                    6    physaddr:         329977204736

```