### PR TITLE
fix(2.x): reference aspect_bazel_lib toolchains in public consts

### DIFF
--- a/e2e/copy_action/copy.bzl
+++ b/e2e/copy_action/copy.bzl
@@ -1,6 +1,7 @@
 """Rule that uses copy actions"""
 
 load("@aspect_bazel_lib//lib:copy_file.bzl", "COPY_FILE_TOOLCHAINS", "copy_file_action")
+load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS")
 
 def _simple_copy_file_impl(ctx):
     if len(ctx.files.src) != 1:
@@ -22,5 +23,5 @@ simple_copy_file = rule(
         "src": attr.label(mandatory = True, allow_files = True),
         "out": attr.output(mandatory = True),
     },
-    toolchains = COPY_FILE_TOOLCHAINS,
+    toolchains = COPY_FILE_TOOLCHAINS + COPY_FILE_TO_BIN_TOOLCHAINS,
 )

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -169,7 +169,10 @@ bzl_library(
 bzl_library(
     name = "copy_to_bin",
     srcs = ["copy_to_bin.bzl"],
-    deps = ["@bazel_lib//lib:copy_to_bin"],
+    deps = [
+        ":copy_file",
+        "@bazel_lib//lib:copy_to_bin",
+    ],
 )
 
 #keep

--- a/lib/copy_to_bin.bzl
+++ b/lib/copy_to_bin.bzl
@@ -9,13 +9,17 @@ https://github.com/bazel-contrib/rules_nodejs/blob/8b5d27400db51e7027fe95ae413ee
 
 load(
     "@bazel_lib//lib:copy_to_bin.bzl",
-    _COPY_FILE_TO_BIN_TOOLCHAINS = "COPY_FILE_TO_BIN_TOOLCHAINS",
     _copy_file_to_bin_action = "copy_file_to_bin_action",
     _copy_files_to_bin_actions = "copy_files_to_bin_actions",
     _copy_to_bin = "copy_to_bin",
 )
 
+# bazel-lib 3.x COPY_FILE_TO_BIN_TOOLCHAINS references COPY_FILE_TOOLCHAINS.
+# bazel-lib 2.x COPY_FILE_[TO_BIN_]TOOLCHAINS must only expose the @aspect_bazel_lib toolchain
+# names, which may alias to bazel-lib 3.x
+load(":copy_file.bzl", "COPY_FILE_TOOLCHAINS")
+
 copy_file_to_bin_action = _copy_file_to_bin_action
 copy_files_to_bin_actions = _copy_files_to_bin_actions
 copy_to_bin = _copy_to_bin
-COPY_FILE_TO_BIN_TOOLCHAINS = _COPY_FILE_TO_BIN_TOOLCHAINS
+COPY_FILE_TO_BIN_TOOLCHAINS = COPY_FILE_TOOLCHAINS


### PR DESCRIPTION
The `COPY_FILE_TO_BIN_TOOLCHAINS` simply [references COPY_FILE_TOOLCHAINS](https://github.com/bazel-contrib/bazel-lib/blob/v3.1.0/lib/private/copy_to_bin.bzl#L20). In `2.x` we must reference the 2.x `COPY_FILE_TOOLCHAINS` in this constant so we only directly expose the `aspect_bazel_lib` labels, even thought they are just aliases to `bazel-lib`.