### PR TITLE
chore: skip linux only tests on non-linux platforms

### DIFF
--- a/lib/tests/transitions/BUILD.bazel
+++ b/lib/tests/transitions/BUILD.bazel
@@ -137,6 +137,7 @@ platform_transition_test(
     # only run this test on x86_64 platforms
     target_compatible_with = [
         "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
     ],
     target_platform = "x86_64_linux",
 )
@@ -147,6 +148,7 @@ platform_transition_test(
     # only run this test on arm64 platforms
     target_compatible_with = [
         "@platforms//cpu:arm64",
+        "@platforms//os:linux",
     ],
     target_platform = "arm64_linux",
 )


### PR DESCRIPTION
These fail locally on macos.
