### PR TITLE
chore: bazel run //:gazelle_update_repos

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -24,8 +24,8 @@ def go_dependencies():
         name = "org_golang_x_exp",
         build_file_proto_mode = "disable_global",
         importpath = "golang.org/x/exp",
-        sum = "h1:c0vyKkb6yr3KR7jEfJaOSv4lG7xPkbN6r52aJz1d8a8=",
-        version = "v0.0.0-20231206192017-f3f8817b8deb",
+        sum = "h1:Q8/wZp0KX97QFTc2ywcOE0YRjZPVIx+MXInMzdvQqcA=",
+        version = "v0.0.0-20240119083558-1b970713d09a",
     )
     go_repository(
         name = "org_golang_x_mod",


### PR DESCRIPTION
This got out of date due to a renovate dep bump. Guess we don't have a CI check for `bazel run //:gazelle_update_repos` yet here.
