### PR TITLE
chore: remove non-bzlmod dep on @internal_platforms_do_not_use//host:constraints.bzl now that root workspace is bzlmod-only

### DIFF
--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -265,12 +265,7 @@ bzl_library(
         "@host_platform//:constraints.bzl",  # keep
         "@local_config_platform//:constraints.bzl",  # keep
         "@platforms//host:constraints.bzl",  # keep
-    ] + (select({
-        "@aspect_bazel_lib//lib:bzlmod": [],
-        "//conditions:default": [
-            "@internal_platforms_do_not_use//host:constraints.bzl",  # keep
-        ],
-    }) if is_bazel_7_or_greater() else []),
+    ],
     visibility = ["//lib:__subpackages__"],
     deps = [],  # keep
 )


### PR DESCRIPTION
Now that #915 landed we can remove this sadness.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
