### PR TITLE
chore: add `bzl_srcs` filegroup rules

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -146,3 +146,14 @@ filegroup(
     srcs = glob(["*.md"]),
     tags = ["markdown"],
 )
+
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(
+        include = ["**/*.bzl"],
+        exclude = ["bazel-*/**"],
+    ) + [
+        "//lib:bzl_srcs",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -329,3 +329,11 @@ bzl_library(
     name = "resource_sets",
     srcs = ["resource_sets.bzl"],
 )
+
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["**/*.bzl"]) + [
+        "//lib/private:bzl_srcs",
+    ],
+    visibility = ["//:subpackages"],
+)

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -15,6 +15,12 @@ exports_files(
     visibility = ["//lib/private/docs:__pkg__"],
 )
 
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["**/*.bzl"]),
+    visibility = ["//:__subpackages__"],
+)
+
 utf8_environment(
     name = "utf8_environment",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
https://github.com/abrisco/rules_helm/pull/188 adds a dependency on `aspect_bazel_lib` and uses https://github.com/bazelbuild/stardoc/blob/master/docs/generating_stardoc.md to generate documentation, which requires the complete set of Bazel sources.

Attempting to fix this build error:

```
$ bazel build //docs:rules.extract
ERROR: /home/zachburg/github/rules_helm/docs/BUILD.bazel:16:8: in deps attribute of starlark_doc_extract rule //docs:rules.extract: missing bzl_library targets for Starlark module(s) @aspect_bazel_lib//lib:base64.bzl, @aspect_bazel_lib//lib:repo_utils.bzl. Since this rule was created by the macro 'stardoc', the error might have been caused by the macro implementation
ERROR: /home/zachburg/github/rules_helm/docs/BUILD.bazel:16:8: Analysis of target '//docs:rules.extract' failed
ERROR: Analysis of target '//docs:rules.extract' failed; build aborted
INFO: Elapsed time: 0.074s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
ERROR: Build did NOT complete successfully
```