### PR TITLE
feat: add fail_on to run_binary

### DIFF
--- a/lib/private/run_binary.bzl
+++ b/lib/private/run_binary.bzl
@@ -300,10 +300,10 @@ def run_binary(
             listed exit codes cause the action to fail. All other exit codes are treated
             as success. This is useful for tools such as `diff` that use non-zero exit
             codes for non-error conditions (for example exit `1` when files differ and
-            exit `2` on error). Can be combined with `exit_code_out` to record the exit
-            code while still failing the action on specific codes. `silent_on_success`
-            uses the same success/failure decision when deciding whether to forward
-            buffered output.
+            exit `2` on error, or exit `0` when `grep` finds a match). Can be combined
+            with `exit_code_out` to record the exit code while still failing the action
+            on specific codes. `silent_on_success` uses the same success/failure decision
+            when deciding whether to forward buffered output.
 
         chdir: Working directory to run the binary in.
 

--- a/lib/private/run_binary.bzl
+++ b/lib/private/run_binary.bzl
@@ -49,7 +49,8 @@ def _run_binary_impl(ctx):
     exit_code_out = ctx.outputs.exit_code_out
     silent_on_success = ctx.attr.silent_on_success
     chdir = ctx.attr.chdir
-    use_wrapper = bool(stdout or stderr or exit_code_out or silent_on_success or chdir)
+    fail_on = ctx.attr.fail_on
+    use_wrapper = bool(stdout or stderr or exit_code_out or silent_on_success or chdir or fail_on)
 
     capture_outputs = [o for o in [stdout, stderr, exit_code_out] if o]
     action_outputs = outputs + capture_outputs
@@ -59,7 +60,7 @@ def _run_binary_impl(ctx):
     if use_wrapper:
         spawn_binary_toolchain = ctx.toolchains["//lib:spawn_binary_toolchain_type"]
         if not spawn_binary_toolchain:
-            fail("run_binary target {} requests a feature that requires the spawn_binary toolchain (one of stdout, stderr, exit_code_out, silent_on_success, chdir), but none is registered. Register it with register_spawn_binary_toolchains() (WORKSPACE) or the bazel_lib `spawn_binary` toolchain extension (bzlmod).".format(ctx.label))
+            fail("run_binary target {} requests a feature that requires the spawn_binary toolchain (one of stdout, stderr, exit_code_out, silent_on_success, chdir, fail_on), but none is registered. Register it with register_spawn_binary_toolchains() (WORKSPACE) or the bazel_lib `spawn_binary` toolchain extension (bzlmod).".format(ctx.label))
         spawn_binary = spawn_binary_toolchain.spawn_binary_info.bin
         if stdout:
             args.add("--stdout", stdout)
@@ -69,6 +70,8 @@ def _run_binary_impl(ctx):
             args.add("--exit-code-out", exit_code_out)
         if silent_on_success:
             args.add("--silent-on-success")
+        for code in fail_on:
+            args.add("--fail-on", str(code))
 
     if len(action_outputs) < 1:
         fail("""\
@@ -157,7 +160,7 @@ Possible fixes:
 _run_binary = rule(
     implementation = _run_binary_impl,
     # Optional: only targets that request a wrapper feature (stdout, stderr,
-    # exit_code_out, silent_on_success, chdir) use the wrapper, so a plain run_binary
+    # exit_code_out, silent_on_success, chdir, fail_on) use the wrapper, so a plain run_binary
     # that spawns its tool directly does not require this toolchain to be registered.
     toolchains = [
         config_common.toolchain_type("//lib:spawn_binary_toolchain_type", mandatory = False),
@@ -184,6 +187,7 @@ _run_binary = rule(
         "exit_code_out": attr.output(),
         "chdir": attr.string(),
         "silent_on_success": attr.bool(),
+        "fail_on": attr.int_list(),
         "args": attr.string_list(),
         "mnemonic": attr.string(),
         "progress_message": attr.string(),
@@ -205,6 +209,7 @@ def run_binary(
         exit_code_out = None,
         chdir = None,
         silent_on_success = False,
+        fail_on = [],
         mnemonic = "RunBinary",
         progress_message = None,
         execution_requirements = None,
@@ -217,7 +222,7 @@ def run_binary(
     This rule does not require Bash (unlike `native.genrule`).
 
     By default the binary is spawned directly. When any of the `stdout`, `stderr`,
-    `exit_code_out`, `chdir`, or `silent_on_success` attributes is set, the binary is
+    `exit_code_out`, `chdir`, `silent_on_success`, or `fail_on` attributes is set, the binary is
     instead launched through a small wrapper (`spawn_binary`) that provides these
     features. This is handy both to feed a program's output into a downstream action
     when the program has no flag to write it to a file, and to silence the output of
@@ -286,6 +291,20 @@ def run_binary(
             useful to record the result of a tool whose failure should be handled by a
             downstream target rather than breaking the build.
 
+            When `fail_on` is also set, only the listed exit codes fail the action; the
+            exit code is still written to this file.
+
+        fail_on: Exit codes that should fail the action.
+
+            When set, the binary is launched through the spawn_binary wrapper and only the
+            listed exit codes cause the action to fail. All other exit codes are treated
+            as success. This is useful for tools such as `diff` that use non-zero exit
+            codes for non-error conditions (for example exit `1` when files differ and
+            exit `2` on error). Can be combined with `exit_code_out` to record the exit
+            code while still failing the action on specific codes. `silent_on_success`
+            uses the same success/failure decision when deciding whether to forward
+            buffered output.
+
         chdir: Working directory to run the binary in.
 
             When set, the binary is run with this as its working directory instead of the
@@ -297,8 +316,10 @@ def run_binary(
         silent_on_success: Suppress the binary's output unless it fails.
 
             When True, stdout and stderr that are not being captured to a file are buffered
-            and only forwarded to the console if the binary exits non-zero. This silences
-            logspam from successful build steps while preserving diagnostics on failure.
+            and only forwarded to the console if the action is treated as a failure. With
+            `fail_on`, that means exit codes listed in `fail_on`; otherwise a non-zero
+            exit code. This silences logspam from successful build steps while preserving
+            diagnostics on failure.
 
         mnemonic: A one-word description of the action, for example, CppCompile or GoLink.
 
@@ -371,6 +392,7 @@ def run_binary(
         exit_code_out = exit_code_out,
         chdir = chdir,
         silent_on_success = silent_on_success,
+        fail_on = fail_on,
         mnemonic = mnemonic,
         progress_message = progress_message,
         execution_requirements = execution_requirements,

--- a/lib/tests/run_binary/BUILD.bazel
+++ b/lib/tests/run_binary/BUILD.bazel
@@ -225,6 +225,51 @@ assert_contains(
     expected = "3",
 )
 
+# fail_on: like diff(1), exit 1 is a non-error result while exit 2 is an error.
+write_file(
+    name = "make_diff_like_sh",
+    out = "diff_like.sh",
+    content = [
+        "#!/usr/bin/env bash",
+        "set -o errexit -o nounset -o pipefail",
+        "exit \"$1\"",
+    ],
+    is_executable = True,
+)
+
+sh_binary(
+    name = "diff_like",
+    srcs = [":diff_like.sh"],
+)
+
+run_binary(
+    name = "fail_on_allows_one",
+    args = ["1"],
+    exit_code_out = "fail_on_allows_one_code.txt",
+    fail_on = [2],
+    tool = ":diff_like",
+)
+
+assert_contains(
+    name = "fail_on_allows_one_test",
+    actual = ":fail_on_allows_one_code.txt",
+    expected = "1",
+)
+
+run_binary(
+    name = "fail_on_allows_zero",
+    args = ["0"],
+    exit_code_out = "fail_on_allows_zero_code.txt",
+    fail_on = [2],
+    tool = ":diff_like",
+)
+
+assert_contains(
+    name = "fail_on_allows_zero_test",
+    actual = ":fail_on_allows_zero_code.txt",
+    expected = "0",
+)
+
 # silent_on_success: a successful run still produces its declared outputs. (Console
 # suppression itself is not observable from a build action assertion.)
 write_file(

--- a/tools/spawn_binary/main.go
+++ b/tools/spawn_binary/main.go
@@ -10,7 +10,9 @@
 //
 //	--stdout=FILE         capture the program's stdout into FILE
 //	--stderr=FILE         capture the program's stderr into FILE
-//	--exit-code-out=FILE  write the program's exit code into FILE and exit 0
+//	--exit-code-out=FILE  write the program's exit code into FILE
+//	--fail-on=CODE       treat CODE as an action failure (repeatable; comma-separated
+//	                     values in one flag are also accepted)
 //	--chdir=DIR           run the program with DIR as its working directory
 //	--silent-on-success   only forward non-captured stdout/stderr to the console
 //	                      when the program exits non-zero
@@ -42,6 +44,7 @@ type options struct {
 	stdoutPath      string
 	stderrPath      string
 	exitCodePath    string
+	failOn          []int
 	chdir           string
 	silentOnSuccess bool
 }
@@ -75,7 +78,7 @@ func run(args []string) int {
 	cmdArgs[0] = abs
 
 	// Set up the stdout and stderr handling. Each stream is either written straight
-	// to a declared output file, buffered (revealed only on failure when
+	// to a declared output file, buffered (revealed only on action failure when
 	// --silent-on-success is set), or passed through to our own fd verbatim.
 	stdout, finalizeStdout, err := newStream(opts.stdoutPath, opts.silentOnSuccess, os.Stdout)
 	if err != nil {
@@ -83,7 +86,7 @@ func run(args []string) int {
 	}
 	stderr, finalizeStderr, err := newStream(opts.stderrPath, opts.silentOnSuccess, os.Stderr)
 	if err != nil {
-		_ = finalizeStdout(1)
+		_ = finalizeStdout(true)
 		return fatalf("%v", err)
 	}
 
@@ -96,8 +99,8 @@ func run(args []string) int {
 	cmd.Dir = opts.chdir
 
 	if serr := cmd.Start(); serr != nil {
-		_ = finalizeStdout(1)
-		_ = finalizeStderr(1)
+		_ = finalizeStdout(true)
+		_ = finalizeStderr(true)
 		return fatalf("failed to start %q: %v", cmdArgs[0], serr)
 	}
 
@@ -121,18 +124,19 @@ func run(args []string) int {
 		if exitErr, ok := werr.(*exec.ExitError); ok {
 			code = exitCode(exitErr)
 		} else {
-			_ = finalizeStdout(1)
-			_ = finalizeStderr(1)
+			_ = finalizeStdout(true)
+			_ = finalizeStderr(true)
 			return fatalf("failed to run %q: %v", cmdArgs[0], werr)
 		}
 	}
 
-	// Flush capture files and reveal any buffered output, based on the child's exit
-	// code.
-	if ferr := finalizeStdout(code); ferr != nil {
+	failed := actionFailed(code, opts)
+
+	// Flush capture files and reveal any buffered output when the action failed.
+	if ferr := finalizeStdout(failed); ferr != nil {
 		return fatalf("%v", ferr)
 	}
-	if ferr := finalizeStderr(code); ferr != nil {
+	if ferr := finalizeStderr(failed); ferr != nil {
 		return fatalf("%v", ferr)
 	}
 
@@ -140,12 +144,30 @@ func run(args []string) int {
 		if werr := os.WriteFile(opts.exitCodePath, []byte(strconv.Itoa(code)), 0o644); werr != nil {
 			return fatalf("failed to write exit code file %q: %v", opts.exitCodePath, werr)
 		}
-		// The exit code has been captured as an output, so the wrapper (and thus the
-		// build action) succeeds regardless of the child's exit code.
-		return 0
 	}
 
+	if !failed {
+		return 0
+	}
 	return code
+}
+
+// actionFailed reports whether the build action should fail for the child's exit
+// code. When --fail-on is set it takes precedence; otherwise exit_code_out forces
+// success and the default is to fail on any non-zero exit.
+func actionFailed(code int, opts options) bool {
+	if len(opts.failOn) > 0 {
+		for _, c := range opts.failOn {
+			if code == c {
+				return true
+			}
+		}
+		return false
+	}
+	if opts.exitCodePath != "" {
+		return false
+	}
+	return code != 0
 }
 
 // newStream returns the writer to hand to the child for one output stream, plus a
@@ -153,9 +175,9 @@ func run(args []string) int {
 //
 //   - path != "":         the child writes directly to the declared output file.
 //   - silentOnSuccess:    the stream is buffered and only written to console when
-//     the child exits non-zero.
+//     the action is treated as a failure (see actionFailed).
 //   - otherwise:          the stream passes through to console (our own fd) verbatim.
-func newStream(path string, silentOnSuccess bool, console *os.File) (io.Writer, func(code int) error, error) {
+func newStream(path string, silentOnSuccess bool, console *os.File) (io.Writer, func(failed bool) error, error) {
 	if path != "" {
 		// Handing the child an *os.File passes the file descriptor directly, so it
 		// writes straight to the output file with no intermediate copy.
@@ -163,19 +185,19 @@ func newStream(path string, silentOnSuccess bool, console *os.File) (io.Writer, 
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create output file %q: %w", path, err)
 		}
-		return f, func(int) error { return f.Close() }, nil
+		return f, func(bool) error { return f.Close() }, nil
 	}
 	if silentOnSuccess {
 		buf := &bytes.Buffer{}
-		return buf, func(code int) error {
-			if code == 0 {
+		return buf, func(failed bool) error {
+			if !failed {
 				return nil
 			}
 			_, err := console.Write(buf.Bytes())
 			return err
 		}, nil
 	}
-	return console, func(int) error { return nil }, nil
+	return console, func(bool) error { return nil }, nil
 }
 
 // parseArgs separates the wrapper's own flags (everything before the "--"
@@ -203,6 +225,16 @@ func parseArgs(args []string) (options, []string, error) {
 			return opts, nil, err
 		} else if ok {
 			opts.exitCodePath = v
+			continue
+		}
+		if v, ok, err := valueFlag("--fail-on", arg, args, &i); err != nil {
+			return opts, nil, err
+		} else if ok {
+			codes, err := parseFailOn(v)
+			if err != nil {
+				return opts, nil, err
+			}
+			opts.failOn = append(opts.failOn, codes...)
 			continue
 		}
 		if v, ok, err := valueFlag("--chdir", arg, args, &i); err != nil {
@@ -234,6 +266,25 @@ func valueFlag(name, arg string, args []string, i *int) (string, bool, error) {
 		return strings.TrimPrefix(arg, prefix), true, nil
 	}
 	return "", false, nil
+}
+
+func parseFailOn(s string) ([]int, error) {
+	var codes []int
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, fmt.Errorf("invalid exit code %q in --fail-on", part)
+		}
+		codes = append(codes, n)
+	}
+	if len(codes) == 0 {
+		return nil, fmt.Errorf("--fail-on requires at least one exit code")
+	}
+	return codes, nil
 }
 
 func fatalf(format string, a ...interface{}) int {

--- a/tools/spawn_binary/main.go
+++ b/tools/spawn_binary/main.go
@@ -149,7 +149,17 @@ func run(args []string) int {
 	if !failed {
 		return 0
 	}
-	return code
+	return wrapperExitStatus(code)
+}
+
+// wrapperExitStatus maps a failed action to a non-zero process exit. When the child
+// exited 0 but fail_on treats that as failure (e.g. grep finding a match), the
+// wrapper must still exit non-zero so Bazel fails the action.
+func wrapperExitStatus(childCode int) int {
+	if childCode == 0 {
+		return 1
+	}
+	return childCode
 }
 
 // actionFailed reports whether the build action should fail for the child's exit

--- a/tools/spawn_binary/parse_test.go
+++ b/tools/spawn_binary/parse_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestParseArgs(t *testing.T) {
 	cases := []struct {
@@ -17,8 +20,14 @@ func TestParseArgs(t *testing.T) {
 		},
 		{
 			name:    "space-separated values",
-			args:    []string{"--stdout", "o", "--stderr", "e", "--exit-code-out", "c", "--chdir", "d", "--silent-on-success", "--", "tool"},
-			want:    options{stdoutPath: "o", stderrPath: "e", exitCodePath: "c", chdir: "d", silentOnSuccess: true},
+			args:    []string{"--stdout", "o", "--stderr", "e", "--exit-code-out", "c", "--fail-on", "2", "--chdir", "d", "--silent-on-success", "--", "tool"},
+			want:    options{stdoutPath: "o", stderrPath: "e", exitCodePath: "c", failOn: []int{2}, chdir: "d", silentOnSuccess: true},
+			wantCmd: []string{"tool"},
+		},
+		{
+			name:    "comma-separated fail-on",
+			args:    []string{"--fail-on=1,2", "--", "tool"},
+			want:    options{failOn: []int{1, 2}},
 			wantCmd: []string{"tool"},
 		},
 		{
@@ -55,7 +64,7 @@ func TestParseArgs(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parseArgs(%v) unexpected error: %v", tc.args, err)
 			}
-			if opts != tc.want {
+			if !reflect.DeepEqual(opts, tc.want) {
 				t.Errorf("options = %+v, want %+v", opts, tc.want)
 			}
 			if len(cmd) != len(tc.wantCmd) {

--- a/tools/spawn_binary/run_unix_test.go
+++ b/tools/spawn_binary/run_unix_test.go
@@ -3,8 +3,10 @@
 package main
 
 import (
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -78,5 +80,99 @@ func TestExitCodePropagates(t *testing.T) {
 
 	if code := run([]string{"--", "fail.sh"}); code != 7 {
 		t.Fatalf("run() = %d, want 7", code)
+	}
+}
+
+// fail_on allows listed codes to fail the action while other non-zero codes succeed.
+func TestFailOnAllowsNonListedExit(t *testing.T) {
+	dir := t.TempDir()
+	writeScript(t, filepath.Join(dir, "tool.sh"), "exit 1\n")
+	t.Chdir(dir)
+
+	if code := run([]string{"--fail-on=2", "--", "tool.sh"}); code != 0 {
+		t.Fatalf("run() = %d, want 0", code)
+	}
+}
+
+func TestFailOnRejectsListedExit(t *testing.T) {
+	dir := t.TempDir()
+	writeScript(t, filepath.Join(dir, "tool.sh"), "exit 2\n")
+	t.Chdir(dir)
+
+	if code := run([]string{"--fail-on=2", "--", "tool.sh"}); code != 2 {
+		t.Fatalf("run() = %d, want 2", code)
+	}
+}
+
+// fail_on takes precedence over exit_code_out: the code is written, but listed codes
+// still fail the action.
+func TestFailOnWithExitCodeOut(t *testing.T) {
+	dir := t.TempDir()
+	writeScript(t, filepath.Join(dir, "exit2.sh"), "exit 2\n")
+	writeScript(t, filepath.Join(dir, "exit1.sh"), "exit 1\n")
+	t.Chdir(dir)
+
+	codeFile := filepath.Join(dir, "code.txt")
+	if code := run([]string{"--exit-code-out", codeFile, "--fail-on=2", "--", "exit2.sh"}); code != 2 {
+		t.Fatalf("run() = %d, want 2", code)
+	}
+	if got, _ := os.ReadFile(codeFile); string(got) != "2" {
+		t.Fatalf("exit code file = %q, want %q", got, "2")
+	}
+
+	codeFile = filepath.Join(dir, "code_ok.txt")
+	if code := run([]string{"--exit-code-out", codeFile, "--fail-on=2", "--", "exit1.sh"}); code != 0 {
+		t.Fatalf("run() = %d, want 0 for exit 1", code)
+	}
+	if got, _ := os.ReadFile(codeFile); string(got) != "1" {
+		t.Fatalf("exit code file = %q, want %q", got, "1")
+	}
+}
+
+// silent_on_success uses the same success/failure decision as fail_on.
+func TestSilentOnSuccessRespectsFailOn(t *testing.T) {
+	dir := t.TempDir()
+	writeScript(t, filepath.Join(dir, "tool.sh"), "echo noisy >&2\nexit \"$1\"\n")
+	t.Chdir(dir)
+
+	readStderr := func(args []string) string {
+		t.Helper()
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		old := os.Stderr
+		os.Stderr = w
+		code := run(args)
+		w.Close()
+		os.Stderr = old
+		out, _ := io.ReadAll(r)
+		r.Close()
+		if code != 0 {
+			t.Fatalf("run(%v) = %d, want 0", args, code)
+		}
+		return string(out)
+	}
+
+	if got := readStderr([]string{"--silent-on-success", "--fail-on=2", "--", "tool.sh", "1"}); got != "" {
+		t.Fatalf("stderr on successful exit 1 = %q, want empty", got)
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stderr
+	os.Stderr = w
+	code := run([]string{"--silent-on-success", "--fail-on=2", "--", "tool.sh", "2"})
+	w.Close()
+	os.Stderr = old
+	out, _ := io.ReadAll(r)
+	r.Close()
+	if code != 2 {
+		t.Fatalf("run() = %d, want 2", code)
+	}
+	if !strings.Contains(string(out), "noisy") {
+		t.Fatalf("stderr on failed exit 2 = %q, want noisy output", out)
 	}
 }

--- a/tools/spawn_binary/run_unix_test.go
+++ b/tools/spawn_binary/run_unix_test.go
@@ -104,6 +104,18 @@ func TestFailOnRejectsListedExit(t *testing.T) {
 	}
 }
 
+// fail_on can include 0 for grep-style tools where a successful child exit should
+// still fail the action; the wrapper must exit non-zero in that case.
+func TestFailOnRejectsExitZero(t *testing.T) {
+	dir := t.TempDir()
+	writeScript(t, filepath.Join(dir, "tool.sh"), "exit 0\n")
+	t.Chdir(dir)
+
+	if code := run([]string{"--fail-on=0", "--", "tool.sh"}); code != 1 {
+		t.Fatalf("run() = %d, want 1", code)
+	}
+}
+
 // fail_on takes precedence over exit_code_out: the code is written, but listed codes
 // still fail the action.
 func TestFailOnWithExitCodeOut(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #1260 implementing the `fail_on` API discussed in https://github.com/bazel-contrib/bazel-lib/pull/1260#issuecomment-4898266475.

- Adds `fail_on` to `run_binary` so only listed exit codes fail the action (e.g. `fail_on = [2]` for `diff`-like tools where exit `1` is a normal result).
- `spawn_binary` gains `--fail-on` (repeatable; comma-separated values in one flag are also accepted).
- When `fail_on` is set it takes precedence over the unconditional success implied by `exit_code_out`; the exit code is still written when `exit_code_out` is set.
- `silent_on_success` now uses the same success/failure decision as `fail_on` when deciding whether to forward buffered output.

## Test plan

- [x] `bazel test //tools/spawn_binary:spawn_binary_test` (parse, fail_on semantics, silent_on_success interaction)
- [x] `bazel test //lib/tests/run_binary/...` (integration tests for exit codes 0 and 1 with `fail_on = [2]`)