### PR TITLE
ci: Test with Bazel 9.x in presubmit.yml

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -5,6 +5,7 @@ bcr_test_module:
     bazel:
       - 7.x
       - 8.x
+      - 9.x
       - rolling
   tasks:
     run_tests:


### PR DESCRIPTION
Since bazel 9 was release, rolling is pointing to something else so we should explicitly test for bazel 9.