### PR TITLE
feat: pass bare $(BINDIR) args in run_binary as File objects for path mapping

### DIFF
--- a/lib/private/run_binary.bzl
+++ b/lib/private/run_binary.bzl
@@ -122,6 +122,7 @@ Possible fixes:
             args.add_all([expansion_outputs[0]], map_each = _bindir_path, expand_directories = False)
         else:
             expanded = expand_variables(ctx, ctx.expand_location(a, targets = targets), inputs = inputs, outs = expansion_outputs)
+            # Disable path mapping if any location or variable expansion occurred
             can_path_map = can_path_map and expanded == a
             args.add_all(split_args(expanded))
     envs = {}

--- a/lib/private/run_binary.bzl
+++ b/lib/private/run_binary.bzl
@@ -122,6 +122,7 @@ Possible fixes:
             args.add_all([expansion_outputs[0]], map_each = _bindir_path, expand_directories = False)
         else:
             expanded = expand_variables(ctx, ctx.expand_location(a, targets = targets), inputs = inputs, outs = expansion_outputs)
+
             # Disable path mapping if any location or variable expansion occurred
             can_path_map = can_path_map and expanded == a
             args.add_all(split_args(expanded))

--- a/lib/private/run_binary.bzl
+++ b/lib/private/run_binary.bzl
@@ -20,6 +20,9 @@ load("//lib:stamping.bzl", "STAMP_ATTRS", "maybe_stamp")
 load(":expand_variables.bzl", "expand_variables")
 load(":strings.bzl", "split_args")
 
+def _bindir_path(file):
+    return file.root.path
+
 def _run_binary_impl(ctx):
     args = ctx.actions.args()
 
@@ -108,9 +111,16 @@ Possible fixes:
         args.add(ctx.executable.tool)
 
     for a in ctx.attr.args:
-        expanded = expand_variables(ctx, ctx.expand_location(a, targets = targets), inputs = inputs, outs = expansion_outputs)
-        can_path_map = can_path_map and expanded == a
-        args.add_all(split_args(expanded))
+        if a == "$(BINDIR)":
+            # As a special case, we expand arguments exactly equal to
+            # "$(BINDIR)" directly, in a way that is compatible with path
+            # mapping. Every output has the same bin directory, so we just
+            # examine the first one.
+            args.add_all([expansion_outputs[0]], map_each = _bindir_path)
+        else:
+            expanded = expand_variables(ctx, ctx.expand_location(a, targets = targets), inputs = inputs, outs = expansion_outputs)
+            can_path_map = can_path_map and expanded == a
+            args.add_all(split_args(expanded))
     envs = {}
     for k, v in ctx.attr.env.items():
         envs[k] = expand_variables(ctx, ctx.expand_location(v, targets = targets), inputs = inputs, outs = expansion_outputs, attribute_name = "env")

--- a/lib/private/run_binary.bzl
+++ b/lib/private/run_binary.bzl
@@ -115,8 +115,11 @@ Possible fixes:
             # As a special case, we expand arguments exactly equal to
             # "$(BINDIR)" directly, in a way that is compatible with path
             # mapping. Every output has the same bin directory, so we just
-            # examine the first one.
-            args.add_all([expansion_outputs[0]], map_each = _bindir_path)
+            # examine the first one. expand_directories is disabled since
+            # the first output may be a not-yet-created output directory
+            # (from out_dirs); we want its path, not its (currently
+            # nonexistent) contents.
+            args.add_all([expansion_outputs[0]], map_each = _bindir_path, expand_directories = False)
         else:
             expanded = expand_variables(ctx, ctx.expand_location(a, targets = targets), inputs = inputs, outs = expansion_outputs)
             can_path_map = can_path_map and expanded == a

--- a/lib/tests/run_binary/BUILD.bazel
+++ b/lib/tests/run_binary/BUILD.bazel
@@ -643,3 +643,57 @@ diff_test(
     file1 = ":bindir_location.txt",
     file2 = ":expected_bindir_location.txt",
 )
+
+# Covers the path-mapping-friendly handling of a bare "$(BINDIR)" arg when
+# the target has only out_dirs (no outs), so the first expansion output is
+# an as-yet-uncreated output directory rather than a regular file. Args.add_all
+# expands directory File values by default, which would try (and fail) to
+# expand this not-yet-created directory; run_binary must pass
+# expand_directories = False so the directory's path is used as-is.
+#
+# The tool both creates the required out_dir (so the action is valid) and
+# reports what it actually received via stdout, captured to a plain file so
+# the test can inspect it directly (a file inside an output directory isn't
+# addressable as its own label).
+write_file(
+    name = "make_bindir_out_dirs_only_sh",
+    out = "bindir_out_dirs_only.sh",
+    content = [
+        "#!/usr/bin/env bash",
+        "set -o errexit -o nounset -o pipefail",
+        "outdir=$1",
+        "shift",
+        "touch \"$outdir/marker\"",
+        "echo \"argc=$#\"",
+        "echo \"args=$*\"",
+    ],
+    is_executable = True,
+)
+
+sh_binary(
+    name = "bindir_out_dirs_only_tool",
+    srcs = [":bindir_out_dirs_only.sh"],
+)
+
+run_binary(
+    name = "bindir_out_dirs_only",
+    args = [
+        "$(@D)",
+        "$(BINDIR)",
+    ],
+    out_dirs = ["bindir_out_dirs_only_dir"],
+    stdout = "bindir_out_dirs_only_stdout.txt",
+    tool = ":bindir_out_dirs_only_tool",
+)
+
+assert_contains(
+    name = "bindir_out_dirs_only_argc_test",
+    actual = ":bindir_out_dirs_only_stdout.txt",
+    expected = "argc=1",
+)
+
+assert_contains(
+    name = "bindir_out_dirs_only_value_test",
+    actual = ":bindir_out_dirs_only_stdout.txt",
+    expected = "args=bazel-out/",
+)

--- a/lib/tests/run_binary/BUILD.bazel
+++ b/lib/tests/run_binary/BUILD.bazel
@@ -617,3 +617,29 @@ assert_contains(
     actual = ":target_os_windows",
     expected = "windows",
 )
+
+# Covers the path-mapping-friendly handling of a bare "$(BINDIR)" arg (with
+# no prefix or suffix). $(BINDIR) doesn't depend on the target's own name
+# (it's just the root of the bin tree for the target's configuration), so a
+# genrule produces an identical value and can be diffed against directly.
+run_binary(
+    name = "bindir_location",
+    outs = ["bindir_location.txt"],
+    args = [
+        "$(BINDIR)",
+        "$@",
+    ],
+    tool = ":echo_arg",
+)
+
+genrule(
+    name = "expected_bindir_location",
+    outs = ["expected_bindir_location.txt"],
+    cmd = "echo $(BINDIR) > $@",
+)
+
+diff_test(
+    name = "bindir_location_test",
+    file1 = ":bindir_location.txt",
+    file2 = ":expected_bindir_location.txt",
+)


### PR DESCRIPTION
`$(BINDIR)` bakes in the unmapped `bazel-out/<cfg>/bin` prefix at analysis time, which breaks under Bazel's path mapping. When an args element is exactly `$(BINDIR)` (no prefix or suffix), add the root of any declared output directly via `Args.add_all`/`map_each` instead, keeping the action eligible for path mapping.

The motivation for this is to enable path mapping for `js_run_binary` in `aspect_rules_js`. Running a `js_binary` requires providing the Bazel output bin directory, so we need a path-mapping-friendly way to convey that information.