### PR TITLE
feat: add stderr, exit_code_out, chdir, silent_on_success to run_binary

### DIFF
--- a/lib/private/run_binary.bzl
+++ b/lib/private/run_binary.bzl
@@ -35,27 +35,40 @@ def _run_binary_impl(ctx):
         outputs.append(out_dir)
 
     # When a feature that requires interposing on the spawned process is requested
-    # (currently only stdout capture), the tool is launched through the spawn_binary
-    # wrapper instead of directly. When no such feature is used the tool is spawned
-    # directly, avoiding the extra process and keeping the wrapper out of the action
-    # inputs entirely.
+    # (capturing stdout/stderr/exit code, changing directory, or silencing output on
+    # success), the tool is launched through the spawn_binary wrapper instead of
+    # directly. When no such feature is used the tool is spawned directly, avoiding
+    # the extra process and keeping the wrapper out of the action inputs entirely.
     #
-    # `outputs` (outs + out_dirs) are also what make variables like $@ and $(@D)
-    # expand to. The stdout capture file is a real action output but is intentionally
-    # kept out of that set, so that a tool with a single declared `outs` file keeps
-    # working with $@; it is only used for expansion when it is the sole output.
+    # The capture output files (stdout/stderr/exit_code_out) are real action outputs,
+    # but are intentionally kept out of the make-variable output set (`outputs`, used
+    # by $@ and $(@D)), so that a tool with a single declared `outs` file keeps
+    # working with $@. They are only used for expansion when there is no other output.
     stdout = ctx.outputs.stdout
+    stderr = ctx.outputs.stderr
+    exit_code_out = ctx.outputs.exit_code_out
+    silent_on_success = ctx.attr.silent_on_success
+    chdir = ctx.attr.chdir
+    use_wrapper = bool(stdout or stderr or exit_code_out or silent_on_success or chdir)
+
+    capture_outputs = [o for o in [stdout, stderr, exit_code_out] if o]
+    action_outputs = outputs + capture_outputs
+    expansion_outputs = outputs if outputs else action_outputs
+
     spawn_binary = None
-    action_outputs = list(outputs)
-    if stdout:
-        action_outputs.append(stdout)
+    if use_wrapper:
         spawn_binary_toolchain = ctx.toolchains["//lib:spawn_binary_toolchain_type"]
         if not spawn_binary_toolchain:
-            fail("run_binary target {} sets the `stdout` attribute, which requires the spawn_binary toolchain, but none is registered. Register it with register_spawn_binary_toolchains() (WORKSPACE) or the bazel_lib `spawn_binary` toolchain extension (bzlmod).".format(ctx.label))
+            fail("run_binary target {} requests a feature that requires the spawn_binary toolchain (one of stdout, stderr, exit_code_out, silent_on_success, chdir), but none is registered. Register it with register_spawn_binary_toolchains() (WORKSPACE) or the bazel_lib `spawn_binary` toolchain extension (bzlmod).".format(ctx.label))
         spawn_binary = spawn_binary_toolchain.spawn_binary_info.bin
