### PR TITLE
fix: Allow generated files in platform_transition_filegroup

### DIFF
--- a/lib/tests/transitions/BUILD.bazel
+++ b/lib/tests/transitions/BUILD.bazel
@@ -94,6 +94,18 @@ diff_test(
     ],
 )
 
+genrule(
+    name = "dynamic_path",
+    outs = ["dynamic_path.txt"],
+    cmd = "echo $(RULEDIR) > $@",
+)
+
+platform_transition_filegroup(
+    name = "transitioned_dynamic_path",
+    srcs = ["dynamic_path.txt"],
+    target_platform = ":armv7_linux",
+)
+
 go_binary(
     name = "test_transition_binary",
     embed = [":transitions_lib"],

--- a/lib/transitions.bzl
+++ b/lib/transitions.bzl
@@ -38,6 +38,7 @@ platform_transition_filegroup = rule(
         ),
         "srcs": attr.label_list(
             allow_empty = False,
+            allow_files = True,
             cfg = _transition_platform,
             doc = "The input to be transitioned to the target platform.",
         ),


### PR DESCRIPTION
I'm currently running into this error:

    $ bazel build //lib/tests/transitions:transitioned_dynamic_path
    INFO: Invocation ID: ea3f3d4e-ea1a-49cc-84b5-e5d5e1577aaa
    ERROR: /home/philipp.schrader/repos/bazel-lib/lib/tests/transitions/BUILD.bazel:104:30: in srcs attribute of platform_transition_filegroup rule //lib/tests/transitions:transitioned_dynamic_path: generated file '//lib/tests/transitions:dynamic_path.txt' is misplaced here (expected no files)
    ERROR: /home/philipp.schrader/repos/bazel-lib/lib/tests/transitions/BUILD.bazel:104:30: Analysis of target '//lib/tests/transitions:transitioned_dynamic_path' (config: 4996c2f) failed
    ERROR: Analysis of target '//lib/tests/transitions:transitioned_dynamic_path' failed; build aborted
    INFO: Elapsed time: 0.077s, Critical Path: 0.00s
    INFO: 1 process: 1 internal.
    ERROR: Build did NOT complete successfully

Fix the issue by allowing files in the `srcs` attribute.

This is useful if the `genrule` is operating on a transitioned binary
of some kind.