### PR TITLE
fix(2.x): alias DirectoryPath to bazel_lib

### DIFF
--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -96,7 +96,10 @@ bzl_library(
     name = "directory_path",
     srcs = ["directory_path.bzl"],
     visibility = ["//lib:__subpackages__"],
-    deps = ["//lib:utils"],
+    deps = [
+        "//lib:utils",
+        "@bazel_lib//lib:directory_path",
+    ],
 )
 
 #keep

--- a/lib/private/directory_path.bzl
+++ b/lib/private/directory_path.bzl
@@ -2,15 +2,11 @@
 with a path nested within that directory
 """
 
+load("@bazel_lib//lib:directory_path.bzl", _DirectoryPathInfo = "DirectoryPathInfo")
 load("//lib:utils.bzl", _to_label = "to_label")
 
-DirectoryPathInfo = provider(
-    doc = "Joins a label pointing to a TreeArtifact with a path nested within that directory.",
-    fields = {
-        "directory": "a TreeArtifact (ctx.actions.declare_directory)",
-        "path": "path relative to the directory",
-    },
-)
+# Alias the modern bazel_lib v3 providers to ease migration of rulesets to v3.
+DirectoryPathInfo = _DirectoryPathInfo
 
 def _directory_path(ctx):
     if not ctx.file.directory.is_directory:


### PR DESCRIPTION
The goal is to make libraries such as rules_js not have to depend on both v2 and v3 for backward compatibility.