-        args.add("--stdout", stdout)
-        args.add("--")
-        args.add(ctx.executable.tool)
+        if stdout:
+            args.add("--stdout", stdout)
+        if stderr:
+            args.add("--stderr", stderr)
+        if exit_code_out:
+            args.add("--exit-code-out", exit_code_out)
+        if silent_on_success:
+            args.add("--silent-on-success")
 
     if len(action_outputs) < 1:
         fail("""\
@@ -72,12 +85,21 @@ Possible fixes:
             rule_kind = str(ctx.attr.tool.label),
         ))
 
-    expansion_outputs = outputs if outputs else action_outputs
-
     # Location and Make variable expansion can reference paths that aren't path mapped.
     can_path_map = True
     targets = ctx.attr.tools + ctx.attr.srcs
     inputs = ctx.files.tools + ctx.files.srcs
+
+    if use_wrapper:
+        if chdir:
+            expanded_chdir = expand_variables(ctx, ctx.expand_location(chdir, targets = targets), inputs = inputs, outs = expansion_outputs, attribute_name = "chdir")
+            can_path_map = can_path_map and expanded_chdir == chdir
+            args.add("--chdir", expanded_chdir)
+
+        # The remaining args are the command to run: the tool followed by its args.
+        args.add("--")
+        args.add(ctx.executable.tool)
+
     for a in ctx.attr.args:
         expanded = expand_variables(ctx, ctx.expand_location(a, targets = targets), inputs = inputs, outs = expansion_outputs)
         can_path_map = can_path_map and expanded == a
@@ -130,9 +152,9 @@ Possible fixes:
 
 _run_binary = rule(
     implementation = _run_binary_impl,
-    # Optional: only the `stdout` (and future feature) path uses the wrapper, so a
-    # plain run_binary that spawns its tool directly does not require this toolchain
-    # to be registered.
+    # Optional: only targets that request a wrapper feature (stdout, stderr,
+    # exit_code_out, silent_on_success, chdir) use the wrapper, so a plain run_binary
+    # that spawns its tool directly does not require this toolchain to be registered.
     toolchains = [
         config_common.toolchain_type("//lib:spawn_binary_toolchain_type", mandatory = False),
     ],
@@ -154,6 +176,10 @@ _run_binary = rule(
         "out_dirs": attr.string_list(),
         "outs": attr.output_list(),
         "stdout": attr.output(),
+        "stderr": attr.output(),
+        "exit_code_out": attr.output(),
+        "chdir": attr.string(),
+        "silent_on_success": attr.bool(),
         "args": attr.string_list(),
         "mnemonic": attr.string(),
         "progress_message": attr.string(),
@@ -171,6 +197,10 @@ def run_binary(
         outs = [],
         out_dirs = [],
         stdout = None,
+        stderr = None,
+        exit_code_out = None,
+        chdir = None,
+        silent_on_success = False,
         mnemonic = "RunBinary",
         progress_message = None,
         execution_requirements = None,
@@ -182,12 +212,13 @@ def run_binary(
 
     This rule does not require Bash (unlike `native.genrule`).
 
-    By default the binary is spawned directly. When the `stdout` attribute is set, the
-    binary is instead launched through a small wrapper (`spawn_binary`) that captures its
-    standard output into the named file. This is handy both to feed a program's output
-    into a downstream action when the program has no flag to write it to a file, and to
-    silence the output of otherwise-noisy successful build steps. The wrapper is only used
-    when such a feature is requested, so the common case incurs no extra overhead.
+    By default the binary is spawned directly. When any of the `stdout`, `stderr`,
+    `exit_code_out`, `chdir`, or `silent_on_success` attributes is set, the binary is
+    instead launched through a small wrapper (`spawn_binary`) that provides these
+    features. This is handy both to feed a program's output into a downstream action
+    when the program has no flag to write it to a file, and to silence the output of
+    otherwise-noisy successful build steps. The wrapper is only used when such a
+    feature is requested, so the common case incurs no extra overhead.
 
     Args:
         name: The target name
@@ -235,9 +266,35 @@ def run_binary(
             another target, subject to the same semantics as `outs`. If the binary also
             creates declared outputs, those must still be created.
 
-            Only the standard output is captured; standard error and standard input are
-            passed through to the binary unchanged. When `stdout` is not set, the binary
-            is spawned directly without the wrapper.
+            Standard input is always passed through to the binary unchanged. When none of
+            the wrapper features are set, the binary is spawned directly without the wrapper.
+
+        stderr: Output file to capture the stderr of the binary to.
+
+            Behaves like `stdout`, but for the standard error stream. The file can later
+            be used as an input to another target, subject to the same semantics as `outs`.
+
+        exit_code_out: Output file to capture the exit code of the binary to.
+
+            When set, the binary is allowed to exit non-zero without failing the action:
+            its exit code is written to this file (as a decimal string) and the action
+            itself succeeds. Any declared `outs`/`out_dirs` must still be created. This is
+            useful to record the result of a tool whose failure should be handled by a
+            downstream target rather than breaking the build.
+
+        chdir: Working directory to run the binary in.
+
+            When set, the binary is run with this as its working directory instead of the
+            execution root. Subject to `$(location)` and make variable expansions. Note
+            that paths in `args`/`env` are expanded relative to the execution root, so a
+            program that receives such paths and is also given a `chdir` typically needs
+            absolute paths (for example via `$(execpath ...)` combined with `$(RULEDIR)`).
+
+        silent_on_success: Suppress the binary's output unless it fails.
+
+            When True, stdout and stderr that are not being captured to a file are buffered
+            and only forwarded to the console if the binary exits non-zero. This silences
+            logspam from successful build steps while preserving diagnostics on failure.
 
         mnemonic: A one-word description of the action, for example, CppCompile or GoLink.
 
@@ -306,6 +363,10 @@ def run_binary(
         outs = outs,
         out_dirs = out_dirs,
         stdout = stdout,
+        stderr = stderr,
+        exit_code_out = exit_code_out,
+        chdir = chdir,
+        silent_on_success = silent_on_success,
         mnemonic = mnemonic,
         progress_message = progress_message,
         execution_requirements = execution_requirements,

--- a/lib/private/run_binary.bzl
+++ b/lib/private/run_binary.bzl
@@ -93,7 +93,10 @@ Possible fixes:
     if use_wrapper:
         if chdir:
             expanded_chdir = expand_variables(ctx, ctx.expand_location(chdir, targets = targets), inputs = inputs, outs = expansion_outputs, attribute_name = "chdir")
-            can_path_map = can_path_map and expanded_chdir == chdir
+            # Path mapping rewrites action input/output paths in the sandbox. Only
+            # advertise support when chdir is a literal path; $(location) / make
+            # variable expansion can produce paths that must not be remapped.
+            can_path_map = expanded_chdir == chdir
             args.add("--chdir", expanded_chdir)
 
         # The remaining args are the command to run: the tool followed by its args.

--- a/lib/private/run_binary.bzl
+++ b/lib/private/run_binary.bzl
@@ -93,6 +93,7 @@ Possible fixes:
     if use_wrapper:
         if chdir:
             expanded_chdir = expand_variables(ctx, ctx.expand_location(chdir, targets = targets), inputs = inputs, outs = expansion_outputs, attribute_name = "chdir")
+
             # Path mapping rewrites action input/output paths in the sandbox. Only
             # advertise support when chdir is a literal path; $(location) / make
             # variable expansion can produce paths that must not be remapped.

--- a/lib/tests/run_binary/BUILD.bazel
+++ b/lib/tests/run_binary/BUILD.bazel
@@ -155,6 +155,152 @@ diff_test(
     file2 = ":expected_captured_with_out.stdout",
 )
 
+# Capturing stderr: only stderr is redirected to the file; stdout passes through.
+write_file(
+    name = "make_capture_stderr_sh",
+    out = "capture_stderr.sh",
+    content = [
+        "#!/usr/bin/env bash",
+        "set -o errexit -o nounset -o pipefail",
+        '''echo "to stdout: not captured here"''',
+        '''echo "to stderr: captured" >&2''',
+    ],
+    is_executable = True,
+)
+
+sh_binary(
+    name = "capture_stderr",
+    srcs = [":capture_stderr.sh"],
+)
+
+run_binary(
+    name = "captured_stderr",
+    stderr = "captured_stderr.txt",
+    tool = ":capture_stderr",
+)
+
+write_file(
+    name = "expected_captured_stderr",
+    out = "expected_captured_stderr.txt",
+    content = [
+        "to stderr: captured",
+        "",
+    ],
+)
+
+diff_test(
+    name = "captured_stderr_test",
+    file1 = ":captured_stderr.txt",
+    file2 = ":expected_captured_stderr.txt",
+)
+
+# Capturing the exit code: the binary may exit non-zero without failing the action.
+write_file(
+    name = "make_exit_code_sh",
+    out = "exit_code.sh",
+    content = [
+        "#!/usr/bin/env bash",
+        '''echo "doing work"''',
+        "exit 3",
+    ],
+    is_executable = True,
+)
+
+sh_binary(
+    name = "exit_code",
+    srcs = [":exit_code.sh"],
+)
+
+run_binary(
+    name = "captured_exit_code",
+    exit_code_out = "captured_exit_code.txt",
+    tool = ":exit_code",
+)
+
+# The tool exits 3, but with exit_code_out the action succeeds and the code is
+# written to the output file.
+assert_contains(
+    name = "captured_exit_code_test",
+    actual = ":captured_exit_code.txt",
+    expected = "3",
+)
+
+# silent_on_success: a successful run still produces its declared outputs. (Console
+# suppression itself is not observable from a build action assertion.)
+write_file(
+    name = "make_silent_sh",
+    out = "silent.sh",
+    content = [
+        "#!/usr/bin/env bash",
+        "set -o errexit -o nounset -o pipefail",
+        '''echo "noisy stdout"''',
+        '''echo "noisy stderr" >&2''',
+        '''echo "the real output" > "$1"''',
+    ],
+    is_executable = True,
+)
+
+sh_binary(
+    name = "silent",
+    srcs = [":silent.sh"],
+)
+
+run_binary(
+    name = "silent_success",
+    outs = ["silent_success.out"],
+    args = ["$@"],
+    silent_on_success = True,
+    tool = ":silent",
+)
+
+write_file(
+    name = "expected_silent_success",
+    out = "expected_silent_success.out",
+    content = [
+        "the real output",
+        "",
+    ],
+)
+
+diff_test(
+    name = "silent_success_test",
+    file1 = ":silent_success.out",
+    file2 = ":expected_silent_success.out",
+)
+
+# chdir: the binary runs with a different working directory, so it can read a file
+# by a path relative to that directory. The source file lives in chdir_data/.
+write_file(
+    name = "make_chdir_sh",
+    out = "chdir.sh",
+    content = [
+        "#!/usr/bin/env bash",
+        "set -o errexit -o nounset -o pipefail",
+        # Relative to the chdir directory, this resolves to chdir_data/marker.txt.
+        """cat marker.txt""",
+    ],
+    is_executable = True,
+)
+
+sh_binary(
+    name = "chdir_tool",
+    srcs = [":chdir.sh"],
+)
+
+run_binary(
+    name = "chdir_capture",
+    srcs = ["chdir_data/marker.txt"],
+    chdir = "lib/tests/run_binary/chdir_data",
+    stdout = "chdir_capture.txt",
+    tool = ":chdir_tool",
+)
+
+diff_test(
+    name = "chdir_test",
+    file1 = ":chdir_capture.txt",
+    file2 = "chdir_data/marker.txt",
+)
+
 genrule(
     name = "make_foo",
     outs = ["foo"],

--- a/lib/tests/run_binary/chdir_data/marker.txt
+++ b/lib/tests/run_binary/chdir_data/marker.txt
@@ -1,0 +1,1 @@
+in-chdir-dir

--- a/tools/spawn_binary/BUILD.bazel
+++ b/tools/spawn_binary/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "spawn_binary_lib",
@@ -15,4 +15,13 @@ go_binary(
     name = "spawn_binary",
     embed = [":spawn_binary_lib"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "spawn_binary_test",
+    srcs = [
+        "parse_test.go",
+        "run_unix_test.go",
+    ],
+    embed = [":spawn_binary_lib"],
 )

--- a/tools/spawn_binary/BUILD.bazel
+++ b/tools/spawn_binary/BUILD.bazel
@@ -1,5 +1,10 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
+NOT_WINDOWS = select({
+    "@platforms//os:windows": ["@platforms//:incompatible"],
+    "//conditions:default": [],
+})
+
 go_library(
     name = "spawn_binary_lib",
     srcs = [
@@ -24,4 +29,6 @@ go_test(
         "run_unix_test.go",
     ],
     embed = [":spawn_binary_lib"],
+    # run_unix_test.go exercises bash scripts and is behind //go:build !windows.
+    target_compatible_with = NOT_WINDOWS,
 )

--- a/tools/spawn_binary/main.go
+++ b/tools/spawn_binary/main.go
@@ -1,36 +1,57 @@
 // spawn_binary is a thin wrapper around an arbitrary POSIX process, used by the
 // run_binary rule to add features that require interposing on the spawned
-// program. Today the only feature is capturing the program's stdout into a file.
+// program.
 //
 // Usage:
 //
-//	spawn_binary [--stdout=<file>] -- <tool> [args...]
+//	spawn_binary [flags] -- <tool> [args...]
+//
+// Flags:
+//
+//	--stdout=FILE         capture the program's stdout into FILE
+//	--stderr=FILE         capture the program's stderr into FILE
+//	--exit-code-out=FILE  write the program's exit code into FILE and exit 0
+//	--chdir=DIR           run the program with DIR as its working directory
+//	--silent-on-success   only forward non-captured stdout/stderr to the console
+//	                      when the program exits non-zero
 //
 // Design goals (see also the run_binary documentation):
 //   - The spawned program must behave as if Bazel had launched it directly.
-//     Environment, stdin and stderr are passed through verbatim; only stdout is
-//     redirected, and only when --stdout is given.
+//     Environment and stdin are passed through verbatim; a stream is only
+//     redirected when the corresponding feature is requested.
 //   - Termination signals are relayed to the child so that Bazel cancelling or
 //     timing out the action tears down the whole process tree.
 //   - The child's exit status is reported faithfully, including death by signal.
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
+	"strconv"
 	"strings"
 )
 
 const separator = "--"
+
+type options struct {
+	stdoutPath      string
+	stderrPath      string
+	exitCodePath    string
+	chdir           string
+	silentOnSuccess bool
+}
 
 func main() {
 	os.Exit(run(os.Args[1:]))
 }
 
 func run(args []string) int {
-	stdoutPath, cmdArgs, err := parseArgs(args)
+	opts, cmdArgs, err := parseArgs(args)
 	if err != nil {
 		return fatalf("%v", err)
 	}
@@ -38,34 +59,47 @@ func run(args []string) int {
 		return fatalf("no command specified; expected: spawn_binary [flags] -- <tool> [args...]")
 	}
 
-	// #nosec G204 -- spawning an arbitrary tool is the entire purpose of this wrapper.
-	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
-
-	// Pass the environment, stdin and stderr through verbatim so the spawned
-	// program cannot tell it is wrapped and streams we do not intercept are
-	// unaffected.
-	cmd.Env = os.Environ()
-	cmd.Stdin = os.Stdin
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
-
-	if stdoutPath != "" {
-		// Assigning an *os.File hands the file descriptor directly to the child, so
-		// it writes straight to the output file with no intermediate copy.
-		f, ferr := os.Create(stdoutPath)
-		if ferr != nil {
-			return fatalf("failed to create stdout file %q: %v", stdoutPath, ferr)
+	// When changing the child's working directory, resolve a relative tool path to
+	// an absolute one first, so it still refers to the same file (the wrapper itself
+	// keeps running in the original working directory, so the capture output paths,
+	// which it opens, do not need adjusting).
+	if opts.chdir != "" && strings.ContainsRune(cmdArgs[0], '/') {
+		abs, aerr := filepath.Abs(cmdArgs[0])
+		if aerr != nil {
+			return fatalf("failed to resolve tool path %q: %v", cmdArgs[0], aerr)
 		}
-		defer f.Close()
-		cmd.Stdout = f
+		cmdArgs[0] = abs
 	}
 
+	// Set up the stdout and stderr handling. Each stream is either written straight
+	// to a declared output file, buffered (revealed only on failure when
+	// --silent-on-success is set), or passed through to our own fd verbatim.
+	stdout, finalizeStdout, err := newStream(opts.stdoutPath, opts.silentOnSuccess, os.Stdout)
+	if err != nil {
+		return fatalf("%v", err)
+	}
+	stderr, finalizeStderr, err := newStream(opts.stderrPath, opts.silentOnSuccess, os.Stderr)
+	if err != nil {
+		_ = finalizeStdout(1)
+		return fatalf("%v", err)
+	}
+
+	// #nosec G204 -- spawning an arbitrary tool is the entire purpose of this wrapper.
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+	cmd.Env = os.Environ()
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.Dir = opts.chdir
+
 	if serr := cmd.Start(); serr != nil {
+		_ = finalizeStdout(1)
+		_ = finalizeStderr(1)
 		return fatalf("failed to start %q: %v", cmdArgs[0], serr)
 	}
 
-	// Relay termination signals to the child. Without this, the default
-	// disposition would kill the wrapper and orphan the child.
+	// Relay termination signals to the child. Without this, the default disposition
+	// would kill the wrapper and orphan the child.
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, forwardedSignals...)
 	go func() {
@@ -79,37 +113,124 @@ func run(args []string) int {
 	signal.Stop(sigs)
 	close(sigs)
 
-	if werr == nil {
+	code := 0
+	if werr != nil {
+		if exitErr, ok := werr.(*exec.ExitError); ok {
+			code = exitCode(exitErr)
+		} else {
+			_ = finalizeStdout(1)
+			_ = finalizeStderr(1)
+			return fatalf("failed to run %q: %v", cmdArgs[0], werr)
+		}
+	}
+
+	// Flush capture files and reveal any buffered output, based on the child's exit
+	// code.
+	if ferr := finalizeStdout(code); ferr != nil {
+		return fatalf("%v", ferr)
+	}
+	if ferr := finalizeStderr(code); ferr != nil {
+		return fatalf("%v", ferr)
+	}
+
+	if opts.exitCodePath != "" {
+		if werr := os.WriteFile(opts.exitCodePath, []byte(strconv.Itoa(code)), 0o644); werr != nil {
+			return fatalf("failed to write exit code file %q: %v", opts.exitCodePath, werr)
+		}
+		// The exit code has been captured as an output, so the wrapper (and thus the
+		// build action) succeeds regardless of the child's exit code.
 		return 0
 	}
-	if exitErr, ok := werr.(*exec.ExitError); ok {
-		return exitCode(exitErr)
+
+	return code
+}
+
+// newStream returns the writer to hand to the child for one output stream, plus a
+// finalize callback to run after the child exits with its exit code.
+//
+//   - path != "":         the child writes directly to the declared output file.
+//   - silentOnSuccess:    the stream is buffered and only written to console when
+//     the child exits non-zero.
+//   - otherwise:          the stream passes through to console (our own fd) verbatim.
+func newStream(path string, silentOnSuccess bool, console *os.File) (io.Writer, func(code int) error, error) {
+	if path != "" {
+		// Handing the child an *os.File passes the file descriptor directly, so it
+		// writes straight to the output file with no intermediate copy.
+		f, err := os.Create(path)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create output file %q: %w", path, err)
+		}
+		return f, func(int) error { return f.Close() }, nil
 	}
-	return fatalf("failed to run %q: %v", cmdArgs[0], werr)
+	if silentOnSuccess {
+		buf := &bytes.Buffer{}
+		return buf, func(code int) error {
+			if code == 0 {
+				return nil
+			}
+			_, err := console.Write(buf.Bytes())
+			return err
+		}, nil
+	}
+	return console, func(int) error { return nil }, nil
 }
 
 // parseArgs separates the wrapper's own flags (everything before the "--"
 // separator) from the command to run (everything after it).
-func parseArgs(args []string) (stdoutPath string, cmdArgs []string, err error) {
+func parseArgs(args []string) (options, []string, error) {
+	var opts options
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if arg == separator {
-			return stdoutPath, args[i+1:], nil
+			return opts, args[i+1:], nil
 		}
-		switch {
-		case arg == "--stdout":
-			if i+1 >= len(args) {
-				return "", nil, fmt.Errorf("--stdout requires a value")
-			}
-			i++
-			stdoutPath = args[i]
-		case strings.HasPrefix(arg, "--stdout="):
-			stdoutPath = strings.TrimPrefix(arg, "--stdout=")
-		default:
-			return "", nil, fmt.Errorf("unrecognized flag %q before the %q separator", arg, separator)
+		if v, ok, err := valueFlag("--stdout", arg, args, &i); err != nil {
+			return opts, nil, err
+		} else if ok {
+			opts.stdoutPath = v
+			continue
 		}
+		if v, ok, err := valueFlag("--stderr", arg, args, &i); err != nil {
+			return opts, nil, err
+		} else if ok {
+			opts.stderrPath = v
+			continue
+		}
+		if v, ok, err := valueFlag("--exit-code-out", arg, args, &i); err != nil {
+			return opts, nil, err
+		} else if ok {
+			opts.exitCodePath = v
+			continue
+		}
+		if v, ok, err := valueFlag("--chdir", arg, args, &i); err != nil {
+			return opts, nil, err
+		} else if ok {
+			opts.chdir = v
+			continue
+		}
+		if arg == "--silent-on-success" {
+			opts.silentOnSuccess = true
+			continue
+		}
+		return opts, nil, fmt.Errorf("unrecognized flag %q before the %q separator", arg, separator)
 	}
-	return "", nil, fmt.Errorf("missing %q separator before the command to run", separator)
+	return opts, nil, fmt.Errorf("missing %q separator before the command to run", separator)
+}
+
+// valueFlag matches either "--name value" or "--name=value". It advances *i past a
+// consumed value in the "--name value" form.
+func valueFlag(name, arg string, args []string, i *int) (string, bool, error) {
+	if arg == name {
+		if *i+1 >= len(args) {
+			return "", false, fmt.Errorf("%s requires a value", name)
+		}
+		*i++
+		return args[*i], true, nil
+	}
+	if prefix := name + "="; strings.HasPrefix(arg, prefix) {
+		return strings.TrimPrefix(arg, prefix), true, nil
+	}
+	return "", false, nil
 }
 
 func fatalf(format string, a ...interface{}) int {

--- a/tools/spawn_binary/main.go
+++ b/tools/spawn_binary/main.go
@@ -59,17 +59,20 @@ func run(args []string) int {
 		return fatalf("no command specified; expected: spawn_binary [flags] -- <tool> [args...]")
 	}
 
-	// When changing the child's working directory, resolve a relative tool path to
-	// an absolute one first, so it still refers to the same file (the wrapper itself
-	// keeps running in the original working directory, so the capture output paths,
-	// which it opens, do not need adjusting).
-	if opts.chdir != "" && strings.ContainsRune(cmdArgs[0], '/') {
-		abs, aerr := filepath.Abs(cmdArgs[0])
-		if aerr != nil {
-			return fatalf("failed to resolve tool path %q: %v", cmdArgs[0], aerr)
-		}
-		cmdArgs[0] = abs
+	// The tool is always a declared input file, referenced by its execroot-relative
+	// path, never a command to look up on PATH. Resolve it to an absolute path
+	// (relative to the wrapper's working directory, the execution root) so that:
+	//   - a separator-less execpath (e.g. a tool at the workspace root, passed as
+	//     "tool.sh") is executed as a file rather than mistaken for a PATH lookup by
+	//     exec.Command, and
+	//   - it still refers to the same file when --chdir changes the child's working
+	//     directory. The wrapper itself stays in the original working directory, so
+	//     the capture output paths it opens do not need adjusting.
+	abs, aerr := filepath.Abs(cmdArgs[0])
+	if aerr != nil {
+		return fatalf("failed to resolve tool path %q: %v", cmdArgs[0], aerr)
 	}
+	cmdArgs[0] = abs
 
 	// Set up the stdout and stderr handling. Each stream is either written straight
 	// to a declared output file, buffered (revealed only on failure when

--- a/tools/spawn_binary/parse_test.go
+++ b/tools/spawn_binary/parse_test.go
@@ -1,0 +1,71 @@
+package main
+
+import "testing"
+
+func TestParseArgs(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		want    options
+		wantCmd []string
+		wantErr bool
+	}{
+		{
+			name:    "no flags",
+			args:    []string{"--", "tool", "a", "b"},
+			wantCmd: []string{"tool", "a", "b"},
+		},
+		{
+			name:    "space-separated values",
+			args:    []string{"--stdout", "o", "--stderr", "e", "--exit-code-out", "c", "--chdir", "d", "--silent-on-success", "--", "tool"},
+			want:    options{stdoutPath: "o", stderrPath: "e", exitCodePath: "c", chdir: "d", silentOnSuccess: true},
+			wantCmd: []string{"tool"},
+		},
+		{
+			name:    "equals-separated values",
+			args:    []string{"--stdout=o", "--chdir=d", "--", "tool", "--stdout=passed-through"},
+			want:    options{stdoutPath: "o", chdir: "d"},
+			wantCmd: []string{"tool", "--stdout=passed-through"},
+		},
+		{
+			name:    "missing separator",
+			args:    []string{"--stdout", "o"},
+			wantErr: true,
+		},
+		{
+			name:    "missing value",
+			args:    []string{"--stdout"},
+			wantErr: true,
+		},
+		{
+			name:    "unknown flag",
+			args:    []string{"--nope", "--", "tool"},
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, cmd, err := parseArgs(tc.args)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseArgs(%v) = nil error, want error", tc.args)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseArgs(%v) unexpected error: %v", tc.args, err)
+			}
+			if opts != tc.want {
+				t.Errorf("options = %+v, want %+v", opts, tc.want)
+			}
+			if len(cmd) != len(tc.wantCmd) {
+				t.Fatalf("cmd = %v, want %v", cmd, tc.wantCmd)
+			}
+			for i := range cmd {
+				if cmd[i] != tc.wantCmd[i] {
+					t.Fatalf("cmd = %v, want %v", cmd, tc.wantCmd)
+				}
+			}
+		})
+	}
+}

--- a/tools/spawn_binary/run_unix_test.go
+++ b/tools/spawn_binary/run_unix_test.go
@@ -1,0 +1,82 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeScript(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("#!/usr/bin/env bash\n"+body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A tool referenced by a bare, separator-less path (as Bazel passes for a tool at
+// the workspace root) must be executed as a file, not looked up on PATH.
+func TestRunResolvesBareToolPath(t *testing.T) {
+	dir := t.TempDir()
+	writeScript(t, filepath.Join(dir, "bare.sh"), "echo ran\n")
+	t.Chdir(dir)
+
+	out := filepath.Join(dir, "out.txt")
+	if code := run([]string{"--stdout", out, "--", "bare.sh"}); code != 0 {
+		t.Fatalf("run() = %d, want 0", code)
+	}
+	if got, _ := os.ReadFile(out); string(got) != "ran\n" {
+		t.Fatalf("captured stdout = %q, want %q", got, "ran\n")
+	}
+}
+
+// A bare tool path must keep working when --chdir changes the child's working
+// directory: the tool is resolved against the original directory, while the child
+// runs in (and reads relative paths from) the chdir directory.
+func TestRunChdirWithBareToolPath(t *testing.T) {
+	dir := t.TempDir()
+	writeScript(t, filepath.Join(dir, "bare.sh"), "cat data.txt\n")
+	sub := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "data.txt"), []byte("in-sub\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	out := filepath.Join(dir, "out.txt")
+	if code := run([]string{"--chdir", "sub", "--stdout", out, "--", "bare.sh"}); code != 0 {
+		t.Fatalf("run() = %d, want 0", code)
+	}
+	if got, _ := os.ReadFile(out); string(got) != "in-sub\n" {
+		t.Fatalf("captured stdout = %q, want %q", got, "in-sub\n")
+	}
+}
+
+// exit_code_out captures the child's non-zero exit code and lets the wrapper exit 0.
+func TestExitCodeOutForcesSuccess(t *testing.T) {
+	dir := t.TempDir()
+	writeScript(t, filepath.Join(dir, "fail.sh"), "exit 7\n")
+	t.Chdir(dir)
+
+	codeFile := filepath.Join(dir, "code.txt")
+	if code := run([]string{"--exit-code-out", codeFile, "--", "fail.sh"}); code != 0 {
+		t.Fatalf("run() = %d, want 0 (exit code captured)", code)
+	}
+	if got, _ := os.ReadFile(codeFile); string(got) != "7" {
+		t.Fatalf("exit code file = %q, want %q", got, "7")
+	}
+}
+
+// Without exit_code_out, the child's non-zero exit code propagates.
+func TestExitCodePropagates(t *testing.T) {
+	dir := t.TempDir()
+	writeScript(t, filepath.Join(dir, "fail.sh"), "exit 7\n")
+	t.Chdir(dir)
+
+	if code := run([]string{"--", "fail.sh"}); code != 7 {
+		t.Fatalf("run() = %d, want 7", code)
+	}
+}


### PR DESCRIPTION
## Summary

Completes the `run_binary` feature set requested in #575. PR #1259 added the `spawn_binary` wrapper + toolchain and the first feature (stdout capture); this PR extends the wrapper with the remaining `js_run_binary`-style features:

| attribute | behavior |
|---|---|
| `stderr` | Capture the binary's standard error to a file (mirrors `stdout`). |
| `exit_code_out` | Write the binary's exit code to a file and let the action **succeed** even when the binary exits non-zero. |
| `chdir` | Run the binary with a different working directory (location/make-var expanded). |
| `silent_on_success` | Buffer non-captured stdout/stderr and only forward it to the console when the binary exits non-zero — silences logspam from successful steps. |

As before, the wrapper is used **only** when one of these features is requested; a plain `run_binary` spawns its tool directly and does not require the (optional) `spawn_binary` toolchain.

## Wrapper behavior / transparency

- stdin and the environment are passed through verbatim; a stream is only redirected when its feature is requested.
- Termination signals are relayed to the child; exit status is reported faithfully (`128+signum` on signal death).
- `chdir` resolves a relative tool path to absolute before changing the child's directory, so the tool still resolves; the wrapper itself stays in the exec root so capture-file paths open correctly.
- Capture files (`stdout`/`stderr`/`exit_code_out`) are real action outputs but are kept out of make-variable (`$@`, `$(@D)`) expansion, consistent with #1259.

## Tests

Added to `lib/tests/run_binary`:
- `captured_stderr_test` — stderr captured, stdout passes through.
- `captured_exit_code_test` — tool exits 3, action succeeds, exit code file contains `3`.
- `silent_success_test` — successful run still produces declared outputs through the buffered path.
- `chdir_test` — tool reads a file by a path relative to the `chdir` directory.

All `run_binary` / `run_binary_expansions` / `stamping` tests pass; `gofmt` + `buildifier` clean. The new wrapper behavior was also smoke-tested directly (silent-on-success reveals output only on failure; `exit_code_out` forces exit 0; chdir + relative read).

## Docs

Updated the `run_binary` overview and added attribute docs for `stderr`, `exit_code_out`, `chdir`, and `silent_on_success` — the same documentation spots introduced in #1259.

## Note

The wrapper changes ship in prebuilt `spawn_binary` binaries on the next release; dev/prerelease trees build it from source via the existing `source_toolchains_repo` path, so no integrity changes are needed here.

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)