### PR TITLE
fix: add bzlmod use_repo of org_golang_x_sys

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -66,6 +66,7 @@ use_repo(
     go_deps,
     "com_github_bmatcuk_doublestar_v4",
     "org_golang_x_exp",
+    "org_golang_x_sys",
 )
 
 host = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "host", dev_dependency = True)


### PR DESCRIPTION
Commit 3c121a9cd9c665f3aca903c473ec91dc8af68721 broke E2E tests with the following error:

```
(23:31:56) ERROR: no such package '@@[unknown repo 'org_golang_x_sys' requested from @@aspect_bazel_lib~]//unix': The repository '@@[unknown repo 'org_golang_x_sys' requested from @@aspect_bazel_lib~]' could not be resolved: No repository visible as '@org_golang_x_sys' from repository '@@aspect_bazel_lib~'
```

The build worked when operating within the `aspect_bazel_lib` repo itself, but not when importing it with Bzlmod. This is because the `org_golang_x_sys` repo is imported indirectly by `rules_go`'s `go_rules_dependencies` macro in the `WORKSPACE` file, which is still active under bzlmod because there is no `WORKSPACE.bzlmod` file to suppress it.

---

### Changes are visible to end-users: no

### Test plan

Have confirmed that `e2e/copy_to_directory` and `e2e/external_copy_to_directory`
were broken before this change and fixed after.