### PR TITLE
Fix a compatability issue with the mtime test and Mac

### DIFF
--- a/e2e/smoke/test_preserve_mtime.sh
+++ b/e2e/smoke/test_preserve_mtime.sh
@@ -7,15 +7,26 @@ function main {
   compareMTimes d/1 copy_directory_mtime_out/1
 }
 
+function mtime {
+    local file="$1"
+    if [[ "$(uname)" == "Linux" ]]; then
+        stat --dereference --format=%y "$file"
+    elif [[ "$(uname)" == "Darwin" ]]; then
+        stat -L -f %m "$file"
+    else
+        echo "untested"
+    fi
+}
+
 function compareMTimes {
   local originalFile="$1"
   local copiedFile="$2"
 
-  local mtimeOriginal
-  mtimeOriginal="$(stat --dereference --format=%y "$originalFile")"
+    local mtimeOriginal
+    mtimeOriginal="$(mtime "$originalFile")"
 
-  local mtimeCopy
-  mtimeCopy="$(stat --dereference --format=%y "$copiedFile")"
+    local mtimeCopy
+    mtimeCopy="$(mtime "$copiedFile")"
 
   if [[ "$mtimeOriginal" != "$mtimeCopy" ]]; then
     echo "Preserve mtime test failed. Modify times do not match for $originalFile and $copiedFile"


### PR DESCRIPTION
Fix a CI failure caused by the new mtime test.

### Changes are visible to end-users: no

### Test plan

The tests were run locally for the Linux variant only.