### PR TITLE
fix: get BCR publishing working by upgrading rules_go

### DIFF
--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -5,4 +5,4 @@ local_path_override(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.8.1", dev_dependency = True)
-bazel_dep(name = "rules_go", version = "0.55.0", dev_dependency = True, repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_go", version = "0.59.0", dev_dependency = True, repo_name = "io_bazel_rules_go")


### PR DESCRIPTION
Recent BCR deployments have been failing, like this one for 3.7.0 for example: https://github.com/bazelbuild/bazel-central-registry/pull/9894

It appears to be because e2e/smoke is on an older version of rules_go that is missing this fix required for newer Bazel versions: https://github.com/bazel-contrib/rules_go/pull/4508

We're only hitting this issue on BCR deployment because for BCR we make rules_go a dev_dependency in the top-level MODULE.bazel, causing rules_go to use the older version from e2e/smoke/MODULE.bazel.

This should fix #1277.