### PR TITLE
fix: declare COREUTILS_TOOLCHAIN as a Label()

### DIFF
--- a/lib/private/copy_file.bzl
+++ b/lib/private/copy_file.bzl
@@ -21,7 +21,7 @@ These rules copy a file to another location using hermetic uutils/coreutils `cp`
 load(":copy_common.bzl", "SUPPORTS_PATH_MAPPING")
 load(":directory_path.bzl", "DirectoryPathInfo")
 
-_COREUTILS_TOOLCHAIN = "@bazel_lib//lib:coreutils_toolchain_type"
+_COREUTILS_TOOLCHAIN = Label("@bazel_lib//lib:coreutils_toolchain_type")
 
 # Declare toolchains used by copy file actions so that downstream rulesets can pass it into
 # the `toolchains` attribute of their rule.


### PR DESCRIPTION
When this is referenced by the public `COPY_FILE_TOOLCHAINS` in `lib/copy_file.bzl` it may be passed along to a rule invocation that does not directly depend on `bazel_lib`.

For example:
`aspect_rules_jest` => `aspect_rules_js` (v3) => `bazel_lib`
while `aspect_rules_jest` only directly depends on v2 (`aspect_bazel_lib`)