### PR TITLE
chore(coreutils): update to 0.9.0

### DIFF
--- a/lib/private/coreutils_toolchain.bzl
+++ b/lib/private/coreutils_toolchain.bzl
@@ -45,6 +45,36 @@ COREUTILS_PLATFORMS = {
 # The integrity hashes can be automatically fetched for the coreutils releases by running
 # `tools/coreutils_mirror_release.sh`.
 COREUTILS_VERSIONS = {
+    "0.9.0": {
+        "darwin_arm64": {
+            "filename": "coreutils-0.9.0-aarch64-apple-darwin.tar.gz",
+            "sha256": "sha256-7WkY+n3VETYzm5Y+QYeev/v02pM15QGTat/OkEjC8vc="
+        },
+        "windows_arm64": {
+            "filename": "coreutils-0.9.0-aarch64-pc-windows-msvc.zip",
+            "sha256": "sha256-x5LjlJpqPZH5RLdlqrbwtizyE+iGs0fbuBxm1+BJnQQ="
+        },
+        "linux_arm64": {
+            "filename": "coreutils-0.9.0-aarch64-unknown-linux-musl.tar.gz",
+            "sha256": "sha256-ww0v/2Y/pwfyaC/Enm/UUhsF8Rjus4Urkt1U/Z2va68="
+        },
+        "linux_riscv64gc": {
+            "filename": "coreutils-0.9.0-riscv64gc-unknown-linux-musl.tar.gz",
+            "sha256": "sha256-3IjaSFyVxxlXzArdiX5QU83qCtlYeXh6zvIjYtZiXXI="
+        },
+        "darwin_amd64": {
+            "filename": "coreutils-0.9.0-x86_64-apple-darwin.tar.gz",
+            "sha256": "sha256-XsgJUZ6YGzL0cwpqrM8G8Yzn829T/DvCNCzB9Xd8Aq8="
+        },
+        "windows_amd64": {
+            "filename": "coreutils-0.9.0-x86_64-pc-windows-msvc.zip",
+            "sha256": "sha256-d7TK0gJYtlSnXEzef09wM+qJanGnAPaAcu5EWZwddtQ="
+        },
+        "linux_amd64": {
+            "filename": "coreutils-0.9.0-x86_64-unknown-linux-musl.tar.gz",
+            "sha256": "sha256-f/++nINQVPEUOl8qaO9HjvtCdBcWPgQQwmyQHaFWR+U="
+        }
+    },
     "0.5.0": {
         "darwin_arm64": {
             "filename": "coreutils-0.5.0-aarch64-apple-darwin.tar.gz",

--- a/lib/private/coreutils_toolchain.bzl
+++ b/lib/private/coreutils_toolchain.bzl
@@ -48,32 +48,31 @@ COREUTILS_VERSIONS = {
     "0.9.0": {
         "darwin_arm64": {
             "filename": "coreutils-0.9.0-aarch64-apple-darwin.tar.gz",
-            "sha256": "sha256-7WkY+n3VETYzm5Y+QYeev/v02pM15QGTat/OkEjC8vc="
+            "sha256": "sha256-7WkY+n3VETYzm5Y+QYeev/v02pM15QGTat/OkEjC8vc=",
         },
         "windows_arm64": {
             "filename": "coreutils-0.9.0-aarch64-pc-windows-msvc.zip",
-            "sha256": "sha256-x5LjlJpqPZH5RLdlqrbwtizyE+iGs0fbuBxm1+BJnQQ="
+            "sha256": "sha256-x5LjlJpqPZH5RLdlqrbwtizyE+iGs0fbuBxm1+BJnQQ=",
         },
         "linux_arm64": {
             "filename": "coreutils-0.9.0-aarch64-unknown-linux-musl.tar.gz",
-            "sha256": "sha256-ww0v/2Y/pwfyaC/Enm/UUhsF8Rjus4Urkt1U/Z2va68="
-        },
-        "linux_riscv64gc": {
-            "filename": "coreutils-0.9.0-riscv64gc-unknown-linux-musl.tar.gz",
-            "sha256": "sha256-3IjaSFyVxxlXzArdiX5QU83qCtlYeXh6zvIjYtZiXXI="
+            "sha256": "sha256-ww0v/2Y/pwfyaC/Enm/UUhsF8Rjus4Urkt1U/Z2va68=",
         },
         "darwin_amd64": {
             "filename": "coreutils-0.9.0-x86_64-apple-darwin.tar.gz",
-            "sha256": "sha256-XsgJUZ6YGzL0cwpqrM8G8Yzn829T/DvCNCzB9Xd8Aq8="
+            "sha256": "sha256-XsgJUZ6YGzL0cwpqrM8G8Yzn829T/DvCNCzB9Xd8Aq8=",
         },
         "windows_amd64": {
-            "filename": "coreutils-0.9.0-x86_64-pc-windows-msvc.zip",
-            "sha256": "sha256-d7TK0gJYtlSnXEzef09wM+qJanGnAPaAcu5EWZwddtQ="
+            # The x86_64 msvc archive ships one binary per applet instead of the
+            # multicall `coreutils.exe` (since 0.7.0), so use the gnu archive which
+            # still ships the multicall binary.
+            "filename": "coreutils-0.9.0-x86_64-pc-windows-gnu.zip",
+            "sha256": "sha256-P4SHbSC4bisTzkzKfV/iILx3c7kqPfhE5wwsm1kDV9Y=",
         },
         "linux_amd64": {
             "filename": "coreutils-0.9.0-x86_64-unknown-linux-musl.tar.gz",
-            "sha256": "sha256-f/++nINQVPEUOl8qaO9HjvtCdBcWPgQQwmyQHaFWR+U="
-        }
+            "sha256": "sha256-f/++nINQVPEUOl8qaO9HjvtCdBcWPgQQwmyQHaFWR+U=",
+        },
     },
     "0.5.0": {
         "darwin_arm64": {

--- a/tools/release/hashes.bzl
+++ b/tools/release/hashes.bzl
@@ -14,7 +14,7 @@ def _hash(ctx, algo, file):
         inputs = [file],
         tools = [coreutils.coreutils_info.bin],
         # coreutils has --no-names option but it doesn't work in current version, so we have to use cut.
-        command = """HASH=$({coreutils} hashsum --{algo} {src} | {coreutils} cut -f1 -d " ") && {coreutils} echo -e "$HASH {basename}" > {out}""".format(
+        command = """HASH=$({coreutils} cksum --algorithm={algo} {src} | {coreutils} cut -f4 -d " ") && {coreutils} echo -e "$HASH {basename}" > {out}""".format(
             coreutils = coreutils.coreutils_info.bin.path,
             algo = algo,
             src = file.path,


### PR DESCRIPTION
Update https://github.com/uutils/coreutils from 0.5.0 to 0.9.0 with all its bug fixes and performance improvements.