### PR TITLE
feat: expand the usefulness of resource_sets

### DIFF
--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -276,4 +276,5 @@ bzl_library(
 bzl_library(
     name = "resource_sets",
     srcs = ["resource_sets.bzl"],
+    deps = ["//lib/private:resource_sets"],
 )

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -290,6 +290,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "resource_sets",
+    srcs = ["resource_sets.bzl"],
+    visibility = ["//lib:__subpackages__"],
+)
+
+bzl_library(
     name = "source_toolchains_repo",
     srcs = ["source_toolchains_repo.bzl"],
     visibility = ["//lib:__subpackages__"],

--- a/lib/private/resource_sets.bzl
+++ b/lib/private/resource_sets.bzl
@@ -1,0 +1,2234 @@
+"""generated with lib/private/resource_sets_generator.py | buildifier - > lib/private/resource_sets.bzl"""
+
+def _resource_set_cpu_0_mem_512(_, __):
+    return {"memory": 512}
+
+def _resource_set_cpu_0_mem_1024(_, __):
+    return {"memory": 1024}
+
+def _resource_set_cpu_0_mem_2048(_, __):
+    return {"memory": 2048}
+
+def _resource_set_cpu_0_mem_4096(_, __):
+    return {"memory": 4096}
+
+def _resource_set_cpu_0_mem_8192(_, __):
+    return {"memory": 8192}
+
+def _resource_set_cpu_0_mem_16384(_, __):
+    return {"memory": 16384}
+
+def _resource_set_cpu_0_mem_32768(_, __):
+    return {"memory": 32768}
+
+def _resource_set_cpu_1_mem_0(_, __):
+    return {"cpu": 1}
+
+def _resource_set_cpu_1_mem_512(_, __):
+    return {"cpu": 1, "memory": 512}
+
+def _resource_set_cpu_1_mem_1024(_, __):
+    return {"cpu": 1, "memory": 1024}
+
+def _resource_set_cpu_1_mem_2048(_, __):
+    return {"cpu": 1, "memory": 2048}
+
+def _resource_set_cpu_1_mem_4096(_, __):
+    return {"cpu": 1, "memory": 4096}
+
+def _resource_set_cpu_1_mem_8192(_, __):
+    return {"cpu": 1, "memory": 8192}
+
+def _resource_set_cpu_1_mem_16384(_, __):
+    return {"cpu": 1, "memory": 16384}
+
+def _resource_set_cpu_1_mem_32768(_, __):
+    return {"cpu": 1, "memory": 32768}
+
+def _resource_set_cpu_2_mem_0(_, __):
+    return {"cpu": 2}
+
+def _resource_set_cpu_2_mem_512(_, __):
+    return {"cpu": 2, "memory": 512}
+
+def _resource_set_cpu_2_mem_1024(_, __):
+    return {"cpu": 2, "memory": 1024}
+
+def _resource_set_cpu_2_mem_2048(_, __):
+    return {"cpu": 2, "memory": 2048}
+
+def _resource_set_cpu_2_mem_4096(_, __):
+    return {"cpu": 2, "memory": 4096}
+
+def _resource_set_cpu_2_mem_8192(_, __):
+    return {"cpu": 2, "memory": 8192}
+
+def _resource_set_cpu_2_mem_16384(_, __):
+    return {"cpu": 2, "memory": 16384}
+
+def _resource_set_cpu_2_mem_32768(_, __):
+    return {"cpu": 2, "memory": 32768}
+
+def _resource_set_cpu_3_mem_0(_, __):
+    return {"cpu": 3}
+
+def _resource_set_cpu_3_mem_512(_, __):
+    return {"cpu": 3, "memory": 512}
+
+def _resource_set_cpu_3_mem_1024(_, __):
+    return {"cpu": 3, "memory": 1024}
+
+def _resource_set_cpu_3_mem_2048(_, __):
+    return {"cpu": 3, "memory": 2048}
+
+def _resource_set_cpu_3_mem_4096(_, __):
+    return {"cpu": 3, "memory": 4096}
+
+def _resource_set_cpu_3_mem_8192(_, __):
+    return {"cpu": 3, "memory": 8192}
+
+def _resource_set_cpu_3_mem_16384(_, __):
+    return {"cpu": 3, "memory": 16384}
+
+def _resource_set_cpu_3_mem_32768(_, __):
+    return {"cpu": 3, "memory": 32768}
+
+def _resource_set_cpu_4_mem_0(_, __):
+    return {"cpu": 4}
+
+def _resource_set_cpu_4_mem_512(_, __):
+    return {"cpu": 4, "memory": 512}
+
+def _resource_set_cpu_4_mem_1024(_, __):
+    return {"cpu": 4, "memory": 1024}
+
+def _resource_set_cpu_4_mem_2048(_, __):
+    return {"cpu": 4, "memory": 2048}
+
+def _resource_set_cpu_4_mem_4096(_, __):
+    return {"cpu": 4, "memory": 4096}
+
+def _resource_set_cpu_4_mem_8192(_, __):
+    return {"cpu": 4, "memory": 8192}
+
+def _resource_set_cpu_4_mem_16384(_, __):
+    return {"cpu": 4, "memory": 16384}
+
+def _resource_set_cpu_4_mem_32768(_, __):
+    return {"cpu": 4, "memory": 32768}
+
+def _resource_set_cpu_5_mem_0(_, __):
+    return {"cpu": 5}
+
+def _resource_set_cpu_5_mem_512(_, __):
+    return {"cpu": 5, "memory": 512}
+
+def _resource_set_cpu_5_mem_1024(_, __):
+    return {"cpu": 5, "memory": 1024}
+
+def _resource_set_cpu_5_mem_2048(_, __):
+    return {"cpu": 5, "memory": 2048}
+
+def _resource_set_cpu_5_mem_4096(_, __):
+    return {"cpu": 5, "memory": 4096}
+
+def _resource_set_cpu_5_mem_8192(_, __):
+    return {"cpu": 5, "memory": 8192}
+
+def _resource_set_cpu_5_mem_16384(_, __):
+    return {"cpu": 5, "memory": 16384}
+
+def _resource_set_cpu_5_mem_32768(_, __):
+    return {"cpu": 5, "memory": 32768}
+
+def _resource_set_cpu_6_mem_0(_, __):
+    return {"cpu": 6}
+
+def _resource_set_cpu_6_mem_512(_, __):
+    return {"cpu": 6, "memory": 512}
+
+def _resource_set_cpu_6_mem_1024(_, __):
+    return {"cpu": 6, "memory": 1024}
+
+def _resource_set_cpu_6_mem_2048(_, __):
+    return {"cpu": 6, "memory": 2048}
+
+def _resource_set_cpu_6_mem_4096(_, __):
+    return {"cpu": 6, "memory": 4096}
+
+def _resource_set_cpu_6_mem_8192(_, __):
+    return {"cpu": 6, "memory": 8192}
+
+def _resource_set_cpu_6_mem_16384(_, __):
+    return {"cpu": 6, "memory": 16384}
+
+def _resource_set_cpu_6_mem_32768(_, __):
+    return {"cpu": 6, "memory": 32768}
+
+def _resource_set_cpu_7_mem_0(_, __):
+    return {"cpu": 7}
+
+def _resource_set_cpu_7_mem_512(_, __):
+    return {"cpu": 7, "memory": 512}
+
+def _resource_set_cpu_7_mem_1024(_, __):
+    return {"cpu": 7, "memory": 1024}
+
+def _resource_set_cpu_7_mem_2048(_, __):
+    return {"cpu": 7, "memory": 2048}
+
+def _resource_set_cpu_7_mem_4096(_, __):
+    return {"cpu": 7, "memory": 4096}
+
+def _resource_set_cpu_7_mem_8192(_, __):
+    return {"cpu": 7, "memory": 8192}
+
+def _resource_set_cpu_7_mem_16384(_, __):
+    return {"cpu": 7, "memory": 16384}
+
+def _resource_set_cpu_7_mem_32768(_, __):
+    return {"cpu": 7, "memory": 32768}
+
+def _resource_set_cpu_8_mem_0(_, __):
+    return {"cpu": 8}
+
+def _resource_set_cpu_8_mem_512(_, __):
+    return {"cpu": 8, "memory": 512}
+
+def _resource_set_cpu_8_mem_1024(_, __):
+    return {"cpu": 8, "memory": 1024}
+
+def _resource_set_cpu_8_mem_2048(_, __):
+    return {"cpu": 8, "memory": 2048}
+
+def _resource_set_cpu_8_mem_4096(_, __):
+    return {"cpu": 8, "memory": 4096}
+
+def _resource_set_cpu_8_mem_8192(_, __):
+    return {"cpu": 8, "memory": 8192}
+
+def _resource_set_cpu_8_mem_16384(_, __):
+    return {"cpu": 8, "memory": 16384}
+
+def _resource_set_cpu_8_mem_32768(_, __):
+    return {"cpu": 8, "memory": 32768}
+
+def _resource_set_cpu_9_mem_0(_, __):
+    return {"cpu": 9}
+
+def _resource_set_cpu_9_mem_512(_, __):
+    return {"cpu": 9, "memory": 512}
+
+def _resource_set_cpu_9_mem_1024(_, __):
+    return {"cpu": 9, "memory": 1024}
+
+def _resource_set_cpu_9_mem_2048(_, __):
+    return {"cpu": 9, "memory": 2048}
+
+def _resource_set_cpu_9_mem_4096(_, __):
+    return {"cpu": 9, "memory": 4096}
+
+def _resource_set_cpu_9_mem_8192(_, __):
+    return {"cpu": 9, "memory": 8192}
+
+def _resource_set_cpu_9_mem_16384(_, __):
+    return {"cpu": 9, "memory": 16384}
+
+def _resource_set_cpu_9_mem_32768(_, __):
+    return {"cpu": 9, "memory": 32768}
+
+def _resource_set_cpu_10_mem_0(_, __):
+    return {"cpu": 10}
+
+def _resource_set_cpu_10_mem_512(_, __):
+    return {"cpu": 10, "memory": 512}
+
+def _resource_set_cpu_10_mem_1024(_, __):
+    return {"cpu": 10, "memory": 1024}
+
+def _resource_set_cpu_10_mem_2048(_, __):
+    return {"cpu": 10, "memory": 2048}
+
+def _resource_set_cpu_10_mem_4096(_, __):
+    return {"cpu": 10, "memory": 4096}
+
+def _resource_set_cpu_10_mem_8192(_, __):
+    return {"cpu": 10, "memory": 8192}
+
+def _resource_set_cpu_10_mem_16384(_, __):
+    return {"cpu": 10, "memory": 16384}
+
+def _resource_set_cpu_10_mem_32768(_, __):
+    return {"cpu": 10, "memory": 32768}
+
+def _resource_set_cpu_11_mem_0(_, __):
+    return {"cpu": 11}
+
+def _resource_set_cpu_11_mem_512(_, __):
+    return {"cpu": 11, "memory": 512}
+
+def _resource_set_cpu_11_mem_1024(_, __):
+    return {"cpu": 11, "memory": 1024}
+
+def _resource_set_cpu_11_mem_2048(_, __):
+    return {"cpu": 11, "memory": 2048}
+
+def _resource_set_cpu_11_mem_4096(_, __):
+    return {"cpu": 11, "memory": 4096}
+
+def _resource_set_cpu_11_mem_8192(_, __):
+    return {"cpu": 11, "memory": 8192}
+
+def _resource_set_cpu_11_mem_16384(_, __):
+    return {"cpu": 11, "memory": 16384}
+
+def _resource_set_cpu_11_mem_32768(_, __):
+    return {"cpu": 11, "memory": 32768}
+
+def _resource_set_cpu_12_mem_0(_, __):
+    return {"cpu": 12}
+
+def _resource_set_cpu_12_mem_512(_, __):
+    return {"cpu": 12, "memory": 512}
+
+def _resource_set_cpu_12_mem_1024(_, __):
+    return {"cpu": 12, "memory": 1024}
+
+def _resource_set_cpu_12_mem_2048(_, __):
+    return {"cpu": 12, "memory": 2048}
+
+def _resource_set_cpu_12_mem_4096(_, __):
+    return {"cpu": 12, "memory": 4096}
+
+def _resource_set_cpu_12_mem_8192(_, __):
+    return {"cpu": 12, "memory": 8192}
+
+def _resource_set_cpu_12_mem_16384(_, __):
+    return {"cpu": 12, "memory": 16384}
+
+def _resource_set_cpu_12_mem_32768(_, __):
+    return {"cpu": 12, "memory": 32768}
+
+def _resource_set_cpu_13_mem_0(_, __):
+    return {"cpu": 13}
+
+def _resource_set_cpu_13_mem_512(_, __):
+    return {"cpu": 13, "memory": 512}
+
+def _resource_set_cpu_13_mem_1024(_, __):
+    return {"cpu": 13, "memory": 1024}
+
+def _resource_set_cpu_13_mem_2048(_, __):
+    return {"cpu": 13, "memory": 2048}
+
+def _resource_set_cpu_13_mem_4096(_, __):
+    return {"cpu": 13, "memory": 4096}
+
+def _resource_set_cpu_13_mem_8192(_, __):
+    return {"cpu": 13, "memory": 8192}
+
+def _resource_set_cpu_13_mem_16384(_, __):
+    return {"cpu": 13, "memory": 16384}
+
+def _resource_set_cpu_13_mem_32768(_, __):
+    return {"cpu": 13, "memory": 32768}
+
+def _resource_set_cpu_14_mem_0(_, __):
+    return {"cpu": 14}
+
+def _resource_set_cpu_14_mem_512(_, __):
+    return {"cpu": 14, "memory": 512}
+
+def _resource_set_cpu_14_mem_1024(_, __):
+    return {"cpu": 14, "memory": 1024}
+
+def _resource_set_cpu_14_mem_2048(_, __):
+    return {"cpu": 14, "memory": 2048}
+
+def _resource_set_cpu_14_mem_4096(_, __):
+    return {"cpu": 14, "memory": 4096}
+
+def _resource_set_cpu_14_mem_8192(_, __):
+    return {"cpu": 14, "memory": 8192}
+
+def _resource_set_cpu_14_mem_16384(_, __):
+    return {"cpu": 14, "memory": 16384}
+
+def _resource_set_cpu_14_mem_32768(_, __):
+    return {"cpu": 14, "memory": 32768}
+
+def _resource_set_cpu_15_mem_0(_, __):
+    return {"cpu": 15}
+
+def _resource_set_cpu_15_mem_512(_, __):
+    return {"cpu": 15, "memory": 512}
+
+def _resource_set_cpu_15_mem_1024(_, __):
+    return {"cpu": 15, "memory": 1024}
+
+def _resource_set_cpu_15_mem_2048(_, __):
+    return {"cpu": 15, "memory": 2048}
+
+def _resource_set_cpu_15_mem_4096(_, __):
+    return {"cpu": 15, "memory": 4096}
+
+def _resource_set_cpu_15_mem_8192(_, __):
+    return {"cpu": 15, "memory": 8192}
+
+def _resource_set_cpu_15_mem_16384(_, __):
+    return {"cpu": 15, "memory": 16384}
+
+def _resource_set_cpu_15_mem_32768(_, __):
+    return {"cpu": 15, "memory": 32768}
+
+def _resource_set_cpu_16_mem_0(_, __):
+    return {"cpu": 16}
+
+def _resource_set_cpu_16_mem_512(_, __):
+    return {"cpu": 16, "memory": 512}
+
+def _resource_set_cpu_16_mem_1024(_, __):
+    return {"cpu": 16, "memory": 1024}
+
+def _resource_set_cpu_16_mem_2048(_, __):
+    return {"cpu": 16, "memory": 2048}
+
+def _resource_set_cpu_16_mem_4096(_, __):
+    return {"cpu": 16, "memory": 4096}
+
+def _resource_set_cpu_16_mem_8192(_, __):
+    return {"cpu": 16, "memory": 8192}
+
+def _resource_set_cpu_16_mem_16384(_, __):
+    return {"cpu": 16, "memory": 16384}
+
+def _resource_set_cpu_16_mem_32768(_, __):
+    return {"cpu": 16, "memory": 32768}
+
+def _resource_set_cpu_17_mem_0(_, __):
+    return {"cpu": 17}
+
+def _resource_set_cpu_17_mem_512(_, __):
+    return {"cpu": 17, "memory": 512}
+
+def _resource_set_cpu_17_mem_1024(_, __):
+    return {"cpu": 17, "memory": 1024}
+
+def _resource_set_cpu_17_mem_2048(_, __):
+    return {"cpu": 17, "memory": 2048}
+
+def _resource_set_cpu_17_mem_4096(_, __):
+    return {"cpu": 17, "memory": 4096}
+
+def _resource_set_cpu_17_mem_8192(_, __):
+    return {"cpu": 17, "memory": 8192}
+
+def _resource_set_cpu_17_mem_16384(_, __):
+    return {"cpu": 17, "memory": 16384}
+
+def _resource_set_cpu_17_mem_32768(_, __):
+    return {"cpu": 17, "memory": 32768}
+
+def _resource_set_cpu_18_mem_0(_, __):
+    return {"cpu": 18}
+
+def _resource_set_cpu_18_mem_512(_, __):
+    return {"cpu": 18, "memory": 512}
+
+def _resource_set_cpu_18_mem_1024(_, __):
+    return {"cpu": 18, "memory": 1024}
+
+def _resource_set_cpu_18_mem_2048(_, __):
+    return {"cpu": 18, "memory": 2048}
+
+def _resource_set_cpu_18_mem_4096(_, __):
+    return {"cpu": 18, "memory": 4096}
+
+def _resource_set_cpu_18_mem_8192(_, __):
+    return {"cpu": 18, "memory": 8192}
+
+def _resource_set_cpu_18_mem_16384(_, __):
+    return {"cpu": 18, "memory": 16384}
+
+def _resource_set_cpu_18_mem_32768(_, __):
+    return {"cpu": 18, "memory": 32768}
+
+def _resource_set_cpu_19_mem_0(_, __):
+    return {"cpu": 19}
+
+def _resource_set_cpu_19_mem_512(_, __):
+    return {"cpu": 19, "memory": 512}
+
+def _resource_set_cpu_19_mem_1024(_, __):
+    return {"cpu": 19, "memory": 1024}
+
+def _resource_set_cpu_19_mem_2048(_, __):
+    return {"cpu": 19, "memory": 2048}
+
+def _resource_set_cpu_19_mem_4096(_, __):
+    return {"cpu": 19, "memory": 4096}
+
+def _resource_set_cpu_19_mem_8192(_, __):
+    return {"cpu": 19, "memory": 8192}
+
+def _resource_set_cpu_19_mem_16384(_, __):
+    return {"cpu": 19, "memory": 16384}
+
+def _resource_set_cpu_19_mem_32768(_, __):
+    return {"cpu": 19, "memory": 32768}
+
+def _resource_set_cpu_20_mem_0(_, __):
+    return {"cpu": 20}
+
+def _resource_set_cpu_20_mem_512(_, __):
+    return {"cpu": 20, "memory": 512}
+
+def _resource_set_cpu_20_mem_1024(_, __):
+    return {"cpu": 20, "memory": 1024}
+
+def _resource_set_cpu_20_mem_2048(_, __):
+    return {"cpu": 20, "memory": 2048}
+
+def _resource_set_cpu_20_mem_4096(_, __):
+    return {"cpu": 20, "memory": 4096}
+
+def _resource_set_cpu_20_mem_8192(_, __):
+    return {"cpu": 20, "memory": 8192}
+
+def _resource_set_cpu_20_mem_16384(_, __):
+    return {"cpu": 20, "memory": 16384}
+
+def _resource_set_cpu_20_mem_32768(_, __):
+    return {"cpu": 20, "memory": 32768}
+
+def _resource_set_cpu_21_mem_0(_, __):
+    return {"cpu": 21}
+
+def _resource_set_cpu_21_mem_512(_, __):
+    return {"cpu": 21, "memory": 512}
+
+def _resource_set_cpu_21_mem_1024(_, __):
+    return {"cpu": 21, "memory": 1024}
+
+def _resource_set_cpu_21_mem_2048(_, __):
+    return {"cpu": 21, "memory": 2048}
+
+def _resource_set_cpu_21_mem_4096(_, __):
+    return {"cpu": 21, "memory": 4096}
+
+def _resource_set_cpu_21_mem_8192(_, __):
+    return {"cpu": 21, "memory": 8192}
+
+def _resource_set_cpu_21_mem_16384(_, __):
+    return {"cpu": 21, "memory": 16384}
+
+def _resource_set_cpu_21_mem_32768(_, __):
+    return {"cpu": 21, "memory": 32768}
+
+def _resource_set_cpu_22_mem_0(_, __):
+    return {"cpu": 22}
+
+def _resource_set_cpu_22_mem_512(_, __):
+    return {"cpu": 22, "memory": 512}
+
+def _resource_set_cpu_22_mem_1024(_, __):
+    return {"cpu": 22, "memory": 1024}
+
+def _resource_set_cpu_22_mem_2048(_, __):
+    return {"cpu": 22, "memory": 2048}
+
+def _resource_set_cpu_22_mem_4096(_, __):
+    return {"cpu": 22, "memory": 4096}
+
+def _resource_set_cpu_22_mem_8192(_, __):
+    return {"cpu": 22, "memory": 8192}
+
+def _resource_set_cpu_22_mem_16384(_, __):
+    return {"cpu": 22, "memory": 16384}
+
+def _resource_set_cpu_22_mem_32768(_, __):
+    return {"cpu": 22, "memory": 32768}
+
+def _resource_set_cpu_23_mem_0(_, __):
+    return {"cpu": 23}
+
+def _resource_set_cpu_23_mem_512(_, __):
+    return {"cpu": 23, "memory": 512}
+
+def _resource_set_cpu_23_mem_1024(_, __):
+    return {"cpu": 23, "memory": 1024}
+
+def _resource_set_cpu_23_mem_2048(_, __):
+    return {"cpu": 23, "memory": 2048}
+
+def _resource_set_cpu_23_mem_4096(_, __):
+    return {"cpu": 23, "memory": 4096}
+
+def _resource_set_cpu_23_mem_8192(_, __):
+    return {"cpu": 23, "memory": 8192}
+
+def _resource_set_cpu_23_mem_16384(_, __):
+    return {"cpu": 23, "memory": 16384}
+
+def _resource_set_cpu_23_mem_32768(_, __):
+    return {"cpu": 23, "memory": 32768}
+
+def _resource_set_cpu_24_mem_0(_, __):
+    return {"cpu": 24}
+
+def _resource_set_cpu_24_mem_512(_, __):
+    return {"cpu": 24, "memory": 512}
+
+def _resource_set_cpu_24_mem_1024(_, __):
+    return {"cpu": 24, "memory": 1024}
+
+def _resource_set_cpu_24_mem_2048(_, __):
+    return {"cpu": 24, "memory": 2048}
+
+def _resource_set_cpu_24_mem_4096(_, __):
+    return {"cpu": 24, "memory": 4096}
+
+def _resource_set_cpu_24_mem_8192(_, __):
+    return {"cpu": 24, "memory": 8192}
+
+def _resource_set_cpu_24_mem_16384(_, __):
+    return {"cpu": 24, "memory": 16384}
+
+def _resource_set_cpu_24_mem_32768(_, __):
+    return {"cpu": 24, "memory": 32768}
+
+def _resource_set_cpu_25_mem_0(_, __):
+    return {"cpu": 25}
+
+def _resource_set_cpu_25_mem_512(_, __):
+    return {"cpu": 25, "memory": 512}
+
+def _resource_set_cpu_25_mem_1024(_, __):
+    return {"cpu": 25, "memory": 1024}
+
+def _resource_set_cpu_25_mem_2048(_, __):
+    return {"cpu": 25, "memory": 2048}
+
+def _resource_set_cpu_25_mem_4096(_, __):
+    return {"cpu": 25, "memory": 4096}
+
+def _resource_set_cpu_25_mem_8192(_, __):
+    return {"cpu": 25, "memory": 8192}
+
+def _resource_set_cpu_25_mem_16384(_, __):
+    return {"cpu": 25, "memory": 16384}
+
+def _resource_set_cpu_25_mem_32768(_, __):
+    return {"cpu": 25, "memory": 32768}
+
+def _resource_set_cpu_26_mem_0(_, __):
+    return {"cpu": 26}
+
+def _resource_set_cpu_26_mem_512(_, __):
+    return {"cpu": 26, "memory": 512}
+
+def _resource_set_cpu_26_mem_1024(_, __):
+    return {"cpu": 26, "memory": 1024}
+
+def _resource_set_cpu_26_mem_2048(_, __):
+    return {"cpu": 26, "memory": 2048}
+
+def _resource_set_cpu_26_mem_4096(_, __):
+    return {"cpu": 26, "memory": 4096}
+
+def _resource_set_cpu_26_mem_8192(_, __):
+    return {"cpu": 26, "memory": 8192}
+
+def _resource_set_cpu_26_mem_16384(_, __):
+    return {"cpu": 26, "memory": 16384}
+
+def _resource_set_cpu_26_mem_32768(_, __):
+    return {"cpu": 26, "memory": 32768}
+
+def _resource_set_cpu_27_mem_0(_, __):
+    return {"cpu": 27}
+
+def _resource_set_cpu_27_mem_512(_, __):
+    return {"cpu": 27, "memory": 512}
+
+def _resource_set_cpu_27_mem_1024(_, __):
+    return {"cpu": 27, "memory": 1024}
+
+def _resource_set_cpu_27_mem_2048(_, __):
+    return {"cpu": 27, "memory": 2048}
+
+def _resource_set_cpu_27_mem_4096(_, __):
+    return {"cpu": 27, "memory": 4096}
+
+def _resource_set_cpu_27_mem_8192(_, __):
+    return {"cpu": 27, "memory": 8192}
+
+def _resource_set_cpu_27_mem_16384(_, __):
+    return {"cpu": 27, "memory": 16384}
+
+def _resource_set_cpu_27_mem_32768(_, __):
+    return {"cpu": 27, "memory": 32768}
+
+def _resource_set_cpu_28_mem_0(_, __):
+    return {"cpu": 28}
+
+def _resource_set_cpu_28_mem_512(_, __):
+    return {"cpu": 28, "memory": 512}
+
+def _resource_set_cpu_28_mem_1024(_, __):
+    return {"cpu": 28, "memory": 1024}
+
+def _resource_set_cpu_28_mem_2048(_, __):
+    return {"cpu": 28, "memory": 2048}
+
+def _resource_set_cpu_28_mem_4096(_, __):
+    return {"cpu": 28, "memory": 4096}
+
+def _resource_set_cpu_28_mem_8192(_, __):
+    return {"cpu": 28, "memory": 8192}
+
+def _resource_set_cpu_28_mem_16384(_, __):
+    return {"cpu": 28, "memory": 16384}
+
+def _resource_set_cpu_28_mem_32768(_, __):
+    return {"cpu": 28, "memory": 32768}
+
+def _resource_set_cpu_29_mem_0(_, __):
+    return {"cpu": 29}
+
+def _resource_set_cpu_29_mem_512(_, __):
+    return {"cpu": 29, "memory": 512}
+
+def _resource_set_cpu_29_mem_1024(_, __):
+    return {"cpu": 29, "memory": 1024}
+
+def _resource_set_cpu_29_mem_2048(_, __):
+    return {"cpu": 29, "memory": 2048}
+
+def _resource_set_cpu_29_mem_4096(_, __):
+    return {"cpu": 29, "memory": 4096}
+
+def _resource_set_cpu_29_mem_8192(_, __):
+    return {"cpu": 29, "memory": 8192}
+
+def _resource_set_cpu_29_mem_16384(_, __):
+    return {"cpu": 29, "memory": 16384}
+
+def _resource_set_cpu_29_mem_32768(_, __):
+    return {"cpu": 29, "memory": 32768}
+
+def _resource_set_cpu_30_mem_0(_, __):
+    return {"cpu": 30}
+
+def _resource_set_cpu_30_mem_512(_, __):
+    return {"cpu": 30, "memory": 512}
+
+def _resource_set_cpu_30_mem_1024(_, __):
+    return {"cpu": 30, "memory": 1024}
+
+def _resource_set_cpu_30_mem_2048(_, __):
+    return {"cpu": 30, "memory": 2048}
+
+def _resource_set_cpu_30_mem_4096(_, __):
+    return {"cpu": 30, "memory": 4096}
+
+def _resource_set_cpu_30_mem_8192(_, __):
+    return {"cpu": 30, "memory": 8192}
+
+def _resource_set_cpu_30_mem_16384(_, __):
+    return {"cpu": 30, "memory": 16384}
+
+def _resource_set_cpu_30_mem_32768(_, __):
+    return {"cpu": 30, "memory": 32768}
+
+def _resource_set_cpu_31_mem_0(_, __):
+    return {"cpu": 31}
+
+def _resource_set_cpu_31_mem_512(_, __):
+    return {"cpu": 31, "memory": 512}
+
+def _resource_set_cpu_31_mem_1024(_, __):
+    return {"cpu": 31, "memory": 1024}
+
+def _resource_set_cpu_31_mem_2048(_, __):
+    return {"cpu": 31, "memory": 2048}
+
+def _resource_set_cpu_31_mem_4096(_, __):
+    return {"cpu": 31, "memory": 4096}
+
+def _resource_set_cpu_31_mem_8192(_, __):
+    return {"cpu": 31, "memory": 8192}
+
+def _resource_set_cpu_31_mem_16384(_, __):
+    return {"cpu": 31, "memory": 16384}
+
+def _resource_set_cpu_31_mem_32768(_, __):
+    return {"cpu": 31, "memory": 32768}
+
+def _resource_set_cpu_32_mem_0(_, __):
+    return {"cpu": 32}
+
+def _resource_set_cpu_32_mem_512(_, __):
+    return {"cpu": 32, "memory": 512}
+
+def _resource_set_cpu_32_mem_1024(_, __):
+    return {"cpu": 32, "memory": 1024}
+
+def _resource_set_cpu_32_mem_2048(_, __):
+    return {"cpu": 32, "memory": 2048}
+
+def _resource_set_cpu_32_mem_4096(_, __):
+    return {"cpu": 32, "memory": 4096}
+
+def _resource_set_cpu_32_mem_8192(_, __):
+    return {"cpu": 32, "memory": 8192}
+
+def _resource_set_cpu_32_mem_16384(_, __):
+    return {"cpu": 32, "memory": 16384}
+
+def _resource_set_cpu_32_mem_32768(_, __):
+    return {"cpu": 32, "memory": 32768}
+
+def _resource_set_cpu_33_mem_0(_, __):
+    return {"cpu": 33}
+
+def _resource_set_cpu_33_mem_512(_, __):
+    return {"cpu": 33, "memory": 512}
+
+def _resource_set_cpu_33_mem_1024(_, __):
+    return {"cpu": 33, "memory": 1024}
+
+def _resource_set_cpu_33_mem_2048(_, __):
+    return {"cpu": 33, "memory": 2048}
+
+def _resource_set_cpu_33_mem_4096(_, __):
+    return {"cpu": 33, "memory": 4096}
+
+def _resource_set_cpu_33_mem_8192(_, __):
+    return {"cpu": 33, "memory": 8192}
+
+def _resource_set_cpu_33_mem_16384(_, __):
+    return {"cpu": 33, "memory": 16384}
+
+def _resource_set_cpu_33_mem_32768(_, __):
+    return {"cpu": 33, "memory": 32768}
+
+def _resource_set_cpu_34_mem_0(_, __):
+    return {"cpu": 34}
+
+def _resource_set_cpu_34_mem_512(_, __):
+    return {"cpu": 34, "memory": 512}
+
+def _resource_set_cpu_34_mem_1024(_, __):
+    return {"cpu": 34, "memory": 1024}
+
+def _resource_set_cpu_34_mem_2048(_, __):
+    return {"cpu": 34, "memory": 2048}
+
+def _resource_set_cpu_34_mem_4096(_, __):
+    return {"cpu": 34, "memory": 4096}
+
+def _resource_set_cpu_34_mem_8192(_, __):
+    return {"cpu": 34, "memory": 8192}
+
+def _resource_set_cpu_34_mem_16384(_, __):
+    return {"cpu": 34, "memory": 16384}
+
+def _resource_set_cpu_34_mem_32768(_, __):
+    return {"cpu": 34, "memory": 32768}
+
+def _resource_set_cpu_35_mem_0(_, __):
+    return {"cpu": 35}
+
+def _resource_set_cpu_35_mem_512(_, __):
+    return {"cpu": 35, "memory": 512}
+
+def _resource_set_cpu_35_mem_1024(_, __):
+    return {"cpu": 35, "memory": 1024}
+
+def _resource_set_cpu_35_mem_2048(_, __):
+    return {"cpu": 35, "memory": 2048}
+
+def _resource_set_cpu_35_mem_4096(_, __):
+    return {"cpu": 35, "memory": 4096}
+
+def _resource_set_cpu_35_mem_8192(_, __):
+    return {"cpu": 35, "memory": 8192}
+
+def _resource_set_cpu_35_mem_16384(_, __):
+    return {"cpu": 35, "memory": 16384}
+
+def _resource_set_cpu_35_mem_32768(_, __):
+    return {"cpu": 35, "memory": 32768}
+
+def _resource_set_cpu_36_mem_0(_, __):
+    return {"cpu": 36}
+
+def _resource_set_cpu_36_mem_512(_, __):
+    return {"cpu": 36, "memory": 512}
+
+def _resource_set_cpu_36_mem_1024(_, __):
+    return {"cpu": 36, "memory": 1024}
+
+def _resource_set_cpu_36_mem_2048(_, __):
+    return {"cpu": 36, "memory": 2048}
+
+def _resource_set_cpu_36_mem_4096(_, __):
+    return {"cpu": 36, "memory": 4096}
+
+def _resource_set_cpu_36_mem_8192(_, __):
+    return {"cpu": 36, "memory": 8192}
+
+def _resource_set_cpu_36_mem_16384(_, __):
+    return {"cpu": 36, "memory": 16384}
+
+def _resource_set_cpu_36_mem_32768(_, __):
+    return {"cpu": 36, "memory": 32768}
+
+def _resource_set_cpu_37_mem_0(_, __):
+    return {"cpu": 37}
+
+def _resource_set_cpu_37_mem_512(_, __):
+    return {"cpu": 37, "memory": 512}
+
+def _resource_set_cpu_37_mem_1024(_, __):
+    return {"cpu": 37, "memory": 1024}
+
+def _resource_set_cpu_37_mem_2048(_, __):
+    return {"cpu": 37, "memory": 2048}
+
+def _resource_set_cpu_37_mem_4096(_, __):
+    return {"cpu": 37, "memory": 4096}
+
+def _resource_set_cpu_37_mem_8192(_, __):
+    return {"cpu": 37, "memory": 8192}
+
+def _resource_set_cpu_37_mem_16384(_, __):
+    return {"cpu": 37, "memory": 16384}
+
+def _resource_set_cpu_37_mem_32768(_, __):
+    return {"cpu": 37, "memory": 32768}
+
+def _resource_set_cpu_38_mem_0(_, __):
+    return {"cpu": 38}
+
+def _resource_set_cpu_38_mem_512(_, __):
+    return {"cpu": 38, "memory": 512}
+
+def _resource_set_cpu_38_mem_1024(_, __):
+    return {"cpu": 38, "memory": 1024}
+
+def _resource_set_cpu_38_mem_2048(_, __):
+    return {"cpu": 38, "memory": 2048}
+
+def _resource_set_cpu_38_mem_4096(_, __):
+    return {"cpu": 38, "memory": 4096}
+
+def _resource_set_cpu_38_mem_8192(_, __):
+    return {"cpu": 38, "memory": 8192}
+
+def _resource_set_cpu_38_mem_16384(_, __):
+    return {"cpu": 38, "memory": 16384}
+
+def _resource_set_cpu_38_mem_32768(_, __):
+    return {"cpu": 38, "memory": 32768}
+
+def _resource_set_cpu_39_mem_0(_, __):
+    return {"cpu": 39}
+
+def _resource_set_cpu_39_mem_512(_, __):
+    return {"cpu": 39, "memory": 512}
+
+def _resource_set_cpu_39_mem_1024(_, __):
+    return {"cpu": 39, "memory": 1024}
+
+def _resource_set_cpu_39_mem_2048(_, __):
+    return {"cpu": 39, "memory": 2048}
+
+def _resource_set_cpu_39_mem_4096(_, __):
+    return {"cpu": 39, "memory": 4096}
+
+def _resource_set_cpu_39_mem_8192(_, __):
+    return {"cpu": 39, "memory": 8192}
+
+def _resource_set_cpu_39_mem_16384(_, __):
+    return {"cpu": 39, "memory": 16384}
+
+def _resource_set_cpu_39_mem_32768(_, __):
+    return {"cpu": 39, "memory": 32768}
+
+def _resource_set_cpu_40_mem_0(_, __):
+    return {"cpu": 40}
+
+def _resource_set_cpu_40_mem_512(_, __):
+    return {"cpu": 40, "memory": 512}
+
+def _resource_set_cpu_40_mem_1024(_, __):
+    return {"cpu": 40, "memory": 1024}
+
+def _resource_set_cpu_40_mem_2048(_, __):
+    return {"cpu": 40, "memory": 2048}
+
+def _resource_set_cpu_40_mem_4096(_, __):
+    return {"cpu": 40, "memory": 4096}
+
+def _resource_set_cpu_40_mem_8192(_, __):
+    return {"cpu": 40, "memory": 8192}
+
+def _resource_set_cpu_40_mem_16384(_, __):
+    return {"cpu": 40, "memory": 16384}
+
+def _resource_set_cpu_40_mem_32768(_, __):
+    return {"cpu": 40, "memory": 32768}
+
+def _resource_set_cpu_41_mem_0(_, __):
+    return {"cpu": 41}
+
+def _resource_set_cpu_41_mem_512(_, __):
+    return {"cpu": 41, "memory": 512}
+
+def _resource_set_cpu_41_mem_1024(_, __):
+    return {"cpu": 41, "memory": 1024}
+
+def _resource_set_cpu_41_mem_2048(_, __):
+    return {"cpu": 41, "memory": 2048}
+
+def _resource_set_cpu_41_mem_4096(_, __):
+    return {"cpu": 41, "memory": 4096}
+
+def _resource_set_cpu_41_mem_8192(_, __):
+    return {"cpu": 41, "memory": 8192}
+
+def _resource_set_cpu_41_mem_16384(_, __):
+    return {"cpu": 41, "memory": 16384}
+
+def _resource_set_cpu_41_mem_32768(_, __):
+    return {"cpu": 41, "memory": 32768}
+
+def _resource_set_cpu_42_mem_0(_, __):
+    return {"cpu": 42}
+
+def _resource_set_cpu_42_mem_512(_, __):
+    return {"cpu": 42, "memory": 512}
+
+def _resource_set_cpu_42_mem_1024(_, __):
+    return {"cpu": 42, "memory": 1024}
+
+def _resource_set_cpu_42_mem_2048(_, __):
+    return {"cpu": 42, "memory": 2048}
+
+def _resource_set_cpu_42_mem_4096(_, __):
+    return {"cpu": 42, "memory": 4096}
+
+def _resource_set_cpu_42_mem_8192(_, __):
+    return {"cpu": 42, "memory": 8192}
+
+def _resource_set_cpu_42_mem_16384(_, __):
+    return {"cpu": 42, "memory": 16384}
+
+def _resource_set_cpu_42_mem_32768(_, __):
+    return {"cpu": 42, "memory": 32768}
+
+def _resource_set_cpu_43_mem_0(_, __):
+    return {"cpu": 43}
+
+def _resource_set_cpu_43_mem_512(_, __):
+    return {"cpu": 43, "memory": 512}
+
+def _resource_set_cpu_43_mem_1024(_, __):
+    return {"cpu": 43, "memory": 1024}
+
+def _resource_set_cpu_43_mem_2048(_, __):
+    return {"cpu": 43, "memory": 2048}
+
+def _resource_set_cpu_43_mem_4096(_, __):
+    return {"cpu": 43, "memory": 4096}
+
+def _resource_set_cpu_43_mem_8192(_, __):
+    return {"cpu": 43, "memory": 8192}
+
+def _resource_set_cpu_43_mem_16384(_, __):
+    return {"cpu": 43, "memory": 16384}
+
+def _resource_set_cpu_43_mem_32768(_, __):
+    return {"cpu": 43, "memory": 32768}
+
+def _resource_set_cpu_44_mem_0(_, __):
+    return {"cpu": 44}
+
+def _resource_set_cpu_44_mem_512(_, __):
+    return {"cpu": 44, "memory": 512}
+
+def _resource_set_cpu_44_mem_1024(_, __):
+    return {"cpu": 44, "memory": 1024}
+
+def _resource_set_cpu_44_mem_2048(_, __):
+    return {"cpu": 44, "memory": 2048}
+
+def _resource_set_cpu_44_mem_4096(_, __):
+    return {"cpu": 44, "memory": 4096}
+
+def _resource_set_cpu_44_mem_8192(_, __):
+    return {"cpu": 44, "memory": 8192}
+
+def _resource_set_cpu_44_mem_16384(_, __):
+    return {"cpu": 44, "memory": 16384}
+
+def _resource_set_cpu_44_mem_32768(_, __):
+    return {"cpu": 44, "memory": 32768}
+
+def _resource_set_cpu_45_mem_0(_, __):
+    return {"cpu": 45}
+
+def _resource_set_cpu_45_mem_512(_, __):
+    return {"cpu": 45, "memory": 512}
+
+def _resource_set_cpu_45_mem_1024(_, __):
+    return {"cpu": 45, "memory": 1024}
+
+def _resource_set_cpu_45_mem_2048(_, __):
+    return {"cpu": 45, "memory": 2048}
+
+def _resource_set_cpu_45_mem_4096(_, __):
+    return {"cpu": 45, "memory": 4096}
+
+def _resource_set_cpu_45_mem_8192(_, __):
+    return {"cpu": 45, "memory": 8192}
+
+def _resource_set_cpu_45_mem_16384(_, __):
+    return {"cpu": 45, "memory": 16384}
+
+def _resource_set_cpu_45_mem_32768(_, __):
+    return {"cpu": 45, "memory": 32768}
+
+def _resource_set_cpu_46_mem_0(_, __):
+    return {"cpu": 46}
+
+def _resource_set_cpu_46_mem_512(_, __):
+    return {"cpu": 46, "memory": 512}
+
+def _resource_set_cpu_46_mem_1024(_, __):
+    return {"cpu": 46, "memory": 1024}
+
+def _resource_set_cpu_46_mem_2048(_, __):
+    return {"cpu": 46, "memory": 2048}
+
+def _resource_set_cpu_46_mem_4096(_, __):
+    return {"cpu": 46, "memory": 4096}
+
+def _resource_set_cpu_46_mem_8192(_, __):
+    return {"cpu": 46, "memory": 8192}
+
+def _resource_set_cpu_46_mem_16384(_, __):
+    return {"cpu": 46, "memory": 16384}
+
+def _resource_set_cpu_46_mem_32768(_, __):
+    return {"cpu": 46, "memory": 32768}
+
+def _resource_set_cpu_47_mem_0(_, __):
+    return {"cpu": 47}
+
+def _resource_set_cpu_47_mem_512(_, __):
+    return {"cpu": 47, "memory": 512}
+
+def _resource_set_cpu_47_mem_1024(_, __):
+    return {"cpu": 47, "memory": 1024}
+
+def _resource_set_cpu_47_mem_2048(_, __):
+    return {"cpu": 47, "memory": 2048}
+
+def _resource_set_cpu_47_mem_4096(_, __):
+    return {"cpu": 47, "memory": 4096}
+
+def _resource_set_cpu_47_mem_8192(_, __):
+    return {"cpu": 47, "memory": 8192}
+
+def _resource_set_cpu_47_mem_16384(_, __):
+    return {"cpu": 47, "memory": 16384}
+
+def _resource_set_cpu_47_mem_32768(_, __):
+    return {"cpu": 47, "memory": 32768}
+
+def _resource_set_cpu_48_mem_0(_, __):
+    return {"cpu": 48}
+
+def _resource_set_cpu_48_mem_512(_, __):
+    return {"cpu": 48, "memory": 512}
+
+def _resource_set_cpu_48_mem_1024(_, __):
+    return {"cpu": 48, "memory": 1024}
+
+def _resource_set_cpu_48_mem_2048(_, __):
+    return {"cpu": 48, "memory": 2048}
+
+def _resource_set_cpu_48_mem_4096(_, __):
+    return {"cpu": 48, "memory": 4096}
+
+def _resource_set_cpu_48_mem_8192(_, __):
+    return {"cpu": 48, "memory": 8192}
+
+def _resource_set_cpu_48_mem_16384(_, __):
+    return {"cpu": 48, "memory": 16384}
+
+def _resource_set_cpu_48_mem_32768(_, __):
+    return {"cpu": 48, "memory": 32768}
+
+def _resource_set_cpu_49_mem_0(_, __):
+    return {"cpu": 49}
+
+def _resource_set_cpu_49_mem_512(_, __):
+    return {"cpu": 49, "memory": 512}
+
+def _resource_set_cpu_49_mem_1024(_, __):
+    return {"cpu": 49, "memory": 1024}
+
+def _resource_set_cpu_49_mem_2048(_, __):
+    return {"cpu": 49, "memory": 2048}
+
+def _resource_set_cpu_49_mem_4096(_, __):
+    return {"cpu": 49, "memory": 4096}
+
+def _resource_set_cpu_49_mem_8192(_, __):
+    return {"cpu": 49, "memory": 8192}
+
+def _resource_set_cpu_49_mem_16384(_, __):
+    return {"cpu": 49, "memory": 16384}
+
+def _resource_set_cpu_49_mem_32768(_, __):
+    return {"cpu": 49, "memory": 32768}
+
+def _resource_set_cpu_50_mem_0(_, __):
+    return {"cpu": 50}
+
+def _resource_set_cpu_50_mem_512(_, __):
+    return {"cpu": 50, "memory": 512}
+
+def _resource_set_cpu_50_mem_1024(_, __):
+    return {"cpu": 50, "memory": 1024}
+
+def _resource_set_cpu_50_mem_2048(_, __):
+    return {"cpu": 50, "memory": 2048}
+
+def _resource_set_cpu_50_mem_4096(_, __):
+    return {"cpu": 50, "memory": 4096}
+
+def _resource_set_cpu_50_mem_8192(_, __):
+    return {"cpu": 50, "memory": 8192}
+
+def _resource_set_cpu_50_mem_16384(_, __):
+    return {"cpu": 50, "memory": 16384}
+
+def _resource_set_cpu_50_mem_32768(_, __):
+    return {"cpu": 50, "memory": 32768}
+
+def _resource_set_cpu_51_mem_0(_, __):
+    return {"cpu": 51}
+
+def _resource_set_cpu_51_mem_512(_, __):
+    return {"cpu": 51, "memory": 512}
+
+def _resource_set_cpu_51_mem_1024(_, __):
+    return {"cpu": 51, "memory": 1024}
+
+def _resource_set_cpu_51_mem_2048(_, __):
+    return {"cpu": 51, "memory": 2048}
+
+def _resource_set_cpu_51_mem_4096(_, __):
+    return {"cpu": 51, "memory": 4096}
+
+def _resource_set_cpu_51_mem_8192(_, __):
+    return {"cpu": 51, "memory": 8192}
+
+def _resource_set_cpu_51_mem_16384(_, __):
+    return {"cpu": 51, "memory": 16384}
+
+def _resource_set_cpu_51_mem_32768(_, __):
+    return {"cpu": 51, "memory": 32768}
+
+def _resource_set_cpu_52_mem_0(_, __):
+    return {"cpu": 52}
+
+def _resource_set_cpu_52_mem_512(_, __):
+    return {"cpu": 52, "memory": 512}
+
+def _resource_set_cpu_52_mem_1024(_, __):
+    return {"cpu": 52, "memory": 1024}
+
+def _resource_set_cpu_52_mem_2048(_, __):
+    return {"cpu": 52, "memory": 2048}
+
+def _resource_set_cpu_52_mem_4096(_, __):
+    return {"cpu": 52, "memory": 4096}
+
+def _resource_set_cpu_52_mem_8192(_, __):
+    return {"cpu": 52, "memory": 8192}
+
+def _resource_set_cpu_52_mem_16384(_, __):
+    return {"cpu": 52, "memory": 16384}
+
+def _resource_set_cpu_52_mem_32768(_, __):
+    return {"cpu": 52, "memory": 32768}
+
+def _resource_set_cpu_53_mem_0(_, __):
+    return {"cpu": 53}
+
+def _resource_set_cpu_53_mem_512(_, __):
+    return {"cpu": 53, "memory": 512}
+
+def _resource_set_cpu_53_mem_1024(_, __):
+    return {"cpu": 53, "memory": 1024}
+
+def _resource_set_cpu_53_mem_2048(_, __):
+    return {"cpu": 53, "memory": 2048}
+
+def _resource_set_cpu_53_mem_4096(_, __):
+    return {"cpu": 53, "memory": 4096}
+
+def _resource_set_cpu_53_mem_8192(_, __):
+    return {"cpu": 53, "memory": 8192}
+
+def _resource_set_cpu_53_mem_16384(_, __):
+    return {"cpu": 53, "memory": 16384}
+
+def _resource_set_cpu_53_mem_32768(_, __):
+    return {"cpu": 53, "memory": 32768}
+
+def _resource_set_cpu_54_mem_0(_, __):
+    return {"cpu": 54}
+
+def _resource_set_cpu_54_mem_512(_, __):
+    return {"cpu": 54, "memory": 512}
+
+def _resource_set_cpu_54_mem_1024(_, __):
+    return {"cpu": 54, "memory": 1024}
+
+def _resource_set_cpu_54_mem_2048(_, __):
+    return {"cpu": 54, "memory": 2048}
+
+def _resource_set_cpu_54_mem_4096(_, __):
+    return {"cpu": 54, "memory": 4096}
+
+def _resource_set_cpu_54_mem_8192(_, __):
+    return {"cpu": 54, "memory": 8192}
+
+def _resource_set_cpu_54_mem_16384(_, __):
+    return {"cpu": 54, "memory": 16384}
+
+def _resource_set_cpu_54_mem_32768(_, __):
+    return {"cpu": 54, "memory": 32768}
+
+def _resource_set_cpu_55_mem_0(_, __):
+    return {"cpu": 55}
+
+def _resource_set_cpu_55_mem_512(_, __):
+    return {"cpu": 55, "memory": 512}
+
+def _resource_set_cpu_55_mem_1024(_, __):
+    return {"cpu": 55, "memory": 1024}
+
+def _resource_set_cpu_55_mem_2048(_, __):
+    return {"cpu": 55, "memory": 2048}
+
+def _resource_set_cpu_55_mem_4096(_, __):
+    return {"cpu": 55, "memory": 4096}
+
+def _resource_set_cpu_55_mem_8192(_, __):
+    return {"cpu": 55, "memory": 8192}
+
+def _resource_set_cpu_55_mem_16384(_, __):
+    return {"cpu": 55, "memory": 16384}
+
+def _resource_set_cpu_55_mem_32768(_, __):
+    return {"cpu": 55, "memory": 32768}
+
+def _resource_set_cpu_56_mem_0(_, __):
+    return {"cpu": 56}
+
+def _resource_set_cpu_56_mem_512(_, __):
+    return {"cpu": 56, "memory": 512}
+
+def _resource_set_cpu_56_mem_1024(_, __):
+    return {"cpu": 56, "memory": 1024}
+
+def _resource_set_cpu_56_mem_2048(_, __):
+    return {"cpu": 56, "memory": 2048}
+
+def _resource_set_cpu_56_mem_4096(_, __):
+    return {"cpu": 56, "memory": 4096}
+
+def _resource_set_cpu_56_mem_8192(_, __):
+    return {"cpu": 56, "memory": 8192}
+
+def _resource_set_cpu_56_mem_16384(_, __):
+    return {"cpu": 56, "memory": 16384}
+
+def _resource_set_cpu_56_mem_32768(_, __):
+    return {"cpu": 56, "memory": 32768}
+
+def _resource_set_cpu_57_mem_0(_, __):
+    return {"cpu": 57}
+
+def _resource_set_cpu_57_mem_512(_, __):
+    return {"cpu": 57, "memory": 512}
+
+def _resource_set_cpu_57_mem_1024(_, __):
+    return {"cpu": 57, "memory": 1024}
+
+def _resource_set_cpu_57_mem_2048(_, __):
+    return {"cpu": 57, "memory": 2048}
+
+def _resource_set_cpu_57_mem_4096(_, __):
+    return {"cpu": 57, "memory": 4096}
+
+def _resource_set_cpu_57_mem_8192(_, __):
+    return {"cpu": 57, "memory": 8192}
+
+def _resource_set_cpu_57_mem_16384(_, __):
+    return {"cpu": 57, "memory": 16384}
+
+def _resource_set_cpu_57_mem_32768(_, __):
+    return {"cpu": 57, "memory": 32768}
+
+def _resource_set_cpu_58_mem_0(_, __):
+    return {"cpu": 58}
+
+def _resource_set_cpu_58_mem_512(_, __):
+    return {"cpu": 58, "memory": 512}
+
+def _resource_set_cpu_58_mem_1024(_, __):
+    return {"cpu": 58, "memory": 1024}
+
+def _resource_set_cpu_58_mem_2048(_, __):
+    return {"cpu": 58, "memory": 2048}
+
+def _resource_set_cpu_58_mem_4096(_, __):
+    return {"cpu": 58, "memory": 4096}
+
+def _resource_set_cpu_58_mem_8192(_, __):
+    return {"cpu": 58, "memory": 8192}
+
+def _resource_set_cpu_58_mem_16384(_, __):
+    return {"cpu": 58, "memory": 16384}
+
+def _resource_set_cpu_58_mem_32768(_, __):
+    return {"cpu": 58, "memory": 32768}
+
+def _resource_set_cpu_59_mem_0(_, __):
+    return {"cpu": 59}
+
+def _resource_set_cpu_59_mem_512(_, __):
+    return {"cpu": 59, "memory": 512}
+
+def _resource_set_cpu_59_mem_1024(_, __):
+    return {"cpu": 59, "memory": 1024}
+
+def _resource_set_cpu_59_mem_2048(_, __):
+    return {"cpu": 59, "memory": 2048}
+
+def _resource_set_cpu_59_mem_4096(_, __):
+    return {"cpu": 59, "memory": 4096}
+
+def _resource_set_cpu_59_mem_8192(_, __):
+    return {"cpu": 59, "memory": 8192}
+
+def _resource_set_cpu_59_mem_16384(_, __):
+    return {"cpu": 59, "memory": 16384}
+
+def _resource_set_cpu_59_mem_32768(_, __):
+    return {"cpu": 59, "memory": 32768}
+
+def _resource_set_cpu_60_mem_0(_, __):
+    return {"cpu": 60}
+
+def _resource_set_cpu_60_mem_512(_, __):
+    return {"cpu": 60, "memory": 512}
+
+def _resource_set_cpu_60_mem_1024(_, __):
+    return {"cpu": 60, "memory": 1024}
+
+def _resource_set_cpu_60_mem_2048(_, __):
+    return {"cpu": 60, "memory": 2048}
+
+def _resource_set_cpu_60_mem_4096(_, __):
+    return {"cpu": 60, "memory": 4096}
+
+def _resource_set_cpu_60_mem_8192(_, __):
+    return {"cpu": 60, "memory": 8192}
+
+def _resource_set_cpu_60_mem_16384(_, __):
+    return {"cpu": 60, "memory": 16384}
+
+def _resource_set_cpu_60_mem_32768(_, __):
+    return {"cpu": 60, "memory": 32768}
+
+def _resource_set_cpu_61_mem_0(_, __):
+    return {"cpu": 61}
+
+def _resource_set_cpu_61_mem_512(_, __):
+    return {"cpu": 61, "memory": 512}
+
+def _resource_set_cpu_61_mem_1024(_, __):
+    return {"cpu": 61, "memory": 1024}
+
+def _resource_set_cpu_61_mem_2048(_, __):
+    return {"cpu": 61, "memory": 2048}
+
+def _resource_set_cpu_61_mem_4096(_, __):
+    return {"cpu": 61, "memory": 4096}
+
+def _resource_set_cpu_61_mem_8192(_, __):
+    return {"cpu": 61, "memory": 8192}
+
+def _resource_set_cpu_61_mem_16384(_, __):
+    return {"cpu": 61, "memory": 16384}
+
+def _resource_set_cpu_61_mem_32768(_, __):
+    return {"cpu": 61, "memory": 32768}
+
+def _resource_set_cpu_62_mem_0(_, __):
+    return {"cpu": 62}
+
+def _resource_set_cpu_62_mem_512(_, __):
+    return {"cpu": 62, "memory": 512}
+
+def _resource_set_cpu_62_mem_1024(_, __):
+    return {"cpu": 62, "memory": 1024}
+
+def _resource_set_cpu_62_mem_2048(_, __):
+    return {"cpu": 62, "memory": 2048}
+
+def _resource_set_cpu_62_mem_4096(_, __):
+    return {"cpu": 62, "memory": 4096}
+
+def _resource_set_cpu_62_mem_8192(_, __):
+    return {"cpu": 62, "memory": 8192}
+
+def _resource_set_cpu_62_mem_16384(_, __):
+    return {"cpu": 62, "memory": 16384}
+
+def _resource_set_cpu_62_mem_32768(_, __):
+    return {"cpu": 62, "memory": 32768}
+
+def _resource_set_cpu_63_mem_0(_, __):
+    return {"cpu": 63}
+
+def _resource_set_cpu_63_mem_512(_, __):
+    return {"cpu": 63, "memory": 512}
+
+def _resource_set_cpu_63_mem_1024(_, __):
+    return {"cpu": 63, "memory": 1024}
+
+def _resource_set_cpu_63_mem_2048(_, __):
+    return {"cpu": 63, "memory": 2048}
+
+def _resource_set_cpu_63_mem_4096(_, __):
+    return {"cpu": 63, "memory": 4096}
+
+def _resource_set_cpu_63_mem_8192(_, __):
+    return {"cpu": 63, "memory": 8192}
+
+def _resource_set_cpu_63_mem_16384(_, __):
+    return {"cpu": 63, "memory": 16384}
+
+def _resource_set_cpu_63_mem_32768(_, __):
+    return {"cpu": 63, "memory": 32768}
+
+def _resource_set_cpu_64_mem_0(_, __):
+    return {"cpu": 64}
+
+def _resource_set_cpu_64_mem_512(_, __):
+    return {"cpu": 64, "memory": 512}
+
+def _resource_set_cpu_64_mem_1024(_, __):
+    return {"cpu": 64, "memory": 1024}
+
+def _resource_set_cpu_64_mem_2048(_, __):
+    return {"cpu": 64, "memory": 2048}
+
+def _resource_set_cpu_64_mem_4096(_, __):
+    return {"cpu": 64, "memory": 4096}
+
+def _resource_set_cpu_64_mem_8192(_, __):
+    return {"cpu": 64, "memory": 8192}
+
+def _resource_set_cpu_64_mem_16384(_, __):
+    return {"cpu": 64, "memory": 16384}
+
+def _resource_set_cpu_64_mem_32768(_, __):
+    return {"cpu": 64, "memory": 32768}
+
+_RESOURCE_SETS = {
+    0: {
+        512: _resource_set_cpu_0_mem_512,
+        1024: _resource_set_cpu_0_mem_1024,
+        2048: _resource_set_cpu_0_mem_2048,
+        4096: _resource_set_cpu_0_mem_4096,
+        8192: _resource_set_cpu_0_mem_8192,
+        16384: _resource_set_cpu_0_mem_16384,
+        32768: _resource_set_cpu_0_mem_32768,
+    },
+    1: {
+        0: _resource_set_cpu_1_mem_0,
+        512: _resource_set_cpu_1_mem_512,
+        1024: _resource_set_cpu_1_mem_1024,
+        2048: _resource_set_cpu_1_mem_2048,
+        4096: _resource_set_cpu_1_mem_4096,
+        8192: _resource_set_cpu_1_mem_8192,
+        16384: _resource_set_cpu_1_mem_16384,
+        32768: _resource_set_cpu_1_mem_32768,
+    },
+    2: {
+        0: _resource_set_cpu_2_mem_0,
+        512: _resource_set_cpu_2_mem_512,
+        1024: _resource_set_cpu_2_mem_1024,
+        2048: _resource_set_cpu_2_mem_2048,
+        4096: _resource_set_cpu_2_mem_4096,
+        8192: _resource_set_cpu_2_mem_8192,
+        16384: _resource_set_cpu_2_mem_16384,
+        32768: _resource_set_cpu_2_mem_32768,
+    },
+    3: {
+        0: _resource_set_cpu_3_mem_0,
+        512: _resource_set_cpu_3_mem_512,
+        1024: _resource_set_cpu_3_mem_1024,
+        2048: _resource_set_cpu_3_mem_2048,
+        4096: _resource_set_cpu_3_mem_4096,
+        8192: _resource_set_cpu_3_mem_8192,
+        16384: _resource_set_cpu_3_mem_16384,
+        32768: _resource_set_cpu_3_mem_32768,
+    },
+    4: {
+        0: _resource_set_cpu_4_mem_0,
+        512: _resource_set_cpu_4_mem_512,
+        1024: _resource_set_cpu_4_mem_1024,
+        2048: _resource_set_cpu_4_mem_2048,
+        4096: _resource_set_cpu_4_mem_4096,
+        8192: _resource_set_cpu_4_mem_8192,
+        16384: _resource_set_cpu_4_mem_16384,
+        32768: _resource_set_cpu_4_mem_32768,
+    },
+    5: {
+        0: _resource_set_cpu_5_mem_0,
+        512: _resource_set_cpu_5_mem_512,
+        1024: _resource_set_cpu_5_mem_1024,
+        2048: _resource_set_cpu_5_mem_2048,
+        4096: _resource_set_cpu_5_mem_4096,
+        8192: _resource_set_cpu_5_mem_8192,
+        16384: _resource_set_cpu_5_mem_16384,
+        32768: _resource_set_cpu_5_mem_32768,
+    },
+    6: {
+        0: _resource_set_cpu_6_mem_0,
+        512: _resource_set_cpu_6_mem_512,
+        1024: _resource_set_cpu_6_mem_1024,
+        2048: _resource_set_cpu_6_mem_2048,
+        4096: _resource_set_cpu_6_mem_4096,
+        8192: _resource_set_cpu_6_mem_8192,
+        16384: _resource_set_cpu_6_mem_16384,
+        32768: _resource_set_cpu_6_mem_32768,
+    },
+    7: {
+        0: _resource_set_cpu_7_mem_0,
+        512: _resource_set_cpu_7_mem_512,
+        1024: _resource_set_cpu_7_mem_1024,
+        2048: _resource_set_cpu_7_mem_2048,
+        4096: _resource_set_cpu_7_mem_4096,
+        8192: _resource_set_cpu_7_mem_8192,
+        16384: _resource_set_cpu_7_mem_16384,
+        32768: _resource_set_cpu_7_mem_32768,
+    },
+    8: {
+        0: _resource_set_cpu_8_mem_0,
+        512: _resource_set_cpu_8_mem_512,
+        1024: _resource_set_cpu_8_mem_1024,
+        2048: _resource_set_cpu_8_mem_2048,
+        4096: _resource_set_cpu_8_mem_4096,
+        8192: _resource_set_cpu_8_mem_8192,
+        16384: _resource_set_cpu_8_mem_16384,
+        32768: _resource_set_cpu_8_mem_32768,
+    },
+    9: {
+        0: _resource_set_cpu_9_mem_0,
+        512: _resource_set_cpu_9_mem_512,
+        1024: _resource_set_cpu_9_mem_1024,
+        2048: _resource_set_cpu_9_mem_2048,
+        4096: _resource_set_cpu_9_mem_4096,
+        8192: _resource_set_cpu_9_mem_8192,
+        16384: _resource_set_cpu_9_mem_16384,
+        32768: _resource_set_cpu_9_mem_32768,
+    },
+    10: {
+        0: _resource_set_cpu_10_mem_0,
+        512: _resource_set_cpu_10_mem_512,
+        1024: _resource_set_cpu_10_mem_1024,
+        2048: _resource_set_cpu_10_mem_2048,
+        4096: _resource_set_cpu_10_mem_4096,
+        8192: _resource_set_cpu_10_mem_8192,
+        16384: _resource_set_cpu_10_mem_16384,
+        32768: _resource_set_cpu_10_mem_32768,
+    },
+    11: {
+        0: _resource_set_cpu_11_mem_0,
+        512: _resource_set_cpu_11_mem_512,
+        1024: _resource_set_cpu_11_mem_1024,
+        2048: _resource_set_cpu_11_mem_2048,
+        4096: _resource_set_cpu_11_mem_4096,
+        8192: _resource_set_cpu_11_mem_8192,
+        16384: _resource_set_cpu_11_mem_16384,
+        32768: _resource_set_cpu_11_mem_32768,
+    },
+    12: {
+        0: _resource_set_cpu_12_mem_0,
+        512: _resource_set_cpu_12_mem_512,
+        1024: _resource_set_cpu_12_mem_1024,
+        2048: _resource_set_cpu_12_mem_2048,
+        4096: _resource_set_cpu_12_mem_4096,
+        8192: _resource_set_cpu_12_mem_8192,
+        16384: _resource_set_cpu_12_mem_16384,
+        32768: _resource_set_cpu_12_mem_32768,
+    },
+    13: {
+        0: _resource_set_cpu_13_mem_0,
+        512: _resource_set_cpu_13_mem_512,
+        1024: _resource_set_cpu_13_mem_1024,
+        2048: _resource_set_cpu_13_mem_2048,
+        4096: _resource_set_cpu_13_mem_4096,
+        8192: _resource_set_cpu_13_mem_8192,
+        16384: _resource_set_cpu_13_mem_16384,
+        32768: _resource_set_cpu_13_mem_32768,
+    },
+    14: {
+        0: _resource_set_cpu_14_mem_0,
+        512: _resource_set_cpu_14_mem_512,
+        1024: _resource_set_cpu_14_mem_1024,
+        2048: _resource_set_cpu_14_mem_2048,
+        4096: _resource_set_cpu_14_mem_4096,
+        8192: _resource_set_cpu_14_mem_8192,
+        16384: _resource_set_cpu_14_mem_16384,
+        32768: _resource_set_cpu_14_mem_32768,
+    },
+    15: {
+        0: _resource_set_cpu_15_mem_0,
+        512: _resource_set_cpu_15_mem_512,
+        1024: _resource_set_cpu_15_mem_1024,
+        2048: _resource_set_cpu_15_mem_2048,
+        4096: _resource_set_cpu_15_mem_4096,
+        8192: _resource_set_cpu_15_mem_8192,
+        16384: _resource_set_cpu_15_mem_16384,
+        32768: _resource_set_cpu_15_mem_32768,
+    },
+    16: {
+        0: _resource_set_cpu_16_mem_0,
+        512: _resource_set_cpu_16_mem_512,
+        1024: _resource_set_cpu_16_mem_1024,
+        2048: _resource_set_cpu_16_mem_2048,
+        4096: _resource_set_cpu_16_mem_4096,
+        8192: _resource_set_cpu_16_mem_8192,
+        16384: _resource_set_cpu_16_mem_16384,
+        32768: _resource_set_cpu_16_mem_32768,
+    },
+    17: {
+        0: _resource_set_cpu_17_mem_0,
+        512: _resource_set_cpu_17_mem_512,
+        1024: _resource_set_cpu_17_mem_1024,
+        2048: _resource_set_cpu_17_mem_2048,
+        4096: _resource_set_cpu_17_mem_4096,
+        8192: _resource_set_cpu_17_mem_8192,
+        16384: _resource_set_cpu_17_mem_16384,
+        32768: _resource_set_cpu_17_mem_32768,
+    },
+    18: {
+        0: _resource_set_cpu_18_mem_0,
+        512: _resource_set_cpu_18_mem_512,
+        1024: _resource_set_cpu_18_mem_1024,
+        2048: _resource_set_cpu_18_mem_2048,
+        4096: _resource_set_cpu_18_mem_4096,
+        8192: _resource_set_cpu_18_mem_8192,
+        16384: _resource_set_cpu_18_mem_16384,
+        32768: _resource_set_cpu_18_mem_32768,
+    },
+    19: {
+        0: _resource_set_cpu_19_mem_0,
+        512: _resource_set_cpu_19_mem_512,
+        1024: _resource_set_cpu_19_mem_1024,
+        2048: _resource_set_cpu_19_mem_2048,
+        4096: _resource_set_cpu_19_mem_4096,
+        8192: _resource_set_cpu_19_mem_8192,
+        16384: _resource_set_cpu_19_mem_16384,
+        32768: _resource_set_cpu_19_mem_32768,
+    },
+    20: {
+        0: _resource_set_cpu_20_mem_0,
+        512: _resource_set_cpu_20_mem_512,
+        1024: _resource_set_cpu_20_mem_1024,
+        2048: _resource_set_cpu_20_mem_2048,
+        4096: _resource_set_cpu_20_mem_4096,
+        8192: _resource_set_cpu_20_mem_8192,
+        16384: _resource_set_cpu_20_mem_16384,
+        32768: _resource_set_cpu_20_mem_32768,
+    },
+    21: {
+        0: _resource_set_cpu_21_mem_0,
+        512: _resource_set_cpu_21_mem_512,
+        1024: _resource_set_cpu_21_mem_1024,
+        2048: _resource_set_cpu_21_mem_2048,
+        4096: _resource_set_cpu_21_mem_4096,
+        8192: _resource_set_cpu_21_mem_8192,
+        16384: _resource_set_cpu_21_mem_16384,
+        32768: _resource_set_cpu_21_mem_32768,
+    },
+    22: {
+        0: _resource_set_cpu_22_mem_0,
+        512: _resource_set_cpu_22_mem_512,
+        1024: _resource_set_cpu_22_mem_1024,
+        2048: _resource_set_cpu_22_mem_2048,
+        4096: _resource_set_cpu_22_mem_4096,
+        8192: _resource_set_cpu_22_mem_8192,
+        16384: _resource_set_cpu_22_mem_16384,
+        32768: _resource_set_cpu_22_mem_32768,
+    },
+    23: {
+        0: _resource_set_cpu_23_mem_0,
+        512: _resource_set_cpu_23_mem_512,
+        1024: _resource_set_cpu_23_mem_1024,
+        2048: _resource_set_cpu_23_mem_2048,
+        4096: _resource_set_cpu_23_mem_4096,
+        8192: _resource_set_cpu_23_mem_8192,
+        16384: _resource_set_cpu_23_mem_16384,
+        32768: _resource_set_cpu_23_mem_32768,
+    },
+    24: {
+        0: _resource_set_cpu_24_mem_0,
+        512: _resource_set_cpu_24_mem_512,
+        1024: _resource_set_cpu_24_mem_1024,
+        2048: _resource_set_cpu_24_mem_2048,
+        4096: _resource_set_cpu_24_mem_4096,
+        8192: _resource_set_cpu_24_mem_8192,
+        16384: _resource_set_cpu_24_mem_16384,
+        32768: _resource_set_cpu_24_mem_32768,
+    },
+    25: {
+        0: _resource_set_cpu_25_mem_0,
+        512: _resource_set_cpu_25_mem_512,
+        1024: _resource_set_cpu_25_mem_1024,
+        2048: _resource_set_cpu_25_mem_2048,
+        4096: _resource_set_cpu_25_mem_4096,
+        8192: _resource_set_cpu_25_mem_8192,
+        16384: _resource_set_cpu_25_mem_16384,
+        32768: _resource_set_cpu_25_mem_32768,
+    },
+    26: {
+        0: _resource_set_cpu_26_mem_0,
+        512: _resource_set_cpu_26_mem_512,
+        1024: _resource_set_cpu_26_mem_1024,
+        2048: _resource_set_cpu_26_mem_2048,
+        4096: _resource_set_cpu_26_mem_4096,
+        8192: _resource_set_cpu_26_mem_8192,
+        16384: _resource_set_cpu_26_mem_16384,
+        32768: _resource_set_cpu_26_mem_32768,
+    },
+    27: {
+        0: _resource_set_cpu_27_mem_0,
+        512: _resource_set_cpu_27_mem_512,
+        1024: _resource_set_cpu_27_mem_1024,
+        2048: _resource_set_cpu_27_mem_2048,
+        4096: _resource_set_cpu_27_mem_4096,
+        8192: _resource_set_cpu_27_mem_8192,
+        16384: _resource_set_cpu_27_mem_16384,
+        32768: _resource_set_cpu_27_mem_32768,
+    },
+    28: {
+        0: _resource_set_cpu_28_mem_0,
+        512: _resource_set_cpu_28_mem_512,
+        1024: _resource_set_cpu_28_mem_1024,
+        2048: _resource_set_cpu_28_mem_2048,
+        4096: _resource_set_cpu_28_mem_4096,
+        8192: _resource_set_cpu_28_mem_8192,
+        16384: _resource_set_cpu_28_mem_16384,
+        32768: _resource_set_cpu_28_mem_32768,
+    },
+    29: {
+        0: _resource_set_cpu_29_mem_0,
+        512: _resource_set_cpu_29_mem_512,
+        1024: _resource_set_cpu_29_mem_1024,
+        2048: _resource_set_cpu_29_mem_2048,
+        4096: _resource_set_cpu_29_mem_4096,
+        8192: _resource_set_cpu_29_mem_8192,
+        16384: _resource_set_cpu_29_mem_16384,
+        32768: _resource_set_cpu_29_mem_32768,
+    },
+    30: {
+        0: _resource_set_cpu_30_mem_0,
+        512: _resource_set_cpu_30_mem_512,
+        1024: _resource_set_cpu_30_mem_1024,
+        2048: _resource_set_cpu_30_mem_2048,
+        4096: _resource_set_cpu_30_mem_4096,
+        8192: _resource_set_cpu_30_mem_8192,
+        16384: _resource_set_cpu_30_mem_16384,
+        32768: _resource_set_cpu_30_mem_32768,
+    },
+    31: {
+        0: _resource_set_cpu_31_mem_0,
+        512: _resource_set_cpu_31_mem_512,
+        1024: _resource_set_cpu_31_mem_1024,
+        2048: _resource_set_cpu_31_mem_2048,
+        4096: _resource_set_cpu_31_mem_4096,
+        8192: _resource_set_cpu_31_mem_8192,
+        16384: _resource_set_cpu_31_mem_16384,
+        32768: _resource_set_cpu_31_mem_32768,
+    },
+    32: {
+        0: _resource_set_cpu_32_mem_0,
+        512: _resource_set_cpu_32_mem_512,
+        1024: _resource_set_cpu_32_mem_1024,
+        2048: _resource_set_cpu_32_mem_2048,
+        4096: _resource_set_cpu_32_mem_4096,
+        8192: _resource_set_cpu_32_mem_8192,
+        16384: _resource_set_cpu_32_mem_16384,
+        32768: _resource_set_cpu_32_mem_32768,
+    },
+    33: {
+        0: _resource_set_cpu_33_mem_0,
+        512: _resource_set_cpu_33_mem_512,
+        1024: _resource_set_cpu_33_mem_1024,
+        2048: _resource_set_cpu_33_mem_2048,
+        4096: _resource_set_cpu_33_mem_4096,
+        8192: _resource_set_cpu_33_mem_8192,
+        16384: _resource_set_cpu_33_mem_16384,
+        32768: _resource_set_cpu_33_mem_32768,
+    },
+    34: {
+        0: _resource_set_cpu_34_mem_0,
+        512: _resource_set_cpu_34_mem_512,
+        1024: _resource_set_cpu_34_mem_1024,
+        2048: _resource_set_cpu_34_mem_2048,
+        4096: _resource_set_cpu_34_mem_4096,
+        8192: _resource_set_cpu_34_mem_8192,
+        16384: _resource_set_cpu_34_mem_16384,
+        32768: _resource_set_cpu_34_mem_32768,
+    },
+    35: {
+        0: _resource_set_cpu_35_mem_0,
+        512: _resource_set_cpu_35_mem_512,
+        1024: _resource_set_cpu_35_mem_1024,
+        2048: _resource_set_cpu_35_mem_2048,
+        4096: _resource_set_cpu_35_mem_4096,
+        8192: _resource_set_cpu_35_mem_8192,
+        16384: _resource_set_cpu_35_mem_16384,
+        32768: _resource_set_cpu_35_mem_32768,
+    },
+    36: {
+        0: _resource_set_cpu_36_mem_0,
+        512: _resource_set_cpu_36_mem_512,
+        1024: _resource_set_cpu_36_mem_1024,
+        2048: _resource_set_cpu_36_mem_2048,
+        4096: _resource_set_cpu_36_mem_4096,
+        8192: _resource_set_cpu_36_mem_8192,
+        16384: _resource_set_cpu_36_mem_16384,
+        32768: _resource_set_cpu_36_mem_32768,
+    },
+    37: {
+        0: _resource_set_cpu_37_mem_0,
+        512: _resource_set_cpu_37_mem_512,
+        1024: _resource_set_cpu_37_mem_1024,
+        2048: _resource_set_cpu_37_mem_2048,
+        4096: _resource_set_cpu_37_mem_4096,
+        8192: _resource_set_cpu_37_mem_8192,
+        16384: _resource_set_cpu_37_mem_16384,
+        32768: _resource_set_cpu_37_mem_32768,
+    },
+    38: {
+        0: _resource_set_cpu_38_mem_0,
+        512: _resource_set_cpu_38_mem_512,
+        1024: _resource_set_cpu_38_mem_1024,
+        2048: _resource_set_cpu_38_mem_2048,
+        4096: _resource_set_cpu_38_mem_4096,
+        8192: _resource_set_cpu_38_mem_8192,
+        16384: _resource_set_cpu_38_mem_16384,
+        32768: _resource_set_cpu_38_mem_32768,
+    },
+    39: {
+        0: _resource_set_cpu_39_mem_0,
+        512: _resource_set_cpu_39_mem_512,
+        1024: _resource_set_cpu_39_mem_1024,
+        2048: _resource_set_cpu_39_mem_2048,
+        4096: _resource_set_cpu_39_mem_4096,
+        8192: _resource_set_cpu_39_mem_8192,
+        16384: _resource_set_cpu_39_mem_16384,
+        32768: _resource_set_cpu_39_mem_32768,
+    },
+    40: {
+        0: _resource_set_cpu_40_mem_0,
+        512: _resource_set_cpu_40_mem_512,
+        1024: _resource_set_cpu_40_mem_1024,
+        2048: _resource_set_cpu_40_mem_2048,
+        4096: _resource_set_cpu_40_mem_4096,
+        8192: _resource_set_cpu_40_mem_8192,
+        16384: _resource_set_cpu_40_mem_16384,
+        32768: _resource_set_cpu_40_mem_32768,
+    },
+    41: {
+        0: _resource_set_cpu_41_mem_0,
+        512: _resource_set_cpu_41_mem_512,
+        1024: _resource_set_cpu_41_mem_1024,
+        2048: _resource_set_cpu_41_mem_2048,
+        4096: _resource_set_cpu_41_mem_4096,
+        8192: _resource_set_cpu_41_mem_8192,
+        16384: _resource_set_cpu_41_mem_16384,
+        32768: _resource_set_cpu_41_mem_32768,
+    },
+    42: {
+        0: _resource_set_cpu_42_mem_0,
+        512: _resource_set_cpu_42_mem_512,
+        1024: _resource_set_cpu_42_mem_1024,
+        2048: _resource_set_cpu_42_mem_2048,
+        4096: _resource_set_cpu_42_mem_4096,
+        8192: _resource_set_cpu_42_mem_8192,
+        16384: _resource_set_cpu_42_mem_16384,
+        32768: _resource_set_cpu_42_mem_32768,
+    },
+    43: {
+        0: _resource_set_cpu_43_mem_0,
+        512: _resource_set_cpu_43_mem_512,
+        1024: _resource_set_cpu_43_mem_1024,
+        2048: _resource_set_cpu_43_mem_2048,
+        4096: _resource_set_cpu_43_mem_4096,
+        8192: _resource_set_cpu_43_mem_8192,
+        16384: _resource_set_cpu_43_mem_16384,
+        32768: _resource_set_cpu_43_mem_32768,
+    },
+    44: {
+        0: _resource_set_cpu_44_mem_0,
+        512: _resource_set_cpu_44_mem_512,
+        1024: _resource_set_cpu_44_mem_1024,
+        2048: _resource_set_cpu_44_mem_2048,
+        4096: _resource_set_cpu_44_mem_4096,
+        8192: _resource_set_cpu_44_mem_8192,
+        16384: _resource_set_cpu_44_mem_16384,
+        32768: _resource_set_cpu_44_mem_32768,
+    },
+    45: {
+        0: _resource_set_cpu_45_mem_0,
+        512: _resource_set_cpu_45_mem_512,
+        1024: _resource_set_cpu_45_mem_1024,
+        2048: _resource_set_cpu_45_mem_2048,
+        4096: _resource_set_cpu_45_mem_4096,
+        8192: _resource_set_cpu_45_mem_8192,
+        16384: _resource_set_cpu_45_mem_16384,
+        32768: _resource_set_cpu_45_mem_32768,
+    },
+    46: {
+        0: _resource_set_cpu_46_mem_0,
+        512: _resource_set_cpu_46_mem_512,
+        1024: _resource_set_cpu_46_mem_1024,
+        2048: _resource_set_cpu_46_mem_2048,
+        4096: _resource_set_cpu_46_mem_4096,
+        8192: _resource_set_cpu_46_mem_8192,
+        16384: _resource_set_cpu_46_mem_16384,
+        32768: _resource_set_cpu_46_mem_32768,
+    },
+    47: {
+        0: _resource_set_cpu_47_mem_0,
+        512: _resource_set_cpu_47_mem_512,
+        1024: _resource_set_cpu_47_mem_1024,
+        2048: _resource_set_cpu_47_mem_2048,
+        4096: _resource_set_cpu_47_mem_4096,
+        8192: _resource_set_cpu_47_mem_8192,
+        16384: _resource_set_cpu_47_mem_16384,
+        32768: _resource_set_cpu_47_mem_32768,
+    },
+    48: {
+        0: _resource_set_cpu_48_mem_0,
+        512: _resource_set_cpu_48_mem_512,
+        1024: _resource_set_cpu_48_mem_1024,
+        2048: _resource_set_cpu_48_mem_2048,
+        4096: _resource_set_cpu_48_mem_4096,
+        8192: _resource_set_cpu_48_mem_8192,
+        16384: _resource_set_cpu_48_mem_16384,
+        32768: _resource_set_cpu_48_mem_32768,
+    },
+    49: {
+        0: _resource_set_cpu_49_mem_0,
+        512: _resource_set_cpu_49_mem_512,
+        1024: _resource_set_cpu_49_mem_1024,
+        2048: _resource_set_cpu_49_mem_2048,
+        4096: _resource_set_cpu_49_mem_4096,
+        8192: _resource_set_cpu_49_mem_8192,
+        16384: _resource_set_cpu_49_mem_16384,
+        32768: _resource_set_cpu_49_mem_32768,
+    },
+    50: {
+        0: _resource_set_cpu_50_mem_0,
+        512: _resource_set_cpu_50_mem_512,
+        1024: _resource_set_cpu_50_mem_1024,
+        2048: _resource_set_cpu_50_mem_2048,
+        4096: _resource_set_cpu_50_mem_4096,
+        8192: _resource_set_cpu_50_mem_8192,
+        16384: _resource_set_cpu_50_mem_16384,
+        32768: _resource_set_cpu_50_mem_32768,
+    },
+    51: {
+        0: _resource_set_cpu_51_mem_0,
+        512: _resource_set_cpu_51_mem_512,
+        1024: _resource_set_cpu_51_mem_1024,
+        2048: _resource_set_cpu_51_mem_2048,
+        4096: _resource_set_cpu_51_mem_4096,
+        8192: _resource_set_cpu_51_mem_8192,
+        16384: _resource_set_cpu_51_mem_16384,
+        32768: _resource_set_cpu_51_mem_32768,
+    },
+    52: {
+        0: _resource_set_cpu_52_mem_0,
+        512: _resource_set_cpu_52_mem_512,
+        1024: _resource_set_cpu_52_mem_1024,
+        2048: _resource_set_cpu_52_mem_2048,
+        4096: _resource_set_cpu_52_mem_4096,
+        8192: _resource_set_cpu_52_mem_8192,
+        16384: _resource_set_cpu_52_mem_16384,
+        32768: _resource_set_cpu_52_mem_32768,
+    },
+    53: {
+        0: _resource_set_cpu_53_mem_0,
+        512: _resource_set_cpu_53_mem_512,
+        1024: _resource_set_cpu_53_mem_1024,
+        2048: _resource_set_cpu_53_mem_2048,
+        4096: _resource_set_cpu_53_mem_4096,
+        8192: _resource_set_cpu_53_mem_8192,
+        16384: _resource_set_cpu_53_mem_16384,
+        32768: _resource_set_cpu_53_mem_32768,
+    },
+    54: {
+        0: _resource_set_cpu_54_mem_0,
+        512: _resource_set_cpu_54_mem_512,
+        1024: _resource_set_cpu_54_mem_1024,
+        2048: _resource_set_cpu_54_mem_2048,
+        4096: _resource_set_cpu_54_mem_4096,
+        8192: _resource_set_cpu_54_mem_8192,
+        16384: _resource_set_cpu_54_mem_16384,
+        32768: _resource_set_cpu_54_mem_32768,
+    },
+    55: {
+        0: _resource_set_cpu_55_mem_0,
+        512: _resource_set_cpu_55_mem_512,
+        1024: _resource_set_cpu_55_mem_1024,
+        2048: _resource_set_cpu_55_mem_2048,
+        4096: _resource_set_cpu_55_mem_4096,
+        8192: _resource_set_cpu_55_mem_8192,
+        16384: _resource_set_cpu_55_mem_16384,
+        32768: _resource_set_cpu_55_mem_32768,
+    },
+    56: {
+        0: _resource_set_cpu_56_mem_0,
+        512: _resource_set_cpu_56_mem_512,
+        1024: _resource_set_cpu_56_mem_1024,
+        2048: _resource_set_cpu_56_mem_2048,
+        4096: _resource_set_cpu_56_mem_4096,
+        8192: _resource_set_cpu_56_mem_8192,
+        16384: _resource_set_cpu_56_mem_16384,
+        32768: _resource_set_cpu_56_mem_32768,
+    },
+    57: {
+        0: _resource_set_cpu_57_mem_0,
+        512: _resource_set_cpu_57_mem_512,
+        1024: _resource_set_cpu_57_mem_1024,
+        2048: _resource_set_cpu_57_mem_2048,
+        4096: _resource_set_cpu_57_mem_4096,
+        8192: _resource_set_cpu_57_mem_8192,
+        16384: _resource_set_cpu_57_mem_16384,
+        32768: _resource_set_cpu_57_mem_32768,
+    },
+    58: {
+        0: _resource_set_cpu_58_mem_0,
+        512: _resource_set_cpu_58_mem_512,
+        1024: _resource_set_cpu_58_mem_1024,
+        2048: _resource_set_cpu_58_mem_2048,
+        4096: _resource_set_cpu_58_mem_4096,
+        8192: _resource_set_cpu_58_mem_8192,
+        16384: _resource_set_cpu_58_mem_16384,
+        32768: _resource_set_cpu_58_mem_32768,
+    },
+    59: {
+        0: _resource_set_cpu_59_mem_0,
+        512: _resource_set_cpu_59_mem_512,
+        1024: _resource_set_cpu_59_mem_1024,
+        2048: _resource_set_cpu_59_mem_2048,
+        4096: _resource_set_cpu_59_mem_4096,
+        8192: _resource_set_cpu_59_mem_8192,
+        16384: _resource_set_cpu_59_mem_16384,
+        32768: _resource_set_cpu_59_mem_32768,
+    },
+    60: {
+        0: _resource_set_cpu_60_mem_0,
+        512: _resource_set_cpu_60_mem_512,
+        1024: _resource_set_cpu_60_mem_1024,
+        2048: _resource_set_cpu_60_mem_2048,
+        4096: _resource_set_cpu_60_mem_4096,
+        8192: _resource_set_cpu_60_mem_8192,
+        16384: _resource_set_cpu_60_mem_16384,
+        32768: _resource_set_cpu_60_mem_32768,
+    },
+    61: {
+        0: _resource_set_cpu_61_mem_0,
+        512: _resource_set_cpu_61_mem_512,
+        1024: _resource_set_cpu_61_mem_1024,
+        2048: _resource_set_cpu_61_mem_2048,
+        4096: _resource_set_cpu_61_mem_4096,
+        8192: _resource_set_cpu_61_mem_8192,
+        16384: _resource_set_cpu_61_mem_16384,
+        32768: _resource_set_cpu_61_mem_32768,
+    },
+    62: {
+        0: _resource_set_cpu_62_mem_0,
+        512: _resource_set_cpu_62_mem_512,
+        1024: _resource_set_cpu_62_mem_1024,
+        2048: _resource_set_cpu_62_mem_2048,
+        4096: _resource_set_cpu_62_mem_4096,
+        8192: _resource_set_cpu_62_mem_8192,
+        16384: _resource_set_cpu_62_mem_16384,
+        32768: _resource_set_cpu_62_mem_32768,
+    },
+    63: {
+        0: _resource_set_cpu_63_mem_0,
+        512: _resource_set_cpu_63_mem_512,
+        1024: _resource_set_cpu_63_mem_1024,
+        2048: _resource_set_cpu_63_mem_2048,
+        4096: _resource_set_cpu_63_mem_4096,
+        8192: _resource_set_cpu_63_mem_8192,
+        16384: _resource_set_cpu_63_mem_16384,
+        32768: _resource_set_cpu_63_mem_32768,
+    },
+    64: {
+        0: _resource_set_cpu_64_mem_0,
+        512: _resource_set_cpu_64_mem_512,
+        1024: _resource_set_cpu_64_mem_1024,
+        2048: _resource_set_cpu_64_mem_2048,
+        4096: _resource_set_cpu_64_mem_4096,
+        8192: _resource_set_cpu_64_mem_8192,
+        16384: _resource_set_cpu_64_mem_16384,
+        32768: _resource_set_cpu_64_mem_32768,
+    },
+}
+
+_MEMORY_SIZES = [0, 512, 1024, 2048, 4096, 8192, 16384, 32768]
+
+# buildifier: disable=function-docstring
+def resource_lookup(cpu, mem):
+    if cpu == 0 and mem == 0:
+        return None
+
+    if cpu < 0:
+        fail("cpu must be >= 0, not", cpu)
+    elif cpu > 64:
+        cpu = 64
+
+    if mem < 0:
+        fail("mem must be >= 0, not", mem)
+    elif mem >= 32768:
+        mem = 32768
+    else:
+        for i in _MEMORY_SIZES:
+            if i >= mem:
+                mem = i
+                break
+
+    return _RESOURCE_SETS[cpu][mem]

--- a/lib/private/resource_sets_generator.py
+++ b/lib/private/resource_sets_generator.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+# to regenerate, run this as
+# lib/private/resource_sets_generator.py | buildifier - > lib/private/resource_sets.bzl
+
+from pprint import pformat
+
+# Configuration goes here!
+CPU_COUNT: int = 64
+MEMORY_SIZES: list[int] = [
+    0,
+    512,
+    1024,
+    2048,
+    4096,
+    8192,
+    16384,
+    32768,
+]
+
+
+def cpu_dict(cpu: int) -> dict[str, int]:
+    if cpu == 0:
+        return {}
+    else:
+        return {"cpu": cpu}
+
+
+def mem_dict(mem: int) -> dict[str, int]:
+    if mem == 0:
+        return {}
+    else:
+        return {"memory": mem}
+
+
+def resource_func(cpu: int, mem: int) -> str:
+    name = f"_resource_set_cpu_{cpu}_mem_{mem}"
+    value = cpu_dict(cpu) | mem_dict(mem)
+
+    print(f"def {name}(_, __):")
+    print(f"    return {value}")
+    print()
+    return name
+
+
+def main() -> None:
+    resource_sets: dict[int, dict[int, str]] = {}
+
+    print('"""generated with lib/private/resource_sets_generator.py | buildifier - > lib/private/resource_sets.bzl"""')
+    print()
+
+    for cpu in range(CPU_COUNT + 1):
+        for mem in MEMORY_SIZES:
+            # Don't bother to generate the degenerate case; we return a None
+            # here
+            if cpu == 0 and mem == 0:
+                continue
+
+            name = resource_func(cpu, mem)
+            resource_sets.setdefault(cpu, {})[mem] = name
+
+    # This will be formatted wrong, but formatted wrong in a way that
+    # buildifier knows how to correct :)
+    print(f"_RESOURCE_SETS = {pformat(resource_sets).replace('\'', '')}")
+    print()
+    print(f"_MEMORY_SIZES = {pformat(MEMORY_SIZES)}")
+
+    print(
+        f"""
+# buildifier: disable=function-docstring
+def resource_lookup(cpu, mem):
+    if cpu == 0 and mem == 0:
+        return None
+
+    if cpu < 0:
+        fail("cpu must be >= 0, not", cpu)
+    elif cpu > {CPU_COUNT}:
+        cpu = {CPU_COUNT}
+
+    if mem < 0:
+        fail("mem must be >= 0, not", mem)
+    elif mem >= {MEMORY_SIZES[-1]}:
+        mem = {MEMORY_SIZES[-1]}
+    else:
+        for i in _MEMORY_SIZES:
+            if i >= mem:
+                mem = i
+                break
+
+    return _RESOURCE_SETS[cpu][mem]
+"""
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/tests/BUILD.bazel
+++ b/lib/tests/BUILD.bazel
@@ -10,6 +10,7 @@ load(":expand_make_vars_test.bzl", "expand_make_vars_test_suite")
 load(":glob_match_test.bzl", "glob_match_test_suite")
 load(":lists_test.bzl", "lists_test_suite")
 load(":paths_test.bzl", "paths_test_suite")
+load(":resource_sets_tests.bzl", "resource_sets_test_suite")
 load(":strings_tests.bzl", "strings_test_suite")
 load(":utils_test.bzl", "utils_test_suite")
 
@@ -34,6 +35,8 @@ base64_test_suite()
 strings_test_suite()
 
 lists_test_suite()
+
+resource_sets_test_suite()
 
 write_file(
     name = "gen_template",

--- a/lib/tests/resource_sets_tests.bzl
+++ b/lib/tests/resource_sets_tests.bzl
@@ -1,0 +1,37 @@
+""" tests for the resource_set functions """
+
+load("@bazel_skylib//lib:partial.bzl", "partial")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//lib:resource_sets.bzl", "resource_set", "resource_set_for")
+
+def _call_resource_set(value):
+    fake_ctx = struct(resource_set = value)
+    return resource_set(fake_ctx)("", "")
+
+def _resource_set_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, None, resource_set(struct(resource_set = "default")))
+
+    asserts.equals(env, {"cpu": 2}, _call_resource_set("cpu_2"))
+    asserts.equals(env, {"cpu": 4}, _call_resource_set("cpu_4"))
+    asserts.equals(env, {"memory": 8192}, _call_resource_set("mem_8g"))
+
+    asserts.equals(env, None, resource_set_for(cpu_cores = 0, mem_mb = 0))
+    asserts.equals(env, {"cpu": 42}, resource_set_for(cpu_cores = 42, mem_mb = 0)("", ""))
+    asserts.equals(env, {"cpu": 64}, resource_set_for(cpu_cores = 100, mem_mb = 0)("", ""))
+
+    asserts.equals(env, {"memory": 512}, resource_set_for(cpu_cores = 0, mem_mb = 10)("", ""))
+    asserts.equals(env, {"memory": 1024}, resource_set_for(cpu_cores = 0, mem_mb = 600)("", ""))
+    asserts.equals(env, {"memory": 32768}, resource_set_for(cpu_cores = 0, mem_mb = 600000000)("", ""))
+
+    asserts.equals(env, {"cpu": 42, "memory": 512}, resource_set_for(cpu_cores = 42, mem_mb = 10)("", ""))
+
+    return unittest.end(env)
+
+# The unittest library requires that we export the test cases as named test rules,
+# but their names are arbitrary and don't appear anywhere.
+t0_test = unittest.make(_resource_set_test_impl)
+
+def resource_sets_test_suite():
+    unittest.suite("resource_sets_tests", partial.make(t0_test, timeout = "short"))


### PR DESCRIPTION
This adds a new public function, `resource_set_for`, which takes a cpu and memory value and returns an appropriate `resource_set` function for those values, adding some support for the cross-product [mentioned in the previous pass](https://github.com/bazel-contrib/bazel-lib/pull/792#discussion_r1531473277). The bazel resource_set API isn't very easy to work with, and this hides the ugliness here, rather than expecting every module to implement something like [rules_rust did](https://github.com/bazelbuild/rules_rust/blob/f29a63cb3c473bd0158c8c9d3e0793a33187d505/rust/private/rustc_resource_set.bzl).

The ugliness of the implementation is mitigated slightly by using a helper script to generate it, and I reason that people attempting to use the `resource_set` API would be better off with additional abstraction, so if/when this gets fixed in bazel, most people don't need to notice.