### PR TITLE
fix: Add a fallback matching mechanism for output_files

### DIFF
--- a/lib/private/output_files.bzl
+++ b/lib/private/output_files.bzl
@@ -101,6 +101,11 @@ def _find_execution_path_in_files_list(ctx, files_list, path):
         The File if found else None
     """
     for file in files_list:
-        if file.path == "/".join([ctx.bin_dir.path, ctx.attr.target.label.workspace_root, path]):
+        # The `path` can be different depending on whether the file is generated (which will include bin_dir)
+        # or in the source (which will not)
+        if file.path in (
+            "/".join([ctx.bin_dir.path, ctx.attr.target.label.workspace_root, path]),
+            "/".join([ctx.attr.target.label.workspace_root, path]),
+        ):
             return file
     return None


### PR DESCRIPTION
This PR proposes a fallback mechanism for the `output_files` rule, to make it more usable with external repositories.

Specifically, I was trying to select files from the `DefaultInfo` returned by a [rule](https://github.com/DataDog/datadog-agent/blob/b9095bae64e85707b426bc981278f4921c8187bd/deps/openssl.BUILD.bazel#L71) implemented on a build file applied to [an http_archive source](https://github.com/DataDog/datadog-agent/blob/b9095bae64e85707b426bc981278f4921c8187bd/deps/repos.MODULE.bazel#L95-L97) and failed until I discovered that the `short_path` for these files is a relative path containing the canonical repo name, for example:

```
❯ bazel cquery @openssl//:openssl --output=starlark --starlark:expr='[f.short_path for f in providers(target)["DefaultInfo"].files.to_list()]'
["../+_repo_rules+openssl/openssl/include", "../+_repo_rules+openssl/openssl/lib/pkgconfig", "../+_repo_rules+openssl/openssl/bin/openssl", "../+_repo_rules+openssl/openssl/lib/libssl.so", "../+_repo_rules+openssl/openssl/lib/libcrypto.so"]
```

The documentation for `output_files` references [select_file](https://github.com/bazelbuild/bazel-skylib/blob/main/docs/select_file_doc.md) from skylib, but the [implementation](https://github.com/bazelbuild/bazel-skylib/blob/ea054fcaf08c3b014e34212451d8cb45f01d8331/rules/select_file.bzl#L28) of that rule seems to just match based on the ending (`endswith`), which is much more relaxed but also more convenient to use.

This attempts a middle ground, where it keeps the existing mechanism based on `short_path` (ensuring backwards compatibility), while adding a fallback mechanism that reconstructs the execution path such that it can match to the `path`; this works at least for the specific case that I was working with.