### PR TITLE
perf: Remove no-sandbox from copy exec requirements

### DIFF
--- a/lib/private/copy_common.bzl
+++ b/lib/private/copy_common.bzl
@@ -1,15 +1,5 @@
 "Helpers for copy rules"
 
-# Hints for Bazel spawn strategy
 COPY_EXECUTION_REQUIREMENTS = {
-    # ----------------+-----------------------------------------------------------------------------
-    # no-sandbox      | Results in the action or test never being sandboxed; it can still be cached
-    #                 | or run remotely.
-    # ----------------+-----------------------------------------------------------------------------
-    # See https://bazel.google.cn/reference/be/common-definitions?hl=en&authuser=0#common-attributes
-    #
-    # Sandboxing for this action is wasteful since there is a 1:1 mapping of input file/directory to
-    # output file/directory so little room for non-hermetic inputs to sneak in to the execution.
-    "no-sandbox": "1",
     "supports-path-mapping": "1",
 }


### PR DESCRIPTION
Path mapping does not work without sandboxing, and deduping the actions (especially npm packages/etc) is likely a nicer win than the benefit of not sandboxing, given the lower number of inputs.