### PR TITLE
chore: fixup test sizes to resolve warnings

### DIFF
--- a/lib/tests/base64_tests.bzl
+++ b/lib/tests/base64_tests.bzl
@@ -1,5 +1,6 @@
 """unit tests for base64"""
 
+load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//lib/private:base64.bzl", "decode", "encode")
 load("//lib/private:strings.bzl", "INT_TO_CHAR")
@@ -45,5 +46,5 @@ base64_test = unittest.make(_base64_test_impl)
 def base64_test_suite():
     unittest.suite(
         "base64_tests",
-        base64_test,
+        partial.make(base64_test, timeout = "short"),
     )

--- a/lib/tests/lists_test.bzl
+++ b/lib/tests/lists_test.bzl
@@ -1,5 +1,6 @@
 """unit tests for lists"""
 
+load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//lib/private:lists.bzl", "every", "filter", "find", "map", "once", "pick", "some", "unique")
 
@@ -82,12 +83,12 @@ unique_test = unittest.make(_unique_test_impl)
 def lists_test_suite():
     unittest.suite(
         "lists_tests",
-        every_test,
-        filter_test,
-        find_test,
-        map_test,
-        once_test,
-        pick_test,
-        some_test,
-        unique_test,
+        partial.make(every_test, timeout = "short"),
+        partial.make(filter_test, timeout = "short"),
+        partial.make(find_test, timeout = "short"),
+        partial.make(map_test, timeout = "short"),
+        partial.make(once_test, timeout = "short"),
+        partial.make(pick_test, timeout = "short"),
+        partial.make(some_test, timeout = "short"),
+        partial.make(unique_test, timeout = "short"),
     )

--- a/lib/tests/strings_tests.bzl
+++ b/lib/tests/strings_tests.bzl
@@ -1,5 +1,6 @@
 """unit tests for string"""
 
+load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//lib/private:strings.bzl", "chr", "hex", "ord")
 
@@ -58,7 +59,7 @@ hex_test = unittest.make(_hex_test_impl)
 def strings_test_suite():
     unittest.suite(
         "strings_tests",
-        ord_test,
-        chr_test,
-        hex_test,
+        partial.make(ord_test, timeout = "short"),
+        partial.make(chr_test, timeout = "short"),
+        partial.make(hex_test, timeout = "short"),
     )


### PR DESCRIPTION
Resolves:

```
//lib/tests:base64_tests_test_0                                          PASSED in 1.3s
  WARNING: //lib/tests:base64_tests_test_0: Test execution time (1.3s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//lib/tests:lists_tests_test_0                                           PASSED in 1.5s
  WARNING: //lib/tests:lists_tests_test_0: Test execution time (1.5s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//lib/tests:lists_tests_test_1                                           PASSED in 1.6s
  WARNING: //lib/tests:lists_tests_test_1: Test execution time (1.6s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//lib/tests:lists_tests_test_2                                           PASSED in 1.4s
  WARNING: //lib/tests:lists_tests_test_2: Test execution time (1.4s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//lib/tests:lists_tests_test_3                                           PASSED in 1.1s
  WARNING: //lib/tests:lists_tests_test_3: Test execution time (1.1s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//lib/tests:lists_tests_test_4                                           PASSED in 1.5s
  WARNING: //lib/tests:lists_tests_test_4: Test execution time (1.5s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//lib/tests:lists_tests_test_5                                           PASSED in 1.3s
  WARNING: //lib/tests:lists_tests_test_5: Test execution time (1.3s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//lib/tests:lists_tests_test_6                                           PASSED in 1.5s
  WARNING: //lib/tests:lists_tests_test_6: Test execution time (1.5s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//lib/tests:lists_tests_test_7                                           PASSED in 1.6s
  WARNING: //lib/tests:lists_tests_test_7: Test execution time (1.6s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//lib/tests:strings_tests_test_0                                         PASSED in 1.5s
  WARNING: //lib/tests:strings_tests_test_0: Test execution time (1.5s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//lib/tests:strings_tests_test_1                                         PASSED in 1.4s
  WARNING: //lib/tests:strings_tests_test_1: Test execution time (1.4s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//lib/tests:strings_tests_test_2                                         PASSED in 1.5s
  WARNING: //lib/tests:strings_tests_test_2: Test execution time (1.5s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
```