### PR TITLE
fix(2.x): alias copy_directory_bin_action to bazel_lib

### DIFF
--- a/docs/copy_file.md
+++ b/docs/copy_file.md
@@ -68,7 +68,7 @@ To use `copy_file_action` in your own rules, you need to include the toolchains 
 in your rule definition. For example:
 
 ```starlark
-load("@aspect_bazel_lib//lib:copy_file.bzl", "COPY_FILE_TOOLCHAINS")
+load("@bazel_lib//lib:copy_file.bzl", "COPY_FILE_TOOLCHAINS")
 
 my_rule = rule(
     ...,
@@ -80,7 +80,7 @@ Additionally, you must ensure that the coreutils toolchain is has been registere
 WORKSPACE if you are not using bzlmod:
 
 ```starlark
-load("@aspect_bazel_lib//lib:repositories.bzl", "register_coreutils_toolchains")
+load("@bazel_lib//lib:repositories.bzl", "register_coreutils_toolchains")
 
 register_coreutils_toolchains()
 ```

--- a/docs/copy_to_bin.md
+++ b/docs/copy_to_bin.md
@@ -30,7 +30,7 @@ To use `copy_file_to_bin_action` in your own rules, you need to include the tool
 in your rule definition. For example:
 
 ```starlark
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS")
+load("@bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS")
 
 my_rule = rule(
     ...,
@@ -42,7 +42,7 @@ Additionally, you must ensure that the coreutils toolchain is has been registere
 WORKSPACE if you are not using bzlmod:
 
 ```starlark
-load("@aspect_bazel_lib//lib:repositories.bzl", "register_coreutils_toolchains")
+load("@bazel_lib//lib:repositories.bzl", "register_coreutils_toolchains")
 
 register_coreutils_toolchains()
 ```

--- a/lib/copy_file.bzl
+++ b/lib/copy_file.bzl
@@ -30,11 +30,10 @@ This fork of bazel-skylib's copy_file adds `DirectoryPathInfo` support and allow
 
 load(
     "@bazel_lib//lib:copy_file.bzl",
-    _COPY_FILE_TOOLCHAINS = "COPY_FILE_TOOLCHAINS",
     _copy_file = "copy_file",
     _copy_file_action = "copy_file_action",
 )
 
 copy_file = _copy_file
 copy_file_action = _copy_file_action
-COPY_FILE_TOOLCHAINS = _COPY_FILE_TOOLCHAINS
+COPY_FILE_TOOLCHAINS = ["@aspect_bazel_lib//lib:coreutils_toolchain_type"]

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -32,8 +32,8 @@ bzl_library(
     srcs = ["copy_directory.bzl"],
     visibility = ["//lib:__subpackages__"],
     deps = [
-        ":copy_common",
         ":platform_utils",
+        "@bazel_lib//lib:copy_directory",
     ],
 )
 
@@ -52,11 +52,8 @@ bzl_library(
     srcs = ["copy_to_directory.bzl"],
     visibility = ["//lib:__subpackages__"],
     deps = [
-        ":copy_common",
         ":directory_path",
-        ":glob_match",
-        ":paths",
-        ":platform_utils",
+        "@bazel_lib//lib:copy_to_directory",
         "@bazel_skylib//lib:paths",
     ],
 )
@@ -264,12 +261,6 @@ bzl_library(
 bzl_library(
     name = "bats_toolchain",
     srcs = ["bats_toolchain.bzl"],
-    visibility = ["//lib:__subpackages__"],
-)
-
-bzl_library(
-    name = "copy_common",
-    srcs = ["copy_common.bzl"],
     visibility = ["//lib:__subpackages__"],
 )
 

--- a/lib/private/copy_common.bzl
+++ b/lib/private/copy_common.bzl
@@ -1,9 +1,0 @@
-"Helpers for copy rules"
-
-load(
-    "@bazel_lib//lib/private:copy_common.bzl",
-    _COPY_EXECUTION_REQUIREMENTS = "COPY_EXECUTION_REQUIREMENTS",
-)
-
-# Hints for Bazel spawn strategy
-COPY_EXECUTION_REQUIREMENTS = _COPY_EXECUTION_REQUIREMENTS

--- a/lib/private/copy_directory.bzl
+++ b/lib/private/copy_directory.bzl
@@ -3,7 +3,7 @@
 This rule copies a directory to another location using a precompiled binary.
 """
 
-load(":copy_common.bzl", _COPY_EXECUTION_REQUIREMENTS = "COPY_EXECUTION_REQUIREMENTS")
+load("@bazel_lib//lib:copy_directory.bzl", _copy_directory_bin_action = "copy_directory_bin_action")
 
 def copy_directory_bin_action(
         ctx,
@@ -43,32 +43,15 @@ def copy_directory_bin_action(
             See the caveats above about interactions with remote execution and caching.
 
     """
-    args = [
-        src.path,
-        dst.path,
-    ]
-    if verbose:
-        args.append("--verbose")
-
-    if hardlink == "on":
-        args.append("--hardlink")
-    elif hardlink == "auto" and not src.is_source:
-        args.append("--hardlink")
-
-    if preserve_mtime:
-        args.append("--preserve-mtime")
-
-    ctx.actions.run(
-        inputs = [src],
-        outputs = [dst],
-        executable = copy_directory_bin,
-        arguments = args,
-        # TODO: Drop this after https://github.com/bazel-contrib/bazel-lib/issues/1146
-        env = {"GODEBUG": "winsymlink=0"},
-        mnemonic = "CopyDirectory",
-        progress_message = "Copying directory %{input}",
-        execution_requirements = _COPY_EXECUTION_REQUIREMENTS,
-        toolchain = copy_directory_toolchain,
+    _copy_directory_bin_action(
+        ctx,
+        src = src,
+        dst = dst,
+        copy_directory_bin = copy_directory_bin,
+        copy_directory_toolchain = copy_directory_toolchain,
+        hardlink = hardlink,
+        verbose = verbose,
+        preserve_mtime = preserve_mtime,
     )
 
 def _copy_directory_impl(ctx):


### PR DESCRIPTION
So 2.x does not need to refer to the private `COPY_EXECUTION_REQUIREMENTS`.