### PR TITLE
chore: right size tests to supress bazel warning

### DIFF
--- a/lib/tests/transitions/BUILD.bazel
+++ b/lib/tests/transitions/BUILD.bazel
@@ -116,6 +116,7 @@ go_binary(
 
 go_test(
     name = "test_transition_test",
+    size = "small",
     srcs = ["simple_test.go"],
 )
 
@@ -155,6 +156,7 @@ platform_transition_test(
 
 sh_test(
     name = "test_go_binary_is_x86_64",
+    size = "small",
     srcs = ["test_file_type_contains.sh"],
     args = [
         "$(rootpath :transitioned_go_binary_x86_64)",
@@ -165,6 +167,7 @@ sh_test(
 
 sh_test(
     name = "test_go_binary_is_arm64",
+    size = "small",
     srcs = ["test_file_type_contains.sh"],
     args = [
         "$(rootpath :transitioned_go_binary_arm64)",
@@ -175,6 +178,7 @@ sh_test(
 
 sh_test(
     name = "test_go_test_is_x86_64",
+    size = "small",
     srcs = ["test_file_type_contains.sh"],
     args = [
         "$(rootpath :transitioned_go_test_x86_64)",
@@ -185,6 +189,7 @@ sh_test(
 
 sh_test(
     name = "test_go_test_is_arm64",
+    size = "small",
     srcs = ["test_file_type_contains.sh"],
     args = [
         "$(rootpath :transitioned_go_test_arm64)",

--- a/shlib/tests/lib_tests/assertions_tests/BUILD.bazel
+++ b/shlib/tests/lib_tests/assertions_tests/BUILD.bazel
@@ -6,6 +6,7 @@ sh_library(
 
 sh_test(
     name = "assert_equal_test",
+    size = "small",
     srcs = ["assert_equal_test.sh"],
     deps = [
         ":assert_fail",
@@ -16,6 +17,7 @@ sh_test(
 
 sh_test(
     name = "assert_match_test",
+    size = "small",
     srcs = ["assert_match_test.sh"],
     deps = [
         ":assert_fail",
@@ -26,6 +28,7 @@ sh_test(
 
 sh_test(
     name = "assert_no_match_test",
+    size = "small",
     srcs = ["assert_no_match_test.sh"],
     deps = [
         ":assert_fail",


### PR DESCRIPTION
Resolves:

```
//lib/tests/transitions:test_go_binary_is_arm64                 (cached) PASSED in 0.1s
  WARNING: //lib/tests/transitions:test_go_binary_is_arm64: Test execution time (0.1s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//lib/tests/transitions:test_go_binary_is_x86_64                (cached) PASSED in 0.2s
  WARNING: //lib/tests/transitions:test_go_binary_is_x86_64: Test execution time (0.2s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//lib/tests/transitions:test_go_test_is_x86_64                  (cached) PASSED in 0.1s
  WARNING: //lib/tests/transitions:test_go_test_is_x86_64: Test execution time (0.1s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//lib/tests/transitions:test_transition_test                    (cached) PASSED in 0.0s
  WARNING: //lib/tests/transitions:test_transition_test: Test execution time (0.0s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//lib/tests/transitions:transitioned_go_test_x86_64             (cached) PASSED in 0.1s
  WARNING: //lib/tests/transitions:transitioned_go_test_x86_64: Test execution time (0.1s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
...
//shlib/tests/lib_tests/assertions_tests:assert_equal_test      (cached) PASSED in 0.6s
  WARNING: //shlib/tests/lib_tests/assertions_tests:assert_equal_test: Test execution time (0.6s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//shlib/tests/lib_tests/assertions_tests:assert_match_test      (cached) PASSED in 0.7s
  WARNING: //shlib/tests/lib_tests/assertions_tests:assert_match_test: Test execution time (0.7s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//shlib/tests/lib_tests/assertions_tests:assert_no_match_test   (cached) PASSED in 0.7s
  WARNING: //shlib/tests/lib_tests/assertions_tests:assert_no_match_test: Test execution time (0.7s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
```