### PR TITLE
fix: restore missing release binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,9 +32,15 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build Go Binaries
         env:
-          # NB: this variable is read by tools/release/copy_release_artifacts.sh
-          # and must match the path in release_prep.sh under RELEASED_BINARY_INTEGRITY
-          DEST: binaries
+          # NB: this variable is read by
+          # tools/release/copy_release_artifacts.sh.
+          # We intentionally nest everything inside a go-binaries/ directory
+          # inside go-binaries.zip. This works around a unintended change in
+          # actions/download-artifact:
+          # https://github.com/actions/download-artifact/issues/455
+          # The release_ruleset reusable workflow picked up that change in
+          # https://github.com/bazel-contrib/.github/pull/50.
+          DEST: binaries/go-binaries
         run: |
           rm -rf ${{ env.DEST }}
           mkdir -p ${{ env.DEST }}


### PR DESCRIPTION
The release process seems to have broken due to this bug in download-artifact: https://github.com/actions/download-artifact/issues/455 We use the release_ruleset.yaml reusable workflow, which downloads all artifacts [here](https://github.com/bazel-contrib/.github/blob/af28703814cf26522cf5e44d219efece91293123/.github/workflows/release_ruleset.yaml#L103). But since there is only one artifact (`go-binaries.zip`), we hit that bug which causes the binaries to appear directly in the working directory instead of in `./go-binaries`.

This change fixes the problem by nesting everything inside a `go-binaries` directory inside `go-binaries.zip`. This way when the file is unzipped, all the binaries appear to be in the same place they were before.