### PR TITLE
fix: build for bazel 9

### DIFF
--- a/.bcr/patches/go_dev_dep.patch
+++ b/.bcr/patches/go_dev_dep.patch
@@ -11,7 +11,7 @@ index eec026a..4854935 100644
  )
  bazel_dep(
      name = "rules_go",
-     version = "0.58.3",
+     version = "0.59.0",
      repo_name = "io_bazel_rules_go",
 -    # In released versions: dev_dependency = True
 +    dev_dependency = True,

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -41,7 +41,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_go",
-    version = "0.58.3",
+    version = "0.59.0",
     repo_name = "io_bazel_rules_go",
     # In released versions: dev_dependency = True
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bazel-contrib/bazel-lib
 go 1.24.6
 
 require (
-	github.com/bazelbuild/rules_go v0.55.0
+	github.com/bazelbuild/rules_go v0.59.0
 	github.com/bmatcuk/doublestar/v4 v4.7.1
 	golang.org/x/exp v0.0.0-20240823005443-9b4947da3948
 	golang.org/x/sys v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bazelbuild/rules_go v0.55.0 h1:S8X/b/Oygw/Dtv7NuyW7ht0QwdynMEdXQqYigX5A1KY=
-github.com/bazelbuild/rules_go v0.55.0/go.mod h1:T90Gpyq4HDFlsrvtQa2CBdHNJ2P4rAu/uUTmQbanzf0=
+github.com/bazelbuild/rules_go v0.59.0 h1:RLhOwYIqeMgBpKelHEWTfIPjA37so3oa/rX+/qqq/P4=
+github.com/bazelbuild/rules_go v0.59.0/go.mod h1:Pn30cb4M513fe2rQ6GiJ3q8QyrRsgC7zhuDvi50Lw4Y=
 github.com/bmatcuk/doublestar/v4 v4.7.1 h1:fdDeAqgT47acgwd9bd9HxJRDmc9UAmPpc+2m0CXv75Q=
 github.com/bmatcuk/doublestar/v4 v4.7.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 golang.org/x/exp v0.0.0-20240823005443-9b4947da3948 h1:kx6Ds3MlpiUHKj7syVnbp57++8WpuKPcR5yjLBjvLEA=


### PR DESCRIPTION
Observed failures on https://github.com/bazel-contrib/bazel-lib/pull/1214 and https://github.com/bazel-contrib/bazel-lib/pull/1213 for bazel 9. This PR should fix them and unblock the other PRs.