### PR TITLE
refactor: deprecated expand_locations which is just pass-through to ctx.expand_location()

### DIFF
--- a/docs/expand_make_vars.md
+++ b/docs/expand_make_vars.md
@@ -48,6 +48,10 @@ The deprecated `$(location)` and `$(locations)` expansions returns either the ex
 
 The expanded path or the original path
 
+**DEPRECATED**
+
+Use vanilla `ctx.expand_location(input, targets = targets)` instead
+
 
 <a id="expand_variables"></a>
 

--- a/lib/expand_make_vars.bzl
+++ b/lib/expand_make_vars.bzl
@@ -1,5 +1,6 @@
 "Public API for expanding variables"
 
+# buildifier: disable=deprecated-function
 load("//lib/private:expand_locations.bzl", _expand_locations = "expand_locations")
 load("//lib/private:expand_variables.bzl", _expand_variables = "expand_variables")
 

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -122,7 +122,6 @@ bzl_library(
     srcs = ["expand_template.bzl"],
     visibility = ["//lib:__subpackages__"],
     deps = [
-        ":expand_locations",
         ":expand_variables",
         "//lib:stamping",
         "@bazel_skylib//lib:dicts",
@@ -161,7 +160,6 @@ bzl_library(
     srcs = ["jq.bzl"],
     visibility = ["//lib:__subpackages__"],
     deps = [
-        ":expand_locations",
         "//lib:stamping",
     ],
 )
@@ -184,7 +182,6 @@ bzl_library(
     name = "params_file",
     srcs = ["params_file.bzl"],
     visibility = ["//lib:__subpackages__"],
-    deps = [":expand_locations"],
 )
 
 bzl_library(
@@ -206,7 +203,6 @@ bzl_library(
     srcs = ["run_binary.bzl"],
     visibility = ["//lib:__subpackages__"],
     deps = [
-        ":expand_locations",
         ":expand_variables",
         "//lib:stamping",
         "@bazel_skylib//lib:dicts",
@@ -284,7 +280,6 @@ bzl_library(
     srcs = ["bats.bzl"],
     visibility = ["//lib:__subpackages__"],
     deps = [
-        ":expand_locations",
         ":expand_variables",
         "@aspect_bazel_lib//lib:paths",
         "@aspect_bazel_lib//lib:windows_utils",

--- a/lib/private/bats.bzl
+++ b/lib/private/bats.bzl
@@ -2,7 +2,6 @@
 
 load("//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
 load("//lib:windows_utils.bzl", "create_windows_native_launcher_script")
-load(":expand_locations.bzl", "expand_locations")
 load(":expand_variables.bzl", "expand_variables")
 
 _LAUNCHER_TMPL = """#!/usr/bin/env bash
@@ -42,7 +41,7 @@ def _bats_test_impl(ctx):
     for (key, value) in ctx.attr.env.items():
         envs.append(_ENV_SET.format(
             key = key,
-            value = " ".join([expand_variables(ctx, exp, attribute_name = "env") for exp in expand_locations(ctx, value, ctx.attr.data).split(" ")]),
+            value = " ".join([expand_variables(ctx, exp, attribute_name = "env") for exp in ctx.expand_location(value, targets = ctx.attr.data).split(" ")]),
         ))
 
     # See https://www.msys2.org/wiki/Porting/:

--- a/lib/private/expand_locations.bzl
+++ b/lib/private/expand_locations.bzl
@@ -32,6 +32,9 @@ def expand_locations(ctx, input, targets = []):
 
     Returns:
       The expanded path or the original path
+
+    Deprecated:
+      Use vanilla `ctx.expand_location(input, targets = targets)` instead
     """
 
     return ctx.expand_location(input, targets = targets)

--- a/lib/private/expand_template.bzl
+++ b/lib/private/expand_template.bzl
@@ -2,7 +2,6 @@
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("//lib:stamping.bzl", "STAMP_ATTRS", "maybe_stamp")
-load(":expand_locations.bzl", _expand_locations = "expand_locations")
 load(":expand_variables.bzl", _expand_variables = "expand_variables")
 
 def _expand_substitutions(ctx, output, substitutions):
@@ -10,7 +9,7 @@ def _expand_substitutions(ctx, output, substitutions):
     for k, v in substitutions.items():
         result[k] = " ".join([
             _expand_variables(ctx, e, outs = [output], attribute_name = "substitutions")
-            for e in _expand_locations(ctx, v, ctx.attr.data).split(" ")
+            for e in ctx.expand_location(v, targets = ctx.attr.data).split(" ")
         ])
     return result
 

--- a/lib/private/jq.bzl
+++ b/lib/private/jq.bzl
@@ -1,7 +1,6 @@
 """Implementation for jq rule"""
 
 load("//lib:stamping.bzl", "STAMP_ATTRS", "maybe_stamp")
-load(":expand_locations.bzl", "expand_locations")
 
 _jq_attrs = dict({
     "srcs": attr.label_list(
@@ -27,7 +26,7 @@ def _expand_locations(ctx, s):
     # `.split(" ")` is a work-around https://github.com/bazelbuild/bazel/issues/10309
     # TODO: If the string has intentional spaces or if one or more of the expanded file
     # locations has a space in the name, we will incorrectly split it into multiple arguments
-    return expand_locations(ctx, s, targets = ctx.attr.data).split(" ")
+    return ctx.expand_location(s, targets = ctx.attr.data).split(" ")
 
 def _jq_impl(ctx):
     jq_bin = ctx.toolchains["@aspect_bazel_lib//lib:jq_toolchain_type"].jqinfo.bin

--- a/lib/private/params_file.bzl
+++ b/lib/private/params_file.bzl
@@ -1,7 +1,5 @@
 "params_file rule"
 
-load(":expand_locations.bzl", "expand_locations")
-
 _ATTRS = {
     "args": attr.string_list(),
     "data": attr.label_list(allow_files = True),
@@ -17,7 +15,7 @@ def _expand_locations(ctx, s):
     # `.split(" ")` is a work-around https://github.com/bazelbuild/bazel/issues/10309
     # TODO: If the string has intentional spaces or if one or more of the expanded file
     # locations has a space in the name, we will incorrectly split it into multiple arguments
-    return expand_locations(ctx, s, targets = ctx.attr.data).split(" ")
+    return ctx.expand_location(s, targets = ctx.attr.data).split(" ")
 
 def _params_file_impl(ctx):
     is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])

--- a/lib/private/run_binary.bzl
+++ b/lib/private/run_binary.bzl
@@ -16,7 +16,6 @@
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("//lib:stamping.bzl", "STAMP_ATTRS", "maybe_stamp")
-load(":expand_locations.bzl", "expand_locations")
 load(":expand_variables.bzl", "expand_variables")
 
 def _run_binary_impl(ctx):
@@ -52,10 +51,10 @@ Possible fixes:
     # TODO: If the string has intentional spaces or if one or more of the expanded file
     # locations has a space in the name, we will incorrectly split it into multiple arguments
     for a in ctx.attr.args:
-        args.add_all([expand_variables(ctx, e, outs = outputs) for e in expand_locations(ctx, a, ctx.attr.srcs).split(" ")])
+        args.add_all([expand_variables(ctx, e, outs = outputs) for e in ctx.expand_location(a, targets = ctx.attr.srcs).split(" ")])
     envs = {}
     for k, v in ctx.attr.env.items():
-        envs[k] = " ".join([expand_variables(ctx, e, outs = outputs, attribute_name = "env") for e in expand_locations(ctx, v, ctx.attr.srcs).split(" ")])
+        envs[k] = " ".join([expand_variables(ctx, e, outs = outputs, attribute_name = "env") for e in ctx.expand_location(v, targets = ctx.attr.srcs).split(" ")])
 
     stamp = maybe_stamp(ctx)
     if stamp:


### PR DESCRIPTION
`expand_locations` is marked DEPRECATED since it now just calls `ctx.expand_location(input, targets = targets)`. There was once a custom implementation but that was removed a while ago.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`expand_locations` is marked DEPRECATED since it now just calls `ctx.expand_location(input, targets = targets)`. There was once a custom implementation but that was removed a while ago.

### Test plan

- Covered by existing test cases